### PR TITLE
feat: extract unified fetch utility with SSRF protection

### DIFF
--- a/apps/desktop/src-tauri/src/core/fetch_util.rs
+++ b/apps/desktop/src-tauri/src/core/fetch_util.rs
@@ -1,0 +1,430 @@
+/**
+ * Unified remote fetching utilities with SSRF protection.
+ *
+ * This module provides a single, consistent way to perform HTTP requests
+ * with proper security measures (SSRF protection, DNS pinning, redirect validation).
+ *
+ * Security measures aligned with subscription.rs original implementation:
+ * - URL scheme validation (http/https only)
+ * - Private host detection (localhost, .local, .localhost, private IPs)
+ * - Private IP detection using stdlib methods (`is_private`, `is_loopback`, etc.)
+ * - DNS resolution validation (public domain → private IP = SSRF block)
+ * - DNS pinning for public addresses
+ * - Redirect validation (blocks redirects to private hosts/IPs)
+ * - Response size limiting (`MAX_RESPONSE_SIZE`)
+ * - `.no_proxy()` by default to prevent system proxy leaks
+ */
+use std::net::IpAddr;
+use std::time::Duration;
+
+use super::MAX_RESPONSE_SIZE;
+
+/// Configuration for HTTP client building.
+#[derive(Debug, Clone)]
+pub struct HttpClientConfig {
+    pub user_agent: Option<String>,
+    pub timeout_secs: u64,
+    pub connect_timeout_secs: u64,
+    pub proxy_url: Option<String>,
+    pub resolve_pin: Option<(String, std::net::SocketAddr)>,
+}
+
+impl Default for HttpClientConfig {
+    fn default() -> Self {
+        Self {
+            user_agent: None,
+            timeout_secs: 30,
+            connect_timeout_secs: 30,
+            proxy_url: None,
+            resolve_pin: None,
+        }
+    }
+}
+
+/// Check if a host is a private or local address (SSRF protection).
+///
+/// Aligned with subscription.rs `is_private_host` implementation.
+fn is_private_host(host: &str) -> bool {
+    let host_lower = host.to_lowercase();
+
+    // Only allow these local hostname patterns for user-entered private addresses:
+    // - localhost / *.localhost (standard loopback)
+    // - *.local (mDNS / local network)
+    if host_lower == "localhost"
+        || host_lower.ends_with(".localhost")
+        || host_lower.ends_with(".local")
+    {
+        return true;
+    }
+
+    // If it's a direct IP address, check it
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return is_private_ip(ip);
+    }
+
+    false
+}
+
+/// Check if an IP address is private or local.
+///
+/// Aligned with subscription.rs `is_private_ip` implementation,
+/// using stdlib methods for reliability.
+const fn is_private_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ipv4) => {
+            ipv4.is_private()
+                || ipv4.is_loopback()
+                || ipv4.is_link_local()
+                || ipv4.is_broadcast()
+                || ipv4.is_documentation()
+                || ipv4.is_unspecified()
+        }
+        IpAddr::V6(ipv6) => {
+            let segments = ipv6.segments();
+            ipv6.is_loopback()
+                || ipv6.is_unspecified()
+                // fc00::/7 (Unique Local Address)
+                || (segments[0] & 0xfe00) == 0xfc00
+                // fe80::/10 (Link Local Address)
+                || (segments[0] & 0xff00) == 0xfe00
+        }
+    }
+}
+
+/// Format a host:port string, handling IPv6 bracket notation.
+fn format_host_port(host: &str, port: u16) -> String {
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+/// Validate a URL for SSRF protection.
+///
+/// Returns:
+/// - `Ok((host, resolved_addr, user_entered_private))` if valid
+/// - `Err(String)` if invalid or SSRF detected
+///
+/// Security:
+/// - Only allows http/https schemes
+/// - Blocks public domains that resolve to private IPs (DNS rebinding)
+/// - Allows user-entered private addresses (for local networks)
+pub fn validate_url(url: &str) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+    let parsed_url = reqwest::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    // Only allow http and https schemes
+    let scheme = parsed_url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err("Only HTTP and HTTPS URLs are allowed".to_owned());
+    }
+
+    // Extract host
+    let host = parsed_url
+        .host_str()
+        .ok_or("URL must have a host")?
+        .to_owned();
+
+    // Check if user explicitly entered a private/local host
+    let user_entered_private = is_private_host(&host);
+
+    if user_entered_private {
+        // User explicitly typed a private address
+        // Allow it, but return None for resolved_addr (no DNS pinning)
+        return Ok((host, None, true));
+    }
+
+    // Host is a public domain — resolve and verify all IPs are public
+    let port = parsed_url
+        .port()
+        .unwrap_or(if scheme == "https" { 443 } else { 80 });
+    let host_port = format_host_port(&host, port);
+    let addrs: Vec<std::net::SocketAddr> = std::net::ToSocketAddrs::to_socket_addrs(&host_port)
+        .map_err(|e| format!("Failed to resolve host: {e}"))?
+        .collect();
+
+    let mut resolved_addr = None;
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            // Public domain resolving to a private IP = SSRF, always block
+            return Err("Access to private/local resolved addresses is not allowed".to_owned());
+        }
+        if resolved_addr.is_none() {
+            resolved_addr = Some(*addr);
+        }
+    }
+
+    if resolved_addr.is_none() {
+        return Err("Could not resolve any IP address for the host".to_owned());
+    }
+
+    Ok((host, resolved_addr, false))
+}
+
+/// Build an HTTP client with security settings.
+///
+/// Features:
+/// - Redirect validation (blocks redirects to private IPs)
+/// - Timeout configuration
+/// - Optional proxy support
+/// - Optional DNS pinning (`resolve_pin`)
+/// - `.no_proxy()` by default to prevent system proxy leaks
+pub fn build_http_client(config: HttpClientConfig) -> Result<reqwest::Client, String> {
+    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > 5 {
+            return attempt.error("Too many redirects (max 5)");
+        }
+
+        let url = attempt.url().clone();
+        let scheme = url.scheme();
+        if scheme != "http" && scheme != "https" {
+            return attempt.error(format!("Invalid redirect scheme: {scheme}"));
+        }
+
+        let host = match url.host_str() {
+            Some(h) => h.to_owned(),
+            None => return attempt.error("Redirect URL has no host"),
+        };
+
+        if is_private_host(&host) {
+            return attempt.error(format!("Redirect to private host blocked: {host}"));
+        }
+
+        let port = url
+            .port()
+            .unwrap_or(if scheme == "https" { 443 } else { 80 });
+        let host_port = format_host_port(&host, port);
+        match std::net::ToSocketAddrs::to_socket_addrs(&host_port) {
+            Ok(addrs) => {
+                for addr in addrs {
+                    if is_private_ip(addr.ip()) {
+                        return attempt.error(format!(
+                            "Redirect to private IP blocked: {} -> {}",
+                            host,
+                            addr.ip()
+                        ));
+                    }
+                }
+            }
+            Err(e) => return attempt.error(format!("Failed to resolve redirect host {host}: {e}")),
+        }
+
+        attempt.follow()
+    });
+
+    // .no_proxy() by default to prevent system proxy leaks (SSRF attack surface reduction).
+    // A proxy is only added if explicitly configured via config.proxy_url.
+    let mut client_builder = reqwest::Client::builder()
+        .timeout(Duration::from_secs(config.timeout_secs))
+        .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
+        .redirect(redirect_policy)
+        .no_proxy();
+
+    // Add proxy if configured
+    if let Some(proxy_url) = config.proxy_url {
+        let proxy =
+            reqwest::Proxy::all(&proxy_url).map_err(|e| format!("Failed to create proxy: {e}"))?;
+        client_builder = client_builder.proxy(proxy);
+    }
+
+    // Add DNS pinning if configured
+    if let Some((host, addr)) = config.resolve_pin {
+        client_builder = client_builder.resolve(&host, addr);
+    }
+
+    // Set User-Agent (simple default, no Shadowrocket handling here)
+    // Shadowrocket and other custom UA handling is done in subscription.rs
+    let ua = config
+        .user_agent
+        .unwrap_or_else(|| format!("Zephyr/{}", env!("CARGO_PKG_VERSION")));
+    client_builder = client_builder.user_agent(ua);
+
+    client_builder
+        .build()
+        .map_err(|e| format!("HTTP client build failed: {e}"))
+}
+
+/// Fetch content from a URL with full security checks.
+///
+/// This is the main entry point for remote fetching. It handles:
+/// - URL validation (SSRF protection)
+/// - HTTP client building with security settings
+/// - Response size limiting
+/// - Timeout handling
+///
+/// # Arguments
+/// * `url` - The URL to fetch
+/// * `proxy_port` - Optional local proxy port (for proxied downloads)
+///
+/// # Returns
+/// * `Ok(String)` - The fetched content as UTF-8 string
+/// * `Err(String)` - Error message if fetch failed
+pub async fn fetch_url_content(url: &str, proxy_port: Option<u16>) -> Result<String, String> {
+    // Validate URL (SSRF protection + DNS resolution)
+    let (host, resolved_addr, user_entered_private) = validate_url(url)?;
+
+    // Configure DNS pinning for public addresses
+    let resolve_pin = if user_entered_private {
+        None
+    } else {
+        resolved_addr.map(|addr| (host, addr))
+    };
+
+    // Try proxied download first if proxy port is provided
+    if let Some(port) = proxy_port.filter(|&p| p > 0) {
+        let proxy_url = format!("http://127.0.0.1:{port}");
+        let config = HttpClientConfig {
+            proxy_url: Some(proxy_url),
+            resolve_pin: resolve_pin.clone(),
+            ..Default::default()
+        };
+        let client = build_http_client(config)?;
+
+        match fetch_body(&client, url).await {
+            Ok(content) => return Ok(content),
+            Err(proxy_err) => {
+                // Log proxy failure and fall back to direct download
+                eprintln!(
+                    "[fetch_url_content] Proxy download failed ({proxy_err}), retrying direct..."
+                );
+            }
+        }
+    }
+
+    // Direct download (fallback or default)
+    let config = HttpClientConfig {
+        resolve_pin,
+        ..Default::default()
+    };
+    let client = build_http_client(config)?;
+    fetch_body(&client, url).await
+}
+
+/// Fetch body from a response with size limiting.
+async fn fetch_body(client: &reqwest::Client, url: &str) -> Result<String, String> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Download failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Download returned {}", response.status()));
+    }
+
+    // Check Content-Length before reading body
+    // Use unwrap_or(usize::MAX) so that on 32-bit systems where u64 > usize::MAX,
+    // the check correctly triggers an error instead of passing.
+    if let Some(len) = response.content_length() {
+        if usize::try_from(len).unwrap_or(usize::MAX) > MAX_RESPONSE_SIZE {
+            return Err(format!(
+                "Response body exceeds maximum size of {MAX_RESPONSE_SIZE} bytes"
+            ));
+        }
+    }
+
+    // Stream read with size limit
+    use futures_util::StreamExt as _;
+
+    // Pre-allocate buffer if Content-Length is known
+    let content_length = response.content_length();
+    let initial_capacity = content_length
+        .and_then(|l| usize::try_from(l).ok())
+        .unwrap_or(0)
+        .min(MAX_RESPONSE_SIZE);
+    let mut bytes = Vec::with_capacity(initial_capacity);
+
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result.map_err(|e| format!("Failed to read chunk: {e}"))?;
+        if bytes.len() + chunk.len() > MAX_RESPONSE_SIZE {
+            return Err(format!(
+                "Response exceeded size limit of {MAX_RESPONSE_SIZE} bytes"
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    // Use lossy UTF-8 conversion for compatibility with malformed remote content
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Fetch text content from a URL (simple wrapper for backward compatibility).
+pub async fn fetch_text(url: String) -> Result<String, String> {
+    fetch_url_content(&url, None).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_private_host_localhost() {
+        assert!(is_private_host("localhost"));
+        assert!(is_private_host("LOCALHOST"));
+        assert!(is_private_host("my.localhost"));
+        assert!(is_private_host("my.local"));
+    }
+
+    #[test]
+    fn test_is_private_host_does_not_false_positive() {
+        // 127.example.com is a public domain, NOT private
+        assert!(!is_private_host("127.example.com"));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4() {
+        use std::net::Ipv4Addr;
+        // Private ranges
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        // Loopback
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        // Link-local
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))));
+        // Broadcast
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255))));
+        // Unspecified
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED)));
+        // Public
+        assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    #[test]
+    fn test_is_private_ip_v6() {
+        use std::net::Ipv6Addr;
+        // Loopback
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        // Unspecified
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+        // Unique local fc00::/7
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::new(
+            0xfc00, 0, 0, 0, 0, 0, 0, 1
+        ))));
+        // Link local fe80::/10
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0, 0, 0, 0, 0, 0, 1
+        ))));
+        // Public
+        assert!(!is_private_ip(IpAddr::V6(Ipv6Addr::new(
+            0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888
+        ))));
+    }
+
+    #[test]
+    fn test_format_host_port() {
+        assert_eq!(format_host_port("example.com", 443), "example.com:443");
+        assert_eq!(format_host_port("::1", 80), "[::1]:80");
+        assert_eq!(format_host_port("2001:db8::1", 443), "[2001:db8::1]:443");
+    }
+
+    #[test]
+    fn test_validate_url_rejects_invalid_schemes() {
+        assert!(validate_url("ftp://example.com/file").is_err());
+        assert!(validate_url("file:///etc/passwd").is_err());
+        assert!(validate_url("javascript:alert(1)").is_err());
+    }
+}

