### PR TITLE
Potential fix for code scanning alert no. 13: Prototype-polluting function

### DIFF
--- a/src/ui/advanced.js
+++ b/src/ui/advanced.js
@@ -28,37 +28,45 @@ function isPlainObject(value) {
 }
 
 /**
+ * @param {string} key
+ * @returns {boolean}
+ */
+function isSafeMergeKey(key) {
+    return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+}
+
+/**
  * @param {*} target
  * @param {*} source
  * @returns {*}
  */
 function deepMerge(target, source) {
-    if (!isPlainObject(target)) return source;
-    if (!isPlainObject(source)) return source;
-
-    // Arrays are fully replaced (not merged by index).
-    if (Array.isArray(target) && Array.isArray(source)) return source;
-
-    // Block prototype pollution keys
-    const blockedKeys = new Set(['__proto__', 'constructor', 'prototype']);
+    if (!isPlainObject(target) || Array.isArray(target)) return source;
+    if (!isPlainObject(source) || Array.isArray(source)) return source;
 
     for (const key of Object.keys(source)) {
-        if (blockedKeys.has(key)) continue;
+        if (!isSafeMergeKey(key)) continue;
         if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
-        if (!isPlainObject(target)) continue;
+        if (!isPlainObject(target) || Array.isArray(target)) continue;
 
         const sourceValue = source[key];
         const targetHasOwnKey = Object.prototype.hasOwnProperty.call(target, key);
+        const targetValue = targetHasOwnKey ? target[key] : undefined;
         const canRecurse =
             targetHasOwnKey &&
-            isPlainObject(target[key]) &&
-            isPlainObject(sourceValue);
+            isPlainObject(targetValue) &&
+            !Array.isArray(targetValue) &&
+            isPlainObject(sourceValue) &&
+            !Array.isArray(sourceValue);
 
         if (canRecurse) {
-            target[key] = deepMerge(target[key], sourceValue);
-        } else if (isPlainObject(sourceValue)) {
+            target[key] = deepMerge(targetValue, sourceValue);
+        } else if (isPlainObject(sourceValue) && !Array.isArray(sourceValue)) {
             // Avoid assigning attacker-controlled object references directly.
-            const nextTarget = targetHasOwnKey && isPlainObject(target[key]) ? target[key] : {};
+            const nextTarget =
+                targetHasOwnKey && isPlainObject(targetValue) && !Array.isArray(targetValue)
+                    ? targetValue
+                    : Object.create(null);
             Object.defineProperty(target, key, {
                 value: deepMerge(nextTarget, sourceValue),
                 writable: true,

--- a/src/ui/advanced.js
+++ b/src/ui/advanced.js
@@ -44,11 +44,10 @@ function deepMerge(target, source) {
 
     for (const key of Object.keys(source)) {
         if (blockedKeys.has(key)) continue;
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (!isPlainObject(target)) continue;
 
         const sourceValue = source[key];
-        // Skip inherited prototype properties to prevent pollution
-        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
-
         const targetHasOwnKey = Object.prototype.hasOwnProperty.call(target, key);
         const canRecurse =
             targetHasOwnKey &&
@@ -57,6 +56,15 @@ function deepMerge(target, source) {
 
         if (canRecurse) {
             target[key] = deepMerge(target[key], sourceValue);
+        } else if (isPlainObject(sourceValue)) {
+            // Avoid assigning attacker-controlled object references directly.
+            const nextTarget = targetHasOwnKey && isPlainObject(target[key]) ? target[key] : {};
+            Object.defineProperty(target, key, {
+                value: deepMerge(nextTarget, sourceValue),
+                writable: true,
+                enumerable: true,
+                configurable: true,
+            });
         } else {
             // Use Object.defineProperty to avoid triggering setters on the prototype chain
             Object.defineProperty(target, key, {


### PR DESCRIPTION
Potential fix for [https://github.com/Juwan-Hwang/Zephyr/security/code-scanning/13](https://github.com/Juwan-Hwang/Zephyr/security/code-scanning/13)

The best fix is to harden `deepMerge` so it **only writes to own properties of the destination object** (except when creating new safe properties) and **never writes to dangerous keys at any depth**, including nested object values copied from `source`. In this snippet, the highest-value change is:

1. Keep the existing blocked keys check.
2. Before writing/recurse, ensure the current `target` is still a plain object.
3. For assignment, avoid copying object references from `source` directly; if `sourceValue` is a plain object and target does not have an own object to recurse into, create a fresh `{}` and merge into it. This prevents passing attacker-provided object graphs through directly.
4. Maintain `Object.defineProperty` writes only for safe keys on plain-object `target`.

Edit region: `src/ui/advanced.js`, function `deepMerge` (lines 35–71 in shown snippet).  
No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
