### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -4052,19 +4052,32 @@ export async function applyDnsRewrite() {
 function deepMerge(target, source) {
     if (typeof target !== 'object' || target === null) return source;
     if (typeof source !== 'object' || source === null) return source;
-    
+
     // Arrays are fully replaced (not merged by index).
     // This is intentional: config arrays like nameserver/rules/proxies
     // represent complete lists, not partial patches.
     if (Array.isArray(target) && Array.isArray(source)) return source;
 
+    const blockedKeys = new Set(['__proto__', 'constructor', 'prototype']);
+
     for (const key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-            if (typeof source[key] === 'object' && source[key] !== null && !Array.isArray(source[key])) {
-                target[key] = deepMerge(target[key] || {}, source[key]);
-            } else {
-                target[key] = source[key];
-            }
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (blockedKeys.has(key)) continue;
+
+        const sourceValue = source[key];
+        const canRecurse =
+            typeof sourceValue === 'object' &&
+            sourceValue !== null &&
+            !Array.isArray(sourceValue) &&
+            Object.prototype.hasOwnProperty.call(target, key) &&
+            typeof target[key] === 'object' &&
+            target[key] !== null &&
+            !Array.isArray(target[key]);
+
+        if (canRecurse) {
+            target[key] = deepMerge(target[key], sourceValue);
+        } else {
+            target[key] = sourceValue;
         }
     }
     return target;

--- a/src/ui.js
+++ b/src/ui.js
@@ -4049,9 +4049,15 @@ export async function applyDnsRewrite() {
     }
 }
 
+function isPlainObject(value) {
+    if (typeof value !== 'object' || value === null) return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
 function deepMerge(target, source) {
-    if (typeof target !== 'object' || target === null) return source;
-    if (typeof source !== 'object' || source === null) return source;
+    if (!isPlainObject(target)) return source;
+    if (!isPlainObject(source)) return source;
 
     // Arrays are fully replaced (not merged by index).
     // This is intentional: config arrays like nameserver/rules/proxies
@@ -4060,19 +4066,15 @@ function deepMerge(target, source) {
 
     const blockedKeys = new Set(['__proto__', 'constructor', 'prototype']);
 
-    for (const key in source) {
-        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+    for (const key of Object.keys(source)) {
         if (blockedKeys.has(key)) continue;
 
         const sourceValue = source[key];
+        const targetHasOwnKey = Object.prototype.hasOwnProperty.call(target, key);
         const canRecurse =
-            typeof sourceValue === 'object' &&
-            sourceValue !== null &&
-            !Array.isArray(sourceValue) &&
-            Object.prototype.hasOwnProperty.call(target, key) &&
-            typeof target[key] === 'object' &&
-            target[key] !== null &&
-            !Array.isArray(target[key]);
+            targetHasOwnKey &&
+            isPlainObject(target[key]) &&
+            isPlainObject(sourceValue);
 
         if (canRecurse) {
             target[key] = deepMerge(target[key], sourceValue);


### PR DESCRIPTION
Potential fix for [https://github.com/Juwan-Hwang/Zephyr/security/code-scanning/1](https://github.com/Juwan-Hwang/Zephyr/security/code-scanning/1)

General fix: harden the recursive merge function against prototype pollution by (1) rejecting dangerous property names and (2) only recursing into nested objects when the destination already has that property as an own property and it is a plain object.

Best fix in this snippet:
- Edit `deepMerge` in `src/ui.js` (lines ~4052–4071).
- Add a local guard set for blocked keys: `__proto__`, `constructor`, `prototype`.
- Skip any source keys in that blocked set.
- For recursive merge, require:
  - `source[key]` is a non-array object,
  - `target` has own property `key`,
  - `target[key]` is also a non-array object.
- Otherwise assign directly (`target[key] = source[key]`) as before, preserving existing behavior for normal keys and array replacement semantics.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