--- a/apps/desktop/src-tauri/src/core/mod.rs
+++ b/apps/desktop/src-tauri/src/core/mod.rs
@@ -141,6 +141,7 @@ pub mod config_sanitizer;
 pub mod core_log;
 pub mod core_process;
 pub mod crypto;
+pub mod fetch_util;
 pub mod secure_io;
 pub mod subscription;
 pub mod subscription_scheduler;

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Manager as _, State};
 
 use super::config_sanitizer::remove_dangerous_keys;
+use super::fetch_util::fetch_url_content;
 
 /// Quote `short-id` values in YAML content before parsing.
 /// This prevents YAML from interpreting hex-like values (e.g., "34010e92") as scientific notation.
@@ -169,13 +170,6 @@ fn validate_subscription_name(name: &str) -> Result<String, String> {
         return Err("Subscription name cannot be empty".to_owned());
     }
     super::config_sanitizer::sanitize_base_filename(name)
-}
-
-pub(crate) fn build_http_client(
-    user_agent: Option<&str>,
-    resolve_pin: Option<(String, std::net::SocketAddr)>,
-) -> Result<reqwest::Client, String> {
-    build_http_client_with_proxy(user_agent, resolve_pin, None)
 }
 
 fn build_http_client_with_proxy(
@@ -846,27 +840,10 @@ pub struct BatchUpdateItem {
 
 #[tauri::command]
 pub async fn fetch_text(url: String) -> Result<String, String> {
-    let (host, resolved_addr, user_entered_private) = validate_subscription_url_with_ip(&url)?;
-    let resolve_pin = if user_entered_private {
-        None
-    } else {
-        resolved_addr.map(|addr| (host, addr))
-    };
-    let client = build_http_client(None, resolve_pin)?;
-
-    let resp = client.get(&url).send().await.map_err(|e| {
+    fetch_url_content(&url, None).await.map_err(|e| {
         println!("Fetch failed: {e}");
         "Network error occurred during fetch".to_owned()
-    })?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        println!("Fetch failed with status: {status}");
-        return Err("Fetch failed with error status".to_owned());
-    }
-
-    let bytes = read_response_body(resp).await?;
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
+    })
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -7,6 +7,7 @@ use tauri::{Manager as _, State};
 
 use clash_prism_extension::ApplyOptions;
 
+use crate::core_manager::core::fetch_util::fetch_url_content;
 use crate::core_manager::write_file_secure;
 use crate::prism::overrides::overrides_model::{
     LogEntry, OverrideExt, OverrideItem, OverrideLog, OverrideType,
@@ -583,82 +584,12 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
 
 /// Download remote content with optional proxy and automatic direct fallback.
 ///
-/// If `proxy_port` is set, tries proxied download first. On failure (proxy down,
-/// timeout, connection refused), retries once without proxy. This ensures remote
-/// overrides can be refreshed even when the Mihomo core is not running.
+/// Uses the unified `fetch_url_content` function from `fetch_util` for consistent
+/// security measures (SSRF protection, DNS pinning, redirect validation).
 async fn download_remote_content(url: &str, proxy_port: Option<u16>) -> Result<String, String> {
-    const MAX_REMOTE_SIZE: usize = 10 * 1024 * 1024; // 10 MB limit
-
-    // Build proxied client if port is configured
-    let proxied_client: Option<reqwest::Client> = if let Some(port) = proxy_port.filter(|&p| p > 0)
-    {
-        let proxy = reqwest::Proxy::all(format!("http://127.0.0.1:{port}"))
-            .map_err(|e| format!("Failed to create proxy: {e}"))?;
-        Some(
-            reqwest::Client::builder()
-                .proxy(proxy)
-                .timeout(std::time::Duration::from_secs(30))
-                .build()
-                .map_err(|e| format!("HTTP client error: {e}"))?,
-        )
-    } else {
-        None
-    };
-
-    // Try proxied first, then fall back to direct
-    if let Some(client) = &proxied_client {
-        match fetch_body(client, url, MAX_REMOTE_SIZE).await {
-            Ok(content) => {
-                check_input_size(&content, "Remote override content")?;
-                return Ok(content);
-            }
-            Err(proxy_err) => {
-                emit_warn!(
-                    Override,
-                    OVERRIDE_APPLY_FAILED,
-                    "Proxy download failed ({proxy_err}), retrying direct..."
-                );
-            }
-        }
-    }
-
-    // Direct download (fallback or default)
-    let direct_client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| format!("HTTP client error: {e}"))?;
-    let content = fetch_body(&direct_client, url, MAX_REMOTE_SIZE).await?;
+    let content = fetch_url_content(url, proxy_port).await?;
     check_input_size(&content, "Remote override content")?;
     Ok(content)
-}
-
-/// Stream the response body with a hard byte limit.
-async fn fetch_body(
-    client: &reqwest::Client,
-    url: &str,
-    max_size: usize,
-) -> Result<String, String> {
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("Download failed: {e}"))?;
-    if !response.status().is_success() {
-        return Err(format!("Download returned {}", response.status()));
-    }
-
-    use futures_util::StreamExt as _;
-    let mut stream = response.bytes_stream();
-    let mut buf = Vec::with_capacity(4096);
-    while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result.map_err(|e| format!("Failed to read response: {e}"))?;
-        if buf.len() + chunk.len() > max_size {
-            return Err(format!("Remote override content exceeds {max_size} bytes"));
-        }
-        buf.extend_from_slice(&chunk);
-    }
-
-    String::from_utf8(buf).map_err(|e| format!("Invalid UTF-8 in remote override: {e}"))
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/apps/desktop/src-tauri/src/prism/rule_library.rs
+++ b/apps/desktop/src-tauri/src/prism/rule_library.rs
@@ -5,7 +5,7 @@
 use tauri::State;
 
 use crate::core_manager::core::config_sanitizer::remove_dangerous_keys;
-use crate::core_manager::core::subscription::validate_subscription_url_with_ip;
+use crate::core_manager::core::fetch_util::fetch_url_content;
 use crate::core_manager::core::MAX_RESPONSE_SIZE;
 use crate::core_manager::write_file_secure;
 use crate::prism::types::{
@@ -372,55 +372,9 @@ pub async fn rule_import_url(
     name: String,
 ) -> Result<String, String> {
     state.check_rate_limit("rule_import_url")?;
-    // C-3: Validate URL scheme and resolve DNS to prevent SSRF (rebinding/TOCTOU)
-    let (validated_host, resolved_addr, user_entered_private) =
-        validate_subscription_url_with_ip(&url)?;
 
-    // For user-entered private addresses, skip DNS pinning.
-    // For public addresses, pin resolved IP to prevent DNS rebinding.
-    let resolve_pin = if user_entered_private {
-        None
-    } else {
-        resolved_addr.map(|addr| (validated_host, addr))
-    };
-
-    // M-3: Add connection and read timeouts (async client)
-    let client = crate::core_manager::core::subscription::build_http_client(None, resolve_pin)
-        .map_err(|e| format!("HTTP client build failed: {e}"))?;
-
-    let res = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to download: {e}"))?;
-
-    if !res.status().is_success() {
-        return Err(format!("HTTP error: {}", res.status()));
-    }
-
-    // M-4: Check Content-Length header before reading body, reject if > 10MB
-    if let Some(len) = res.content_length() {
-        if usize::try_from(len).unwrap_or(0) > MAX_RESPONSE_SIZE {
-            return Err(format!(
-                "Response body exceeds maximum size of {MAX_RESPONSE_SIZE} bytes"
-            ));
-        }
-    }
-
-    // Read response with byte limit
-    let bytes = res
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to read response body: {e}"))?;
-
-    if bytes.len() > MAX_RESPONSE_SIZE {
-        return Err(format!(
-            "Response body exceeds maximum size of {MAX_RESPONSE_SIZE} bytes"
-        ));
-    }
-
-    let raw = String::from_utf8(bytes.to_vec())
-        .map_err(|e| format!("Response body is not valid UTF-8: {e}"))?;
+    // Use unified fetch function for consistent security measures
+    let raw = fetch_url_content(&url, None).await?;
 
     let content = normalize_to_prism_yaml(&raw);
     if content.is_empty() {


### PR DESCRIPTION
- Add fetch_util.rs with validate_url(), build_http_client(), fetch_url_content()
- Ensure consistent security across subscription, rule import, and remote override
- Includes SSRF protection, DNS pinning, redirect validation, size limits