### PR TITLE
fix(desktop): import shared command constants from workspace package

### DIFF
--- a/apps/desktop/src/i18n.js
+++ b/apps/desktop/src/i18n.js
@@ -8,7 +8,7 @@
  */
 
 import { invoke } from './api.js';
-import { COMMANDS } from './_shared/index.js';
+import { COMMANDS } from '@zephyr/shared';
 import { i18nLogger } from './utils/logger.js';
 import { Bus, Events } from './ui/events.js';
 

--- a/apps/desktop/src/integration.test.js
+++ b/apps/desktop/src/integration.test.js
@@ -15,7 +15,7 @@
 // A failure here means a "silent" integration bug that unit tests cannot catch.
 
 import { describe, it, expect } from 'vitest';
-import { COMMANDS, PRISM, RULE } from './_shared/index.js';
+import { COMMANDS, PRISM, RULE } from '@zephyr/shared';
 import { translations } from './i18n.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/apps/desktop/src/ui/os-notification.js
+++ b/apps/desktop/src/ui/os-notification.js
@@ -7,7 +7,7 @@
  */
 
 import { invoke } from '../api.js';
-import { COMMANDS } from '../_shared/index.js';
+import { COMMANDS } from '@zephyr/shared';
 import { apiLogger } from '../utils/logger.js';
 
 /**


### PR DESCRIPTION
### Motivation
- Several desktop frontend modules imported the generated path `./_shared/index.js`, which is ignored in the repository and may be missing on clean checkouts causing Vite import resolution failures.
- Missing `./_shared/index.js` caused Vitest/Vite to fail with "Failed to resolve import './_shared/index.js'", making integration tests brittle and CI unstable.

### Description
- Replaced imports of the generated path with direct workspace package imports from `@zephyr/shared` in the desktop frontend.
- Updated `apps/desktop/src/i18n.js` to `import { COMMANDS } from '@zephyr/shared'` instead of `./_shared/index.js`.
- Updated `apps/desktop/src/integration.test.js` to `import { COMMANDS, PRISM, RULE } from '@zephyr/shared'` instead of `./_shared/index.js`.
- Updated `apps/desktop/src/ui/os-notification.js` to `import { COMMANDS } from '@zephyr/shared'` instead of `../_shared/index.js`.

### Testing
- Ran the workspace test suite with `pnpm -r test` before the changes which failed due to unresolved `./_shared/index.js` imports (Vite import errors). 
- Ran `pnpm -r test` after the changes which completed successfully for the desktop app (all desktop test files passed), with only non-fatal network-related warnings logged by Happy DOM during run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31c67cad8832fb34dc491858865e6)