### PR TITLE
fix: DNS Rewrite 不再污染原始订阅 profile 文件

### DIFF
--- a/apps/desktop/src-tauri/src/config_manager.rs
+++ b/apps/desktop/src-tauri/src/config_manager.rs
@@ -209,9 +209,9 @@ pub async fn update_config(
         )
     };
 
-    if let Some(profile_name) = last_config_path {
+    if let Some(profile_name) = &last_config_path {
         if profile_name != "run_config.yaml" {
-            let profile_path = paths.profiles_dir.join(&profile_name);
+            let profile_path = paths.profiles_dir.join(profile_name);
             if profile_path.exists() {
                 if let Ok(profile_content) = fs::read_to_string(&profile_path) {
                     let patch_yaml: YamlValue = serde_yaml::to_value(&patch)

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -547,9 +547,9 @@ pub fn prepare_runtime_config(content: &str, secret: &str) -> Option<(String, u1
         }
     }
 
-    serde_yaml::to_string(&yaml_val)
-        .ok()
-        .map(|final_config| (final_config, config_port))
+    let result = serde_yaml::to_string(&yaml_val).ok()?;
+
+    Some((result, config_port))
 }
 
 fn build_minimal_runtime_config(secret: &str) -> (String, u16) {

--- a/apps/desktop/src-tauri/src/prism/commands_core.rs
+++ b/apps/desktop/src-tauri/src/prism/commands_core.rs
@@ -251,15 +251,12 @@ pub async fn prism_rebuild(
             .ok_or_else(|| "No active profile".to_owned())?
             .to_owned();
         let secret = lock.last_secret().to_owned();
-        eprintln!("[prism_rebuild] config_path = {config_path}");
         drop(lock);
 
         let paths = crate::core_manager::ensure_app_storage(&app)?;
         let profile_file = paths.profiles_dir.join(&config_path);
-        eprintln!("[prism_rebuild] reading profile from {profile_file:?}");
         let content = std::fs::read_to_string(&profile_file)
             .map_err(|e| format!("Failed to read profile '{config_path}': {e}"))?;
-        eprintln!("[prism_rebuild] profile size = {} bytes", content.len());
         (content, secret)
     };
 
@@ -269,7 +266,6 @@ pub async fn prism_rebuild(
         {
             let paths = crate::core_manager::ensure_app_storage(&app)?;
             let run_config_path = paths.core_dir.join("run_config.yaml");
-            eprintln!("[prism_rebuild] resetting run_config.yaml at {run_config_path:?}");
 
             // Use prepare_runtime_config to inject secret + external-controller
             // into the raw profile, just like start_core does.
@@ -286,19 +282,8 @@ pub async fn prism_rebuild(
             .as_ref()
             .ok_or_else(|| "Prism not initialized".to_owned())?;
         let result = ext.apply(opts)?;
-        for t in &result.trace {
-            eprintln!(
-                "[prism_rebuild]   patch='{}' file={:?} op='{}' matched={}",
-                t.patch_id, t.source_file, t.op_name, t.condition_matched,
-            );
-        }
-        eprintln!(
-            "[prism_rebuild] ext.apply() OK — trace: {} patches, {} matched, {} skipped",
-            result.trace.len(),
-            result.trace.iter().filter(|t| t.condition_matched).count(),
-            result.trace.iter().filter(|t| !t.condition_matched).count(),
-        );
         drop(lock);
+
         serde_json::to_value(result).map_err(|e| format!("Serialize failed: {e}"))
     })
     .await

--- a/apps/desktop/src/ui/dns-shared.js
+++ b/apps/desktop/src/ui/dns-shared.js
@@ -11,7 +11,6 @@
 import { patchConfig, closeAllConnections, getConfig, invoke } from '../api.js';
 import { dnsLogger } from '../utils/logger.js';
 import { showNotification } from './notifications.js';
-import { persistConfigChanges } from './advanced.js';
 import { invalidateSettingsCache } from './cache.js';
 import { translations, currentLang } from '../i18n.js';
 import { COMMANDS } from '@zephyr/shared';
@@ -183,7 +182,9 @@ export async function buildDnsRewritePayload() {
 }
 
 /**
- * Apply the DNS rewrite payload to the core and persist changes.
+ * Apply the DNS rewrite payload to the core via API only.
+ * Does NOT persist to the original profile file — DNS rewrite is a runtime
+ * overlay that must not corrupt subscription-specific DNS configurations.
  *
  * @returns {Promise<boolean>}
  */
@@ -191,7 +192,6 @@ export async function applyDnsRewrite() {
     try {
         const dnsRewritePayload = await buildDnsRewritePayload();
         await patchConfig(dnsRewritePayload);
-        await persistConfigChanges(dnsRewritePayload);
         return true;
     } catch (err) {
         dnsLogger.error('Failed to apply DNS rewrite', err);
@@ -344,7 +344,6 @@ export async function initDnsRewriteToggle() {
             try {
                 const payload = { dns: { enable: false }, sniffing: false };
                 await patchConfig(payload);
-                await persistConfigChanges(payload);
                 await closeAllConnections();
                 localStorage.setItem('dnsRewrite', 'false');
                 showNotification(t.notifDnsDisabled, 'info');


### PR DESCRIPTION
applyDnsRewrite() 移除 persistConfigChanges() 调用，DNS rewrite payload 仅通过 mihomo API (patchConfig) 在运行时生效，不再写回原始 profile 文件。 修复切换订阅时 CORE_RESTARTED 事件触发 persistConfigChanges 覆盖 订阅原始 DNS 配置导致节点超时的问题。同时清理 prism_rebuild 冗余日志。