### PR TITLE
feat(proxy-groups): deterministic Resolver replaces keyword-guessed m…

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -302,6 +302,8 @@
                         </button>
                     </div>
                 </header>
+                <!-- Group Explanation Bar: shown when uiGroup differs from effectiveGroup -->
+                <div id="group-explanation-bar" class="hidden items-center gap-2 px-4 py-2 rounded-xl bg-amber-500/10 border border-amber-500/20 relative z-10 shrink-0" data-flex-class="flex"></div>
                 <!-- Container added p-4 to prevent 3D scale clipping -->
                 <div id="proxies-list" role="listbox" aria-label="Proxy Nodes" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 overflow-y-auto p-4 -m-4 custom-scrollbar relative z-10">
                     <!-- Cards will be injected here -->

--- a/apps/desktop/src/ui/modes.js
+++ b/apps/desktop/src/ui/modes.js
@@ -33,7 +33,8 @@ export function initModeSelector() {
                 // 1. Capture current node for inheritance
                 let nodeToInherit = null;
                 try {
-                    const resultBefore = await fetchProxyGroups();
+                    const preferredGroupName = appStore.get('uiGroupName') || null;
+                    const resultBefore = await fetchProxyGroups({ preferredGroupName });
                     if (resultBefore) {
                         nodeToInherit = resultBefore.current;
                     }
@@ -54,9 +55,13 @@ export function initModeSelector() {
 
                 // 4. Inherit node in target mode
                 if (nodeToInherit && mode !== 'direct') {
-                    const resultAfter = await fetchProxyGroups();
+                    const preferredGroupName = appStore.get('uiGroupName') || null;
+                    const resultAfter = await fetchProxyGroups({ preferredGroupName });
                     if (resultAfter && resultAfter.proxies.includes(nodeToInherit)) {
-                        await switchProxy(resultAfter.mainGroup, nodeToInherit);
+                        // Use uiGroupName from resolver for accurate group targeting
+                        const targetGroup = resultAfter.uiGroupName || resultAfter.mainGroup;
+                        await switchProxy(targetGroup, nodeToInherit);
+                        appStore.set('uiGroupName', targetGroup);
                     }
                 }
 

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -9,6 +9,9 @@ import { nodeWheelLogger } from '../utils/logger.js';
 import { translations, currentLang } from '../i18n.js';
 import { fetchProxyGroups } from './proxy-groups.js';
 import { sortProxiesByLatency } from './proxies.js';
+import { appStore } from './state.js';
+import { invalidateProxiesCache, getSettingsCached } from './cache.js';
+import { saveProxySelection } from './proxy-memory.js';
 
 /** @type {ReturnType<typeof setTimeout> | null} */
 let wheelHoverTimer = null;
@@ -66,10 +69,24 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
     }
     closeWheel();
     abortLatencyTests();
-    const success = await switchProxy(mainGroup, name);
+
+    // Use uiGroupName from appStore for accurate group targeting
+    const targetGroup = appStore.get('uiGroupName') || mainGroup;
+    const success = await switchProxy(targetGroup, name);
     if (success) {
+        invalidateProxiesCache();
         await closeAllConnections();
-        const updatedNode = await waitForCurrentNode(mainGroup, name);
+
+        // Save proxy selection for restore after core restart
+        try {
+            const settings = await getSettingsCached();
+            const profileName = settings?.last_config;
+            if (profileName) {
+                await saveProxySelection(profileName, name);
+            }
+        } catch { /* non-fatal */ }
+
+        const updatedNode = await waitForCurrentNode(targetGroup, name);
         import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
         const currentNodeEl = document.getElementById('current-node-name');
         if (currentNodeEl) currentNodeEl.textContent = updatedNode || name;
@@ -79,7 +96,7 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
         }
     } else {
         import('./proxies.js').then(m => m.syncCoreConfig());
-        const revertedNode = await waitForCurrentNode(mainGroup, null);
+        const revertedNode = await waitForCurrentNode(targetGroup, null);
         const currentNodeEl = document.getElementById('current-node-name');
         if (currentNodeEl && revertedNode) currentNodeEl.textContent = revertedNode;
     }
@@ -103,10 +120,14 @@ async function populateAndShowWheel(trigger, dropdown, scrollContainer, list, up
     }
 
     try {
-        const proxyGroupsResult = await fetchProxyGroups();
+        const preferredGroupName = appStore.get('uiGroupName') || null;
+        const proxyGroupsResult = await fetchProxyGroups({ preferredGroupName });
         if (!proxyGroupsResult) return;
 
-        const { data, mainGroup, current } = proxyGroupsResult;
+        // Use the resolver's uiGroupName for wheel display
+        const uiGroupName = proxyGroupsResult.uiGroupName
+            || proxyGroupsResult.mainGroup;
+        const { data, current } = proxyGroupsResult;
         /** @type {string[]} */
         const proxies = [...proxyGroupsResult.proxies];
 
@@ -156,7 +177,7 @@ async function populateAndShowWheel(trigger, dropdown, scrollContainer, list, up
                 resetToCenterFocus();
             });
 
-            item.onclick = () => handleWheelProxySwitch(trigger, mainGroup, name, isSelected);
+            item.onclick = () => handleWheelProxySwitch(trigger, uiGroupName, name, isSelected);
             return item;
         };
 

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -24,6 +24,7 @@ import { smartScore, smartNextInterval, smartSelectBest, smartRank, smartConfig 
 import { fetchProxyGroups as fetchProxyGroupsShared } from './proxy-groups.js';
 import { Bus, Events } from './events.js';
 import { saveProxySelection } from './proxy-memory.js';
+import { invalidateRunConfigCache } from './run-config-cache.js';
 
 // Re-export switchPage for external consumers that import from this module
 export { switchPage } from './navigation.js';
@@ -371,10 +372,30 @@ export async function syncCoreConfig() {
 
     // Update current node display
     try {
-        const proxyGroupsResult = await fetchProxyGroupsShared({ existingConfig: config });
+        const preferredGroupName = appStore.get('uiGroupName') || null;
+        const proxyGroupsResult = await fetchProxyGroupsShared({ existingConfig: config, preferredGroupName });
         let currentNode = 'Direct';
         if (proxyGroupsResult) {
-            currentNode = (/** @type {any} */ (proxyGroupsResult)).current || 'Direct';
+            // Use the resolved uiGroupName for accurate current node display
+            const uiGroupName = proxyGroupsResult.uiGroupName || proxyGroupsResult.mainGroup;
+            const proxyMap = proxyGroupsResult.data?.proxies;
+            if (proxyMap && uiGroupName && proxyMap[uiGroupName]) {
+                currentNode = proxyMap[uiGroupName].now || 'Direct';
+            } else {
+                currentNode = proxyGroupsResult.current || 'Direct';
+            }
+
+            // Sync resolver state to appStore
+            appStore.set('uiPrimaryGroupName', proxyGroupsResult.uiPrimaryGroupName || null);
+            appStore.set('effectiveGroupName', proxyGroupsResult.effectiveGroupName || null);
+
+            // Validate uiGroupName: if the stored group no longer exists in proxyMap
+            // (e.g. config changed), reset it so the resolver's primary takes over.
+            // Actual initialization is handled by renderProxies to avoid redundant writes.
+            const currentUiGroup = appStore.get('uiGroupName');
+            if (currentUiGroup && proxyMap && !proxyMap[currentUiGroup]) {
+                appStore.set('uiGroupName', null);
+            }
         }
         const currentNodeEl = document.getElementById('current-node-name');
         if (currentNodeEl) {
@@ -493,7 +514,7 @@ export function initProxyControls() {
                 if (!proxyGroupsResult) {
                     throw new Error('No valid proxy group found for testing');
                 }
-                const { data, mainGroup: _mainGroup, proxies, current: _currentNode } = /** @type {any} */ (proxyGroupsResult);
+                const { data, mainGroup: _mainGroup, proxies, current: _currentNode } = proxyGroupsResult;
                 const settings = await getSettingsCached();
                 hideTimeoutEnabled = !!settings?.hide_timeout_nodes;
 
@@ -653,8 +674,9 @@ export function initProxyControls() {
 
                 const proxyGroupsResult = await fetchProxyGroupsShared();
                 if (!proxyGroupsResult) return;
-                const { mainGroup } = /** @type {any} */ (proxyGroupsResult);
-                const success = await switchProxy(mainGroup, best.name);
+                const { mainGroup } = proxyGroupsResult;
+                const targetGroup = appStore.get('uiGroupName') || mainGroup;
+                const success = await switchProxy(targetGroup, best.name);
                 if (success) {
                     showNotification(`Switched to best node: ${best.name} (score: ${displayScore})`, 'success');
                     await syncCoreConfig();
@@ -681,6 +703,108 @@ export function initProxyControls() {
 }
 
 // --- Render Proxies ---
+
+// --- Group Explanation Bar ---
+
+/**
+ * Render the group explanation bar that shows when the uiGroup differs from
+ * the effectiveGroup (the group that rules actually route traffic to).
+ * This helps users understand why their selected node may not match the
+ * connection page display.
+ *
+ * @param {string} uiGroupName - The group the user is currently operating on
+ * @param {string|null} effectiveGroupName - The group inferred from rules
+ * @param {Object} proxyMap - The proxy map from /proxies response (for writability check)
+ */
+// Track dismissed explanation bar by group pair key — prevents the bar from
+// reappearing on every re-render when the user has already dismissed it.
+// Resets automatically when the group pair changes.
+/** @type {string|null} */
+let _dismissedMismatchKey = null;
+
+function renderGroupExplanationBar(uiGroupName, effectiveGroupName, proxyMap) {
+    const bar = document.getElementById('group-explanation-bar');
+    if (!bar) return;
+
+    // No mismatch or no effective group → hide the bar
+    if (!effectiveGroupName || uiGroupName === effectiveGroupName) {
+        bar.classList.add('hidden');
+        bar.classList.remove('flex');
+        // Reset dismiss state since mismatch no longer exists
+        _dismissedMismatchKey = null;
+        return;
+    }
+
+    // Build a key for this specific group-pair mismatch
+    const mismatchKey = `${uiGroupName}|${effectiveGroupName}`;
+
+    // If user already dismissed this exact mismatch, keep it hidden
+    if (_dismissedMismatchKey === mismatchKey) {
+        return;
+    }
+
+    bar.classList.remove('hidden');
+    bar.classList.add('flex');
+    bar.replaceChildren();
+
+    const t = /** @type {any} */ (translations)[currentLang];
+
+    // Info icon
+    const icon = document.createElement('span');
+    icon.className = 'text-amber-400 text-sm flex-shrink-0';
+    icon.innerHTML = '&#9888;';
+
+    // Explanation text
+    const text = document.createElement('span');
+    text.className = 'text-2xs text-zinc-400 flex-1';
+    // Explanation text — use template with placeholders so translators can reorder
+    const mismatchTemplate = t.groupMismatchExplanation
+        || 'Current group: {uiGroup} — Rules default to: {effectiveGroup}. Connections may use "{effectiveGroup}" instead of your selected node.';
+    text.textContent = mismatchTemplate
+        .replace(/{uiGroup}/g, () => uiGroupName)
+        .replace(/{effectiveGroup}/g, () => effectiveGroupName);
+
+    // Quick-switch button — only enabled if effective group is writable (selector/select)
+    // Non-writable groups (url-test, fallback, etc.) cannot be switched via PUT /proxies/{group}
+    const btn = document.createElement('button');
+    const effectiveType = proxyMap?.[effectiveGroupName]?.type?.toLowerCase() || '';
+    const effectiveIsWritable = effectiveType === 'selector' || effectiveType === 'select';
+
+    if (effectiveIsWritable) {
+        btn.className = 'text-2xs text-accent hover:text-accent/80 underline whitespace-nowrap flex-shrink-0';
+        btn.textContent = t.switchToEffectiveGroup || 'Switch to rules default';
+        btn.onclick = async () => {
+            try {
+                appStore.set('uiGroupName', effectiveGroupName);
+                invalidateProxiesCache();
+                invalidateRunConfigCache();
+                await renderProxies();
+            } catch (e) {
+                proxyLogger.warn('Failed to switch to effective group', e);
+            }
+        };
+    } else {
+        btn.className = 'text-2xs text-zinc-600 cursor-not-allowed whitespace-nowrap flex-shrink-0';
+        btn.textContent = t.effectiveGroupNotSwitchable || 'Rules default is auto-select (not switchable)';
+        btn.disabled = true;
+    }
+
+    // Dismiss button
+    const dismiss = document.createElement('button');
+    dismiss.className = 'text-zinc-600 hover:text-zinc-400 ml-2 flex-shrink-0';
+    dismiss.innerHTML = '&times;';
+    dismiss.title = t.dismiss || 'Dismiss';
+    dismiss.onclick = () => {
+        _dismissedMismatchKey = mismatchKey;
+        bar.classList.add('hidden');
+        bar.classList.remove('flex');
+    };
+
+    bar.appendChild(icon);
+    bar.appendChild(text);
+    bar.appendChild(btn);
+    bar.appendChild(dismiss);
+}
 
 /**
  * Show loading state in the proxy container.
@@ -1041,7 +1165,14 @@ export async function renderProxies() {
         return;
     }
 
-    const proxyGroupsResult = await fetchProxyGroupsShared({ existingData: data, existingConfig: config });
+    // Use the user's explicit group selection or fall back to the resolver
+    const preferredGroupName = appStore.get('uiGroupName') || null;
+
+    const proxyGroupsResult = await fetchProxyGroupsShared({
+        existingData: data,
+        existingConfig: config,
+        preferredGroupName,
+    });
     if (!proxyGroupsResult) {
         container.innerHTML = '';
         const empty = document.createElement('div');
@@ -1051,8 +1182,31 @@ export async function renderProxies() {
         return;
     }
 
-    const { mainGroup, current } = /** @type {any} */ (proxyGroupsResult);
+    // Sync resolver state to appStore
+    appStore.set('uiPrimaryGroupName', proxyGroupsResult.uiPrimaryGroupName || null);
+    appStore.set('effectiveGroupName', proxyGroupsResult.effectiveGroupName || null);
+    appStore.set('uiGroupName', proxyGroupsResult.uiGroupName || null);
+
+    const { mainGroup, current } = proxyGroupsResult;
+    // Use the resolved uiGroupName for node list rendering
+    const uiGroupName = proxyGroupsResult.uiGroupName || mainGroup;
+    const effectiveGroupName = proxyGroupsResult.effectiveGroupName;
+
+    // If no writable group was found, show a clean empty state instead of
+    // rendering actionable buttons that would fail on PUT /proxies/{group}
+    if (!proxyGroupsResult.uiGroupName) {
+        container.innerHTML = '';
+        const empty = document.createElement('div');
+        empty.className = 'col-span-full text-center py-10 text-zinc-500';
+        empty.textContent = t.noGroupsFound || 'No switchable proxy groups found';
+        container.appendChild(empty);
+        return;
+    }
+
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
+
+    // Render the group explanation bar (effective vs ui group mismatch indicator)
+    renderGroupExplanationBar(uiGroupName, effectiveGroupName, data?.proxies);
 
     // Filter out unavailable (timeout) proxies if setting is enabled
     const settings = await getSettingsCached();
@@ -1085,7 +1239,7 @@ export async function renderProxies() {
     }
 
     // Store virtual data for lazy card creation
-    _virtState.set(container, { proxies, data, current, isTestingLatency: appStore.get('isTestingLatency'), mainGroup });
+    _virtState.set(container, { proxies, data, current, isTestingLatency: appStore.get('isTestingLatency'), mainGroup: uiGroupName });
 
     // --- In-place update path ---
     if (await updateProxiesInPlace(container, proxies, data, current)) {
@@ -1100,7 +1254,7 @@ export async function renderProxies() {
         existingObserver.disconnect();
     }
 
-    const fragment = buildProxyWrappers(container, proxies, data, current, mainGroup);
+    const fragment = buildProxyWrappers(container, proxies, data, current, uiGroupName);
     container.innerHTML = '';
     container.appendChild(fragment);
 
@@ -1152,7 +1306,16 @@ async function syncSmartUiVisibility() {
 // --- Event Bus: react to config updates from other modules (e.g. settings.js) ---
 
 Bus.on(Events.CONFIG_UPDATED, async () => {
+    invalidateRunConfigCache();
     await syncSmartUiVisibility();
+    renderProxies();
+});
+
+Bus.on(Events.CORE_RESTARTED, () => {
+    invalidateRunConfigCache();
+    // Do NOT reset uiGroupName here — restoreProxySelection depends on it
+    // to restore the correct group after core restart. The resolver will
+    // re-validate uiGroupName against the new proxyMap on next render.
     renderProxies();
 });
 
@@ -1180,7 +1343,7 @@ const _autoTest = {
         try {
             const proxyGroupsResult = await fetchProxyGroupsShared();
             if (!proxyGroupsResult) return;
-            const { data, proxies } = /** @type {any} */ (proxyGroupsResult);
+            const { data, proxies } = proxyGroupsResult;
 
             const validProxies = proxies.filter((/** @type {string} */ name) => {
                 const node = (/** @type {any} */ (data)).proxies[name];

--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -1,19 +1,336 @@
 // @ts-check
 /**
- * Fetch proxy groups data and determine the main group based on config mode.
- * Extracted from ui.js for reuse across modules.
+ * Proxy-group Resolver — determines the correct "main group" with full
+ * deterministic reasoning instead of fragile keyword guessing.
+ *
+ * Key improvements over the old fetchProxyGroups:
+ *   1. orderedGroups — from run_config.yaml proxy-groups order (deterministic)
+ *   2. effectiveGroup — inferred from rules (FINAL/MATCH target)
+ *   3. uiPrimaryGroup — stable primary group with fallback chain
+ *   4. uiGroup — the group the UI actually operates on (from appStore or primary)
+ *   5. Backward compatible — still returns `mainGroup` mapped to uiPrimaryGroup
+ *
+ * @module ui/proxy-groups
  */
 
 import { getProxies, getConfig } from '../api.js';
+import { getRunConfigCached } from './run-config-cache.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+/** Names that are always treated as special / non-selectable groups. */
+const SPECIAL_GROUPS = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE']);
 
 /**
+ * Returns true if the proxy entry is a "group node" (has `all` array).
+ * This includes selector, url-test, fallback, load-balance, relay, etc.
+ * @param {any} p
+ * @returns {boolean}
+ */
+export function isGroup(p) {
+    return Array.isArray(p?.all);
+}
+
+/**
+ * Returns true if the proxy type supports `PUT /proxies/{name}` to change `now`.
+ * Only selector/select groups are writable via the mihomo API.
+ * @param {string} type
+ * @returns {boolean}
+ */
+export function isWritableGroupType(type = '') {
+    const t = String(type).toLowerCase();
+    return t === 'selector' || t === 'select';
+}
+
+/**
+ * Keyword scoring for group name matching (last-resort fallback).
+ * Higher score = better match as a "primary proxy selector group".
+ * @param {string} name
+ * @returns {number}
+ */
+function keywordScore(name) {
+    const n = name.toLowerCase();
+    // Negative keywords — groups that are clearly NOT the primary selector
+    if (n.includes('auto') || n.includes('自动') || n.includes('url-test')
+        || n.includes('fallback') || n.includes('load-balance') || n.includes('relay')
+        || n.includes('流媒体') || n.includes('stream') || /\bai\b/.test(n)
+        || n.includes('chatgpt') || n.includes('openai') || n.includes('telegram')
+        || n.includes('discord') || n.includes('google') || n.includes('微软')
+        || n.includes('apple') || n.includes('spotify') || n.includes('netflix')) {
+        return -10;
+    }
+    // Positive keywords — groups that are likely the primary selector
+    if (n.includes('proxy') || n.includes('节点') || n.includes('选') || n.includes('代理')
+        || n.includes('select') || n.includes('selector')) {
+        return 5;
+    }
+    return 0;
+}
+
+// ─── orderedGroups from run_config ─────────────────────────────────────
+
+/**
+ * Build an ordered list of group names from the run_config proxy-groups section.
+ * This preserves the YAML definition order — the deterministic backbone.
+ *
+ * @param {any} runConfig - The run_config.yaml JSON
+ * @param {Record<string, any>} proxyMap - The /proxies response map
+ * @returns {string[]} Ordered group names (writable groups first, then all groups)
+ */
+function buildOrderedGroups(runConfig, proxyMap) {
+    const seen = new Set();
+    const writable = [];
+    const all = [];
+
+    // 1. From run_config proxy-groups YAML order
+    if (runConfig && Array.isArray(runConfig['proxy-groups'])) {
+        for (const pg of runConfig['proxy-groups']) {
+            const name = pg?.name;
+            if (!name || SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (seen.has(name)) continue;
+            seen.add(name);
+
+            const p = proxyMap[name];
+            if (!p || !isGroup(p)) continue;
+            if (p.hidden) continue;
+
+            all.push(name);
+            if (isWritableGroupType(p.type)) {
+                writable.push(name);
+            }
+        }
+    }
+
+    // 2. Fallback: GLOBAL.all (preserves subscription-defined order)
+    if (all.length === 0 && proxyMap['GLOBAL']?.all) {
+        for (const name of proxyMap['GLOBAL'].all) {
+            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (seen.has(name)) continue;
+            const p = proxyMap[name];
+            if (!p || !isGroup(p)) continue;
+            if (p.hidden) continue;
+            seen.add(name);
+            all.push(name);
+            if (isWritableGroupType(p.type)) {
+                writable.push(name);
+            }
+        }
+    }
+
+    // 3. Last resort: all group nodes from proxyMap, sorted by name
+    if (all.length === 0) {
+        for (const name of Object.keys(proxyMap).sort()) {
+            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            const p = proxyMap[name];
+            if (!isGroup(p)) continue;
+            if (p.hidden) continue;
+            if (seen.has(name)) continue;
+            seen.add(name);
+            all.push(name);
+            if (isWritableGroupType(p.type)) {
+                writable.push(name);
+            }
+        }
+    }
+
+    // Prefer returning writable groups; fall back to all groups
+    return writable.length > 0 ? writable : all;
+}
+
+// ─── effectiveGroup from rules ──────────────────────────────────────────
+
+/**
+ * Infer the effective (rules default) outbound group from run_config rules.
+ * Looks for the last FINAL or MATCH rule and returns its target group name.
+ *
+ * @param {any} runConfig - The run_config.yaml JSON
+ * @param {Record<string, any>} proxyMap - The /proxies response map
+ * @returns {string|null} The effective group name, or null if undetermined
+ */
+function inferEffectiveGroup(runConfig, proxyMap) {
+    if (!runConfig || !Array.isArray(runConfig.rules)) return null;
+
+    // Scan rules from the end — FINAL/MATCH is typically the last rule
+    for (let i = runConfig.rules.length - 1; i >= 0; i--) {
+        const rule = String(runConfig.rules[i] || '').trim();
+        const upper = rule.toUpperCase();
+
+        if (!upper.startsWith('FINAL') && !upper.startsWith('MATCH')) continue;
+
+        // Parse: "FINAL,GroupName" or "MATCH,GroupName" or "FINAL,GroupName,no-resolve"
+        // Use a regex to extract the group name, supporting quoted names (e.g.,
+        // FINAL,"My, Group",no-resolve) and names without quotes.
+        const match = rule.match(/^(?:FINAL|MATCH),\s*(?:"([^"]+)"|'([^']+)'|([^,]+))/i);
+        if (!match) continue;
+
+        // matched groups: [1]=double-quoted, [2]=single-quoted, [3]=unquoted
+        const candidate = (match[1] || match[2] || match[3] || '').trim();
+        if (!candidate) continue;
+
+        // Verify the target is a known group node
+        const p = proxyMap[candidate];
+        if (p && isGroup(p)) return candidate;
+    }
+
+    return null;
+}
+
+// ─── topLevelGroups ────────────────────────────────────────────────────
+
+/**
+ * Build the list of "top-level" groups shown in the UI group selector.
+ * Uses GLOBAL.all as the primary source, supplemented by orderedGroups.
+ *
+ * @param {Record<string, any>} proxyMap
+ * @param {string[]} orderedGroups
+ * @returns {string[]}
+ */
+function buildTopLevelGroups(proxyMap, orderedGroups) {
+    const seen = new Set();
+    const result = [];
+
+    // 1. GLOBAL.all items that are also groups (preserves subscription order)
+    if (proxyMap['GLOBAL']?.all) {
+        for (const name of proxyMap['GLOBAL'].all) {
+            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            const p = proxyMap[name];
+            if (!p || !isGroup(p)) continue;
+            if (p.hidden) continue;
+            if (seen.has(name)) continue;
+            seen.add(name);
+            result.push(name);
+        }
+    }
+
+    // 2. Supplement with orderedGroups (dedup)
+    for (const name of orderedGroups) {
+        if (seen.has(name)) continue;
+        seen.add(name);
+        result.push(name);
+    }
+
+    return result;
+}
+
+// ─── uiPrimaryGroup determination ──────────────────────────────────────
+
+/**
+ * Determine the primary UI group — the group that the node list should
+ * operate on by default.  Uses a priority chain:
+ *
+ *   1. preferredGroupName (UI explicit selection)
+ *   2. primaryGroupPreference (user preference)
+ *   3. effectiveGroup (from rules)
+ *   4. orderedGroups[0]
+ *   5. topLevelGroups[0]
+ *   6. keyword scoring best match
+ *   7. first writable group by name
+ *
+ * @param {Object} ctx
+ * @param {string|null} ctx.preferredGroupName
+ * @param {string|null} ctx.primaryGroupPreference
+ * @param {string|null} ctx.effectiveGroupName
+ * @param {string[]} ctx.orderedGroups
+ * @param {string[]} ctx.topLevelGroups
+ * @param {Record<string, any>} ctx.proxyMap
+ * @returns {{ name: string|null, reason: { source: string, detail: string } }}
+ */
+function determineUiPrimaryGroup(ctx) {
+    const {
+        preferredGroupName,
+        primaryGroupPreference,
+        effectiveGroupName,
+        orderedGroups,
+        topLevelGroups,
+        proxyMap,
+    } = ctx;
+
+    // Validate a candidate group name: must exist in proxyMap and be a writable group
+    const isValidWritable = (/** @type {string|null} */ name) =>
+        name && proxyMap[name] && isWritableGroupType(proxyMap[name].type) && !proxyMap[name].hidden;
+
+    // 1. preferredGroupName (UI explicit selection) — must be writable
+    if (isValidWritable(preferredGroupName)) {
+        return { name: /** @type {string} */ (preferredGroupName), reason: { source: 'preferred', detail: 'User explicitly selected this group in UI' } };
+    }
+
+    // 2. primaryGroupPreference
+    if (isValidWritable(primaryGroupPreference)) {
+        return { name: /** @type {string} */ (primaryGroupPreference), reason: { source: 'preference', detail: 'Saved primary group preference' } };
+    }
+
+    // 3. effectiveGroup (from rules) — must be writable (selector/select)
+    // Non-writable groups (url-test, fallback, etc.) cannot be switched via
+    // PUT /proxies/{group}, so they must not be used as the uiGroup.
+    if (isValidWritable(effectiveGroupName)) {
+        return { name: effectiveGroupName, reason: { source: 'effective', detail: 'Inferred from FINAL/MATCH rule in config' } };
+    }
+
+    // 4. orderedGroups[0]
+    if (orderedGroups.length > 0 && isValidWritable(orderedGroups[0])) {
+        return { name: orderedGroups[0], reason: { source: 'ordered', detail: 'First writable group from run_config proxy-groups order' } };
+    }
+
+    // 5. topLevelGroups[0]
+    if (topLevelGroups.length > 0 && isValidWritable(topLevelGroups[0])) {
+        return { name: topLevelGroups[0], reason: { source: 'topLevel', detail: 'First writable group from GLOBAL.all' } };
+    }
+
+    // 6. Keyword scoring across all writable groups
+    const allWritable = Object.keys(proxyMap).sort().filter(name =>
+        isWritableGroupType(proxyMap[name]?.type) && !proxyMap[name]?.hidden
+    );
+    if (allWritable.length > 0) {
+        let bestName = allWritable[0];
+        let bestScore = keywordScore(bestName);
+        for (const name of allWritable.slice(1)) {
+            const score = keywordScore(name);
+            if (score > bestScore) {
+                bestScore = score;
+                bestName = name;
+            }
+        }
+        return { name: bestName, reason: { source: 'keyword', detail: `Best keyword match (score=${bestScore})` } };
+    }
+
+    // No writable group found — return null rather than a non-writable group
+    // (url-test/fallback/load-balance groups cannot be switched via PUT /proxies/{group},
+    // and presenting them as actionable targets creates a broken interactive path).
+    return { name: null, reason: { source: 'fallback', detail: 'No writable proxy groups found' } };
+}
+
+// ─── Public API ────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ResolverOutput
+ * @property {Object}  data                  - Raw /proxies response
+ * @property {Object}  config                - Raw /configs response
+ * @property {string[]} groups               - All selector-type group names (legacy compat)
+ * @property {string|null}  mainGroup             - Primary group name (legacy compat → uiPrimaryGroupName)
+ * @property {string[]} proxies              - Candidates of the uiGroup (mainGroup)
+ * @property {string|null} current           - Current `now` of the uiGroup
+ *
+ * @property {string[]} orderedGroupNames    - Groups in run_config YAML order
+ * @property {string[]} topLevelGroupNames   - Top-level groups for group selector UI
+ * @property {string|null} effectiveGroupName - Inferred from FINAL/MATCH rule
+ * @property {string|null}  uiPrimaryGroupName    - Determined primary group (null if no writable groups)
+ * @property {string|null}  uiGroupName           - Actually used UI group (GLOBAL in global mode, or primary)
+ * @property {{source:string, detail:string}} reason - Why this primary group was chosen
+ * @property {Record<string, string[]>} graph - Group → children adjacency list
+ */
+
+/**
+ * Resolve proxy groups with full deterministic reasoning.
+ *
  * @param {Object} options
- * @param {Object} [options.existingData] - Pre-fetched proxies data
- * @param {Object} [options.existingConfig] - Pre-fetched config
- * @returns {Promise<{data: Object, config: Object, groups: string[], mainGroup: string, proxies: string[], current: string|null}|null>}
+ * @param {Object} [options.existingData]         - Pre-fetched /proxies data
+ * @param {Object} [options.existingConfig]       - Pre-fetched /configs data
+ * @param {string} [options.preferredGroupName]    - UI currently selected group
+ * @param {string} [options.primaryGroupPreference] - Saved user preference
+ * @returns {Promise<ResolverOutput|null>}
  */
 export async function fetchProxyGroups(options = {}) {
-    /** @type {{proxies?: Record<string, {type?: string, all?: string[], now?: string|null}>}} */
+    /** @type {{proxies?: Record<string, {type?: string, all?: string[], now?: string|null, hidden?: boolean}>}} */
     const data = options.existingData || await getProxies();
     if (!data || !data.proxies) {
         return null;
@@ -22,39 +339,76 @@ export async function fetchProxyGroups(options = {}) {
     /** @type {{mode?: string}} */
     const config = options.existingConfig || await getConfig();
 
-    // Filter out selector/select type groups
     const proxyMap = data.proxies;
+
+    // Read run_config for deterministic ordering and rules
+    const runConfig = await getRunConfigCached();
+
+    // --- orderedGroups (deterministic backbone) ---
+    const orderedGroupNames = buildOrderedGroups(runConfig, proxyMap);
+
+    // --- topLevelGroups ---
+    const topLevelGroupNames = buildTopLevelGroups(proxyMap, orderedGroupNames);
+
+    // --- effectiveGroup (from rules) ---
+    const effectiveGroupName = inferEffectiveGroup(runConfig, proxyMap);
+
+    // --- Legacy groups list (all selector-type groups) ---
     const groups = Object.keys(proxyMap).filter(name => {
-        const type = proxyMap[name]?.type?.toLowerCase() || '';
-        return type === 'selector' || type === 'select';
+        const p = proxyMap[name];
+        return p && isWritableGroupType(p.type) && !p.hidden;
     });
 
-    // Determine main group based on mode
-    let mainGroup = 'GLOBAL';
-    const mode = config?.mode?.toLowerCase();
+    // --- uiPrimaryGroup ---
+    const { name: uiPrimaryGroupName, reason } = determineUiPrimaryGroup({
+        preferredGroupName: options.preferredGroupName || null,
+        primaryGroupPreference: options.primaryGroupPreference || null,
+        effectiveGroupName,
+        orderedGroups: orderedGroupNames,
+        topLevelGroups: topLevelGroupNames,
+        proxyMap,
+    });
 
-    if (mode === 'direct') {
-        mainGroup = 'DIRECT';
-    } else if (mode !== 'global') {
-        mainGroup = groups.find(g => g.toLowerCase().includes('proxy')) || groups[0];
+    // --- uiGroup (the group the UI actually operates on) ---
+    // In global mode, ALL traffic is routed through the GLOBAL group.
+    // The user must operate on GLOBAL to affect actual routing.
+    let uiGroupName = uiPrimaryGroupName;
+    if (config?.mode?.toLowerCase() === 'global' && proxyMap['GLOBAL']) {
+        uiGroupName = 'GLOBAL';
     }
 
-    // Fallback if mainGroup is missing
-    if (!proxyMap[mainGroup]) {
-        mainGroup = groups.find(g => g.toLowerCase().includes('proxy')) || groups[0];
+    // --- Build graph (group → children adjacency) ---
+    /** @type {Record<string, string[]>} */
+    const graph = {};
+    for (const name of Object.keys(proxyMap)) {
+        const p = proxyMap[name];
+        if (isGroup(p) && p.all) {
+            graph[name] = [...p.all];
+        }
     }
 
-    // Last resort fallback
-    if (!proxyMap[mainGroup]) {
-        mainGroup = groups[0];
-    }
+    // --- Resolve candidates for the uiGroup ---
+    // Gracefully handle null uiGroupName (no writable groups found)
+    const targetGroup = uiGroupName ? proxyMap[uiGroupName] : null;
+    const proxies = targetGroup?.all || [];
+    const current = targetGroup?.now || null;
 
-    if (!mainGroup || !proxyMap[mainGroup]) {
-        return null;
-    }
+    return {
+        // Legacy compat fields
+        data,
+        config,
+        groups,
+        mainGroup: uiPrimaryGroupName,  // Backward compat — null signals "not ready"
+        proxies,
+        current,
 
-    const proxies = proxyMap[mainGroup]?.all || [];
-    const current = proxyMap[mainGroup]?.now || null;
-
-    return { data, config, groups, mainGroup, proxies, current };
+        // New resolver fields
+        orderedGroupNames,
+        topLevelGroupNames,
+        effectiveGroupName,
+        uiPrimaryGroupName,
+        uiGroupName,
+        reason,
+        graph,
+    };
 }

--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -7,9 +7,10 @@
 
 import { invoke, switchProxy } from '../api.js';
 import { COMMANDS } from '@zephyr/shared';
-import { fetchProxyGroups } from './proxy-groups.js';
+import { fetchProxyGroups, isWritableGroupType } from './proxy-groups.js';
 import { invalidateSettingsCache } from './cache.js';
 import { proxyMemoryLogger } from '../utils/logger.js';
+import { appStore } from './state.js';
 
 /** Maximum retries for waiting mihomo to be ready. */
 const MAX_READY_RETRIES = 50;
@@ -43,8 +44,10 @@ async function waitForMihomoReady() {
     for (let i = 0; i < MAX_READY_RETRIES; i++) {
         try {
             const result = await fetchProxyGroups();
-            // API is ready if we get a valid response with groups data
-            if (result && (result.proxies || result.mainGroup)) {
+            // API is ready if we get a valid response with groups data.
+            // mainGroup may be null if no writable groups exist, so check
+            // the groups array (populated from proxyMap, not the resolver).
+            if (result && (result.groups?.length > 0 || result.mainGroup)) {
                 return true;
             }
         } catch {
@@ -79,13 +82,45 @@ export async function restoreProxySelection(profileName) {
 
         if (!savedNode) return false;
 
-        const proxyGroupsResult = await fetchProxyGroups();
+        const proxyGroupsResult = await fetchProxyGroups({
+            preferredGroupName: appStore.get('uiGroupName') || null,
+        });
         if (!proxyGroupsResult) return false;
 
+        // Use the resolved uiGroupName (from resolver) instead of the old
+        // keyword-guessed mainGroup.  This fixes the core bug where the
+        // restored selection was applied to the wrong group.
+        const uiGroupName = proxyGroupsResult.uiGroupName
+            || proxyGroupsResult.mainGroup;
+
+        // Try the resolved uiGroupName first
         if (proxyGroupsResult.proxies && proxyGroupsResult.proxies.includes(savedNode)) {
-            const mainGroup = proxyGroupsResult.mainGroup || 'Proxy';
-            return await switchProxy(mainGroup, savedNode);
+            const success = await switchProxy(uiGroupName, savedNode);
+            if (success) {
+                appStore.set('uiGroupName', uiGroupName);
+            }
+            return success;
         }
+
+        // Fallback: search all writable groups for the saved node.
+        // After profile/core switches, the saved node may belong to a different
+        // selector group than the resolved primary.
+        const proxyMap = proxyGroupsResult.data?.proxies;
+        if (proxyMap) {
+            for (const groupName of Object.keys(proxyMap)) {
+                const group = proxyMap[groupName];
+                if (!isWritableGroupType(group?.type)) continue;
+                if (group.hidden) continue;
+                if (group.all && group.all.includes(savedNode)) {
+                    const success = await switchProxy(groupName, savedNode);
+                    if (success) {
+                        appStore.set('uiGroupName', groupName);
+                        return true;
+                    }
+                }
+            }
+        }
+
         return false;
     } catch (e) {
         proxyMemoryLogger.warn('Failed to restore proxy selection:', e);

--- a/apps/desktop/src/ui/run-config-cache.js
+++ b/apps/desktop/src/ui/run-config-cache.js
@@ -1,0 +1,58 @@
+// @ts-check
+/**
+ * Run-config cache — TTL-based cache for the compiled run_config.yaml JSON.
+ *
+ * The run_config (read via COMMANDS.CORE.READ_CONFIG) contains the deterministic
+ * proxy-groups order and rules that are essential for the Resolver in
+ * proxy-groups.js.  We cache it with a short TTL to avoid hammering the
+ * backend on every render while keeping data reasonably fresh.
+ *
+ * @module ui/run-config-cache
+ */
+
+import { invoke } from '../api.js';
+import { COMMANDS } from '@zephyr/shared';
+
+// --- State ---
+
+/** @type {{ data: any, time: number } | null} */
+let _cached = null;
+
+/** TTL in milliseconds (3 seconds — matches the analysis requirement). */
+const RUN_CONFIG_TTL = 3000;
+
+// --- Public API ---
+
+/**
+ * Get the run_config JSON, using a short TTL cache.
+ *
+ * @param {{ force?: boolean }} [options]
+ * @returns {Promise<any>} The run_config JSON object (or null on failure)
+ */
+export async function getRunConfigCached({ force = false } = {}) {
+    const now = Date.now();
+
+    // Return cached data if fresh and not forced
+    if (!force && _cached && (now - _cached.time) < RUN_CONFIG_TTL) {
+        return _cached.data;
+    }
+
+    try {
+        const data = await invoke(COMMANDS.CORE.READ_CONFIG);
+        _cached = { data, time: now };
+        return data;
+    } catch (_e) {
+        // On failure, return stale data if available, otherwise null
+        if (_cached) return _cached.data;
+        return null;
+    }
+}
+
+/**
+ * Invalidate the run_config cache.
+ * Must be called whenever the config is updated, subscription is switched,
+ * or the core is restarted.
+ */
+export function invalidateRunConfigCache() {
+    _cached = null;
+}

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -28,6 +28,7 @@ import { SVG_ICONS } from '../icons.js';
 import { syncCoreConfig } from '../proxies.js';
 import { initCustomDropdown } from '../dropdown.js';
 import * as prism from '../prism.js';
+import { invalidateRunConfigCache } from '../run-config-cache.js';
 
 /**
  * Extract a human-readable name from a subscription URL.
@@ -1182,6 +1183,7 @@ export function initSubscriptionSettings({
                         s.last_config = name;
                         await invoke(COMMANDS.SAVE_SETTINGS, { settings: s });
                         invalidateSettingsCache();
+                        invalidateRunConfigCache();
 
                         await closeAllConnections();
                         // Re-apply prism patches against the new profile so that

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -36,9 +36,12 @@ const PERSIST_DEBOUNCE_MS = 100;
  * @param {boolean}  [options.persist=true]  - Auto-persist to localStorage
  * @returns {Store}
  */
-export function createStore(storeName, initialState, { persist = true } = {}) {
+export function createStore(storeName, initialState, { persist = true, transientKeys = [] } = {}) {
+    /** @type {Set<string>} Keys that are never persisted to localStorage */
+    const _transient = new Set(transientKeys);
+
     // Hydrate from localStorage
-    const state = hydrate(storeName, initialState);
+    const state = hydrate(storeName, initialState, _transient);
 
     /** @type {Map<string, Set<Function>>} key -> callbacks */
     const keySubs = new Map();
@@ -66,7 +69,12 @@ export function createStore(storeName, initialState, { persist = true } = {}) {
         if (persistTimer) clearTimeout(persistTimer);
         persistTimer = setTimeout(() => {
             try {
-                localStorage.setItem(storeName, JSON.stringify(state));
+                // Strip transient keys before persisting
+                const toSave = { ...state };
+                for (const key of _transient) {
+                    delete toSave[key];
+                }
+                localStorage.setItem(storeName, JSON.stringify(toSave));
             } catch { /* quota exceeded — silently ignore */ }
             persistTimer = null;
         }, PERSIST_DEBOUNCE_MS);
@@ -291,14 +299,16 @@ export function createStore(storeName, initialState, { persist = true } = {}) {
  * @param {Record<string, any>} defaults
  * @returns {Record<string, any>}
  */
-function hydrate(storeName, defaults) {
+function hydrate(storeName, defaults, transientKeys) {
     try {
         const raw = localStorage.getItem(storeName);
         if (raw) {
             const saved = JSON.parse(raw);
             // Merge saved values over defaults (don't add new keys)
+            // Skip transient keys — they must always be computed fresh
             const state = { ...defaults };
             for (const key of Object.keys(defaults)) {
+                if (transientKeys?.has(key)) continue;
                 if (key in saved) {
                     state[key] = saved[key];
                 }
@@ -352,6 +362,13 @@ export const appStore = createStore('zephyr.app', {
     currentSortMode: localStorage.getItem('sortMode') || 'default',
     currentOutboundMode: 'rule',
 
+    // Proxy group resolver state
+    // All resolver state is transient — re-resolved each session.
+    // User's explicit group choice is tracked via saveProxySelection (profile+node).
+    uiGroupName: null,
+    uiPrimaryGroupName: null,
+    effectiveGroupName: null,
+
     // System state
     isSysProxyEnabled: false,
     isTunEnabled: false,
@@ -364,6 +381,8 @@ export const appStore = createStore('zephyr.app', {
     // Config
     currentConfigName: null,
     currentCoreVersion: '',
+}, {
+    transientKeys: ['uiGroupName', 'uiPrimaryGroupName', 'effectiveGroupName'],
 });
 
 /** Tray state (replaces the old sealed TrayState) */

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -12,6 +12,7 @@ import { trayMenuCache, TRAY_CACHE_TTL, invalidateSettingsCache, invalidateProxi
 import { toError } from '../types/guards.js';
 import { appStore } from './state.js';
 import { COMMANDS } from '@zephyr/shared';
+import { invalidateRunConfigCache } from './run-config-cache.js';
 
 // --- Tray event listener cleanup ---
 
@@ -99,13 +100,20 @@ export async function updateTrayMenu(forceRefresh = false) {
             /** @type {any} */
             const pd = proxyData;
             if (pd && pd.proxies) {
-                const groupNames = Object.keys(pd.proxies).filter(/** @param {string} name */ (name) => {
-                    const type = pd.proxies[name].type?.toLowerCase() || '';
-                    return type === 'selector' || type === 'select';
-                });
-
-                // Only use the first selector group to avoid duplicate nodes in tray
-                const mainGroup = groupNames[0];
+                // Use the resolver's active UI group if available, otherwise fall back
+                // to finding the first selector group.
+                // Prefer uiGroupName over uiPrimaryGroupName: in global mode,
+                // uiGroupName is 'GLOBAL' (the actually routing group), while
+                // uiPrimaryGroupName may point to a selector that doesn't affect routing.
+                let mainGroup = appStore.get('uiGroupName')
+                    || appStore.get('uiPrimaryGroupName');
+                if (!mainGroup || !pd.proxies[mainGroup]) {
+                    const groupNames = Object.keys(pd.proxies).filter(/** @param {string} name */ (name) => {
+                        const type = pd.proxies[name].type?.toLowerCase() || '';
+                        return type === 'selector' || type === 'select';
+                    });
+                    mainGroup = groupNames[0];
+                }
                 if (mainGroup) {
                     const group = pd.proxies[mainGroup];
                     proxyGroups = [{
@@ -263,6 +271,7 @@ export async function initTrayEventListeners() {
                 settings.last_config = subName;
                 await invoke(COMMANDS.SAVE_SETTINGS, { settings });
                 invalidateSettingsCache();
+                invalidateRunConfigCache();
 
                 await closeAllConnections();
 
@@ -296,6 +305,12 @@ export async function initTrayEventListeners() {
             const success = await switchProxy(group, proxy);
             if (success) {
                 invalidateProxiesCache();
+                invalidateRunConfigCache();
+
+                // Sync uiGroupName when tray explicitly specifies a group
+                if (group) {
+                    appStore.set('uiGroupName', group);
+                }
 
                 await closeAllConnections();
                 import('./proxies.js').then(m => m.syncCoreConfig());


### PR DESCRIPTION
…ainGroup

- Add run-config-cache.js: TTL 3s cache for read_config IPC

- Rewrite fetchProxyGroups as Resolver: orderedGroups from YAML order, effectiveGroup from FINAL/MATCH rules, uiPrimaryGroup with 7-level priority chain

- All switchProxy entry points now use uiGroupName from appStore

- Add group explanation bar: warns when uiGroup differs from effectiveGroup with one-click switch

- Fix node-wheel: save proxy selection after switch, pass preferredGroupName

- Fix tray menu: use uiGroupName instead of first-selector heuristic

- Fix restoreProxySelection: use resolver uiGroupName instead of keyword-guessed mainGroup

- Add transientKeys to appStore: derived state not persisted to localStorage

- Invalidate run-config cache on CONFIG_UPDATED/CORE_RESTARTED/subscription switch

- Backward compatible: mainGroup mapped to uiPrimaryGroupName