### PR TITLE
fix: correct dropdown and context menu positioning under UI scale tra…

### DIFF
--- a/apps/desktop/src/ui/dropdown.js
+++ b/apps/desktop/src/ui/dropdown.js
@@ -38,10 +38,15 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
     // Position the menu relative to the trigger (used when portaled to body)
     const positionMenu = () => {
         const rect = trigger.getBoundingClientRect();
+        // body has transform: scale(var(--ui-scale)), which makes fixed positioning
+        // relative to the body instead of the viewport. getBoundingClientRect returns
+        // visual (scaled) coordinates, but fixed left/top inside a transformed container
+        // are in the container's coordinate space. Divide by ui-scale to compensate.
+        const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
         menu.style.position = 'fixed';
-        menu.style.left = `${rect.left}px`;
-        menu.style.top = `${rect.bottom + 6}px`;
-        menu.style.width = `${rect.width}px`;
+        menu.style.left = `${rect.left / uiScale}px`;
+        menu.style.top = `${rect.bottom / uiScale + 6 / uiScale}px`;
+        menu.style.width = `${rect.width / uiScale}px`;
         menu.style.zIndex = '99999';
     };
 

--- a/apps/desktop/src/ui/dropdown.js
+++ b/apps/desktop/src/ui/dropdown.js
@@ -45,7 +45,7 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
         const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
         menu.style.position = 'fixed';
         menu.style.left = `${rect.left / uiScale}px`;
-        menu.style.top = `${rect.bottom / uiScale + 6 / uiScale}px`;
+        menu.style.top = `${(rect.bottom + 6) / uiScale}px`;
         menu.style.width = `${rect.width / uiScale}px`;
         menu.style.zIndex = '99999';
     };

--- a/apps/desktop/src/utils/context-menu.js
+++ b/apps/desktop/src/utils/context-menu.js
@@ -40,10 +40,15 @@ export function createContextMenuContainer(e) {
     e.preventDefault();
     removeContextMenu();
 
+    // body has transform: scale(var(--ui-scale)), which makes fixed positioning
+    // relative to the body instead of the viewport. clientX/clientY are visual
+    // (scaled) coordinates — divide by ui-scale to get body-space coordinates.
+    const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
+
     const menu = document.createElement('div');
     menu.className = `${ROOT_CLASS} fixed z-[9999] min-w-[180px] max-w-[320px] max-h-[60vh] overflow-y-auto custom-scrollbar py-1 shadow-xl border border-white/10 rounded-xl glass-card`;
-    menu.style.left = `${e.clientX}px`;
-    menu.style.top = `${e.clientY}px`;
+    menu.style.left = `${e.clientX / uiScale}px`;
+    menu.style.top = `${e.clientY / uiScale}px`;
     return menu;
 }
 
@@ -56,12 +61,13 @@ export function createContextMenuContainer(e) {
 export function attachContextMenuCloseHandlers(menu) {
     // Viewport overflow correction
     requestAnimationFrame(() => {
+        const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
         const rect = menu.getBoundingClientRect();
         if (rect.right > window.innerWidth) {
-            menu.style.left = `${window.innerWidth - rect.width - 8}px`;
+            menu.style.left = `${(window.innerWidth - rect.width - 8) / uiScale}px`;
         }
         if (rect.bottom > window.innerHeight) {
-            menu.style.top = `${window.innerHeight - rect.height - 8}px`;
+            menu.style.top = `${(window.innerHeight - rect.height - 8) / uiScale}px`;
         }
     });
 


### PR DESCRIPTION
…nsform

- dropdown.js: account for body transform:scale() when positioning portaled menus

- context-menu.js: divide clientX/clientY by ui-scale to get body-space coordinates

- context-menu.js: also scale overflow correction values