### PR TITLE
feat: add unified mutex lock utilities

### DIFF
--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -168,6 +168,7 @@ pub mod codes {
     pub const CORE_CRASHED: u16 = 1004;
     pub const CORE_CACHE_LOCKED: u16 = 1005;
     pub const CORE_RELOAD_FAILED: u16 = 1006;
+    pub const CORE_LOCK_FAILED: u16 = 1007;
 
     // Subscription: 2000-2999
     pub const SUB_UPDATE_FAILED: u16 = 2001;
@@ -175,39 +176,48 @@ pub mod codes {
     pub const SUB_PARSE_FAILED: u16 = 2003;
     pub const SUB_ALL_FAILED: u16 = 2004;
     pub const SUB_UPDATE_SUCCESS: u16 = 2005;
+    pub const SUB_LOCK_FAILED: u16 = 2006;
 
     // Prism: 3000-3999
     pub const PRISM_APPLY_FAILED: u16 = 3001;
     pub const PRISM_SCRIPT_ERROR: u16 = 3002;
     pub const PRISM_HOT_RELOAD_FAILED: u16 = 3003;
+    pub const PRISM_LOCK_FAILED: u16 = 3004;
 
     // Config: 4000-4999
     pub const CONFIG_SAVE_FAILED: u16 = 4001;
     pub const CONFIG_PARSE_FAILED: u16 = 4002;
     pub const CONFIG_DELETE_FAILED: u16 = 4003;
     pub const CONFIG_CREATED_DEFAULT: u16 = 4004;
+    pub const CONFIG_LOCK_FAILED: u16 = 4005;
 
     // Plugin: 5000-5999
     pub const PLUGIN_LOAD_FAILED: u16 = 5001;
     pub const PLUGIN_EXEC_ERROR: u16 = 5002;
+    pub const PLUGIN_LOCK_FAILED: u16 = 5003;
 
     // System: 6000-6999
     pub const SYS_PROXY_FAILED: u16 = 6001;
     pub const SYS_TUN_FAILED: u16 = 6002;
     pub const SYS_DNS_FAILED: u16 = 6003;
+    pub const SYS_LOCK_FAILED: u16 = 6004;
 
     // Updater: 7000-7999
     pub const UPDATE_CHECK_FAILED: u16 = 7001;
     pub const UPDATE_DOWNLOAD_FAILED: u16 = 7002;
+    pub const UPDATE_LOCK_FAILED: u16 = 7003;
 
     // Override: 8000-8999
     pub const OVERRIDE_APPLY_FAILED: u16 = 8001;
+    pub const OVERRIDE_LOCK_FAILED: u16 = 8002;
 
     // Rule: 9000-9999
     pub const RULE_PARSE_FAILED: u16 = 9001;
+    pub const RULE_LOCK_FAILED: u16 = 9002;
 
     // Smart: 10000-10999
     pub const SMART_SELECT_FAILED: u16 = 10001;
+    pub const SMART_LOCK_FAILED: u16 = 10002;
 }
 
 // ── Global Emitter ──────────────────────────────────────────────────────────
@@ -307,6 +317,63 @@ macro_rules! emit_error {
             )
         )
     };
+}
+
+// ── Mutex Lock Utilities ─────────────────────────────────────────────────────
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Lock a mutex for critical paths where data consistency is important.
+///
+/// Returns `Err` if the mutex is poisoned (another thread panicked while holding it).
+/// Also emits an error event to notify the frontend.
+///
+/// # Arguments
+/// * `mutex` - The mutex to lock
+/// * `module` - The module for error event (e.g., `BackendModule::Core`)
+/// * `code` - The error code (e.g., `codes::CORE_LOCK_FAILED`)
+///
+/// # Returns
+/// * `Ok(MutexGuard)` - Successfully acquired lock
+/// * `Err(String)` - Lock failed, with error message
+///
+/// # Example
+/// ```ignore
+/// let guard = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
+/// ```
+pub fn lock_critical<T>(
+    mutex: &Mutex<T>,
+    module: BackendModule,
+    code: u16,
+) -> Result<MutexGuard<'_, T>, String> {
+    mutex.lock().map_err(|e| {
+        let msg = format!("Lock failed: {e}");
+        emit_backend_event(&BackendEvent::error(module, code, &msg));
+        msg
+    })
+}
+
+/// Lock a mutex for non-critical paths where best-effort access is acceptable.
+///
+/// If the mutex is poisoned (another thread panicked while holding it),
+/// this still returns the guard with potentially inconsistent data.
+/// Use this only when:
+/// - The data is read-only or can tolerate inconsistency
+/// - Missing the operation is worse than using potentially stale data
+/// - You want to avoid propagating errors
+///
+/// # Arguments
+/// * `mutex` - The mutex to lock
+///
+/// # Returns
+/// * `MutexGuard` - Always returns a guard (never fails)
+///
+/// # Example
+/// ```ignore
+/// let guard = lock_best_effort(&state.0);
+/// ```
+pub fn lock_best_effort<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 #[macro_export]

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::PermissionsExt as _;
 
 use super::config_sanitizer::{sanitize_config_file_name, validate_path_within_dir};
 use super::secure_io::write_file_secure;
-use crate::backend_event::redact_error_message;
+use crate::backend_event::{codes, lock_critical, redact_error_message, BackendModule};
 #[allow(unused_imports)]
 use crate::{emit_error, emit_info, emit_warn};
 
@@ -1095,7 +1095,7 @@ pub async fn start_core(
     // If the requested config differs from the current one, we must restart to apply it.
     // Also extract port/secret for drain before killing.
     let drain_info: Option<(u16, String)> = {
-        let lock = state.0.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
         if lock.process().is_some() {
             let same_config = lock
                 .last_config_path()
@@ -1243,12 +1243,13 @@ pub async fn start_core(
     // Note: MSL was set to 1000ms in root shell during TUN start if applicable.
     // Non-TUN mode does not need low MSL, and changing it requires root anyway.
 
-    let mut lock = if let Ok(l) = state.0.lock() {
-        l
-    } else {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err("Failed to lock state".to_owned());
+    let mut lock = match lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED) {
+        Ok(l) => l,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
     };
     lock.set_process(Some(child));
     lock.set_last_secret(resolved_secret.clone());

--- a/apps/desktop/src-tauri/src/core/fetch_util.rs
+++ b/apps/desktop/src-tauri/src/core/fetch_util.rs
@@ -100,67 +100,6 @@ fn format_host_port(host: &str, port: u16) -> String {
     }
 }
 
-/// Validate a URL for SSRF protection.
-///
-/// Returns:
-/// - `Ok((host, resolved_addr, user_entered_private))` if valid
-/// - `Err(String)` if invalid or SSRF detected
-///
-/// Security:
-/// - Only allows http/https schemes
-/// - Blocks public domains that resolve to private IPs (DNS rebinding)
-/// - Allows user-entered private addresses (for local networks)
-pub fn validate_url(url: &str) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
-    let parsed_url = reqwest::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
-
-    // Only allow http and https schemes
-    let scheme = parsed_url.scheme();
-    if scheme != "http" && scheme != "https" {
-        return Err("Only HTTP and HTTPS URLs are allowed".to_owned());
-    }
-
-    // Extract host
-    let host = parsed_url
-        .host_str()
-        .ok_or("URL must have a host")?
-        .to_owned();
-
-    // Check if user explicitly entered a private/local host
-    let user_entered_private = is_private_host(&host);
-
-    if user_entered_private {
-        // User explicitly typed a private address
-        // Allow it, but return None for resolved_addr (no DNS pinning)
-        return Ok((host, None, true));
-    }
-
-    // Host is a public domain — resolve and verify all IPs are public
-    let port = parsed_url
-        .port()
-        .unwrap_or(if scheme == "https" { 443 } else { 80 });
-    let host_port = format_host_port(&host, port);
-    let addrs: Vec<std::net::SocketAddr> = std::net::ToSocketAddrs::to_socket_addrs(&host_port)
-        .map_err(|e| format!("Failed to resolve host: {e}"))?
-        .collect();
-
-    let mut resolved_addr = None;
-    for addr in &addrs {
-        if is_private_ip(addr.ip()) {
-            // Public domain resolving to a private IP = SSRF, always block
-            return Err("Access to private/local resolved addresses is not allowed".to_owned());
-        }
-        if resolved_addr.is_none() {
-            resolved_addr = Some(*addr);
-        }
-    }
-
-    if resolved_addr.is_none() {
-        return Err("Could not resolve any IP address for the host".to_owned());
-    }
-
-    Ok((host, resolved_addr, false))
-}
-
 /// Build an HTTP client with security settings.
 ///
 /// Features:
@@ -252,48 +191,148 @@ pub fn build_http_client(config: HttpClientConfig) -> Result<reqwest::Client, St
 /// - Response size limiting
 /// - Timeout handling
 ///
+/// Download strategy (aligned with subscription.rs):
+/// 1. Try direct connection first (with DNS pinning for public addresses)
+/// 2. If direct fails and proxy is available, try proxy (without DNS pinning)
+///
+/// The proxy path skips DNS pre-resolve pinning to let the proxy handle DNS
+/// resolution. This avoids issues with CDN / geo-balanced IPs and split-horizon
+/// DNS where only the proxy can resolve the domain.
+///
 /// # Arguments
 /// * `url` - The URL to fetch
-/// * `proxy_port` - Optional local proxy port (for proxied downloads)
+/// * `proxy_port` - Optional local proxy port (for proxied downloads as fallback)
 ///
 /// # Returns
 /// * `Ok(String)` - The fetched content as UTF-8 string
 /// * `Err(String)` - Error message if fetch failed
 pub async fn fetch_url_content(url: &str, proxy_port: Option<u16>) -> Result<String, String> {
-    // Validate URL (SSRF protection + DNS resolution)
-    let (host, resolved_addr, user_entered_private) = validate_url(url)?;
+    // Basic URL validation (scheme, host format) without DNS resolution
+    // DNS resolution is deferred to allow proxy to handle it
+    let (host, port, user_entered_private) = validate_url_basic(url)?;
 
-    // Configure DNS pinning for public addresses
-    let resolve_pin = if user_entered_private {
-        None
-    } else {
-        resolved_addr.map(|addr| (host, addr))
-    };
+    // Try direct connection first (with DNS pinning for public addresses)
+    let direct_result = try_direct_download(url, &host, port, user_entered_private).await;
 
-    // Try proxied download first if proxy port is provided
-    if let Some(port) = proxy_port.filter(|&p| p > 0) {
-        let proxy_url = format!("http://127.0.0.1:{port}");
-        let config = HttpClientConfig {
-            proxy_url: Some(proxy_url),
-            resolve_pin: resolve_pin.clone(),
-            ..Default::default()
-        };
-        let client = build_http_client(config)?;
+    match direct_result {
+        Ok(content) => Ok(content),
+        Err(direct_err) => {
+            eprintln!("[fetch_url_content] Direct download failed: {direct_err}");
 
-        match fetch_body(&client, url).await {
-            Ok(content) => return Ok(content),
-            Err(proxy_err) => {
-                // Log proxy failure and fall back to direct download
-                eprintln!(
-                    "[fetch_url_content] Proxy download failed ({proxy_err}), retrying direct..."
-                );
+            // Try proxy fallback if available
+            if let Some(port) = proxy_port.filter(|&p| p > 0) {
+                eprintln!("[fetch_url_content] Retrying with proxy...");
+                match try_proxy_download(url, port).await {
+                    Ok(content) => Ok(content),
+                    Err(proxy_err) => Err(format!("Direct: {direct_err}; Proxy: {proxy_err}")),
+                }
+            } else {
+                Err(direct_err)
             }
         }
     }
+}
 
-    // Direct download (fallback or default)
+/// Basic URL validation without DNS resolution.
+///
+/// Returns `(host, port, user_entered_private)` for further processing.
+fn validate_url_basic(url: &str) -> Result<(String, u16, bool), String> {
+    let parsed_url = reqwest::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    // Only allow http and https schemes
+    let scheme = parsed_url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err("Only HTTP and HTTPS URLs are allowed".to_owned());
+    }
+
+    // Extract host
+    let host = parsed_url
+        .host_str()
+        .ok_or("URL must have a host")?
+        .to_owned();
+
+    let port = parsed_url
+        .port()
+        .unwrap_or(if scheme == "https" { 443 } else { 80 });
+
+    // Check if user explicitly entered a private/local host
+    let user_entered_private = is_private_host(&host);
+
+    Ok((host, port, user_entered_private))
+}
+
+/// Try direct download with DNS pinning for public addresses.
+async fn try_direct_download(
+    url: &str,
+    host: &str,
+    port: u16,
+    user_entered_private: bool,
+) -> Result<String, String> {
+    // For user-entered private addresses, skip DNS resolution
+    // For public addresses, resolve and pin to prevent DNS rebinding
+    let resolve_pin = if user_entered_private {
+        None
+    } else {
+        let addr = resolve_and_pin(host, port).await?;
+        Some((host.to_owned(), addr))
+    };
+
     let config = HttpClientConfig {
         resolve_pin,
+        ..Default::default()
+    };
+    let client = build_http_client(config)?;
+    fetch_body(&client, url).await
+}
+
+/// Resolve host and return first valid public address for DNS pinning.
+///
+/// The port is included in resolution to ensure the returned `SocketAddr`
+/// matches the request port (e.g., 443 for HTTPS).
+///
+/// Security: If ANY resolved address is private, the request is blocked.
+/// This prevents DNS rebinding attacks where a public domain resolves to
+/// both public and private IPs.
+async fn resolve_and_pin(host: &str, port: u16) -> Result<std::net::SocketAddr, String> {
+    let host_port = format_host_port(host, port);
+
+    let addrs: Vec<std::net::SocketAddr> = tokio::task::spawn_blocking(move || {
+        std::net::ToSocketAddrs::to_socket_addrs(&host_port)
+            .map(std::iter::Iterator::collect)
+            .map_err(|e| format!("Failed to resolve host: {e}"))
+    })
+    .await
+    .map_err(|e| format!("DNS resolution task failed: {e}"))??;
+
+    // Core validation logic - aligned with subscription.rs validate_public_host_addrs
+    let mut resolved_addr = None;
+
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            // Public domain resolving to a private IP = SSRF, always block.
+            return Err("Access to private/local resolved addresses is not allowed".to_owned());
+        }
+        if resolved_addr.is_none() {
+            resolved_addr = Some(*addr);
+        }
+    }
+
+    resolved_addr.ok_or_else(|| "Could not resolve any IP address for the host".to_owned())
+}
+
+/// Try proxy download without DNS pinning.
+///
+/// SSRF protection for proxy path:
+/// - Initial URL host validated (private host check)
+/// - Redirect policy blocks redirects to private hosts/IPs
+/// - Proxy-side SSRF is NOT preventable client-side — inherent to proxy architecture
+async fn try_proxy_download(url: &str, proxy_port: u16) -> Result<String, String> {
+    let proxy_url = format!("http://127.0.0.1:{proxy_port}");
+
+    // No DNS pinning for proxy - let proxy handle DNS resolution
+    let config = HttpClientConfig {
+        proxy_url: Some(proxy_url),
+        resolve_pin: None,
         ..Default::default()
     };
     let client = build_http_client(config)?;
@@ -422,9 +461,36 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_url_rejects_invalid_schemes() {
-        assert!(validate_url("ftp://example.com/file").is_err());
-        assert!(validate_url("file:///etc/passwd").is_err());
-        assert!(validate_url("javascript:alert(1)").is_err());
+    fn test_validate_url_basic_rejects_invalid_schemes() {
+        assert!(validate_url_basic("ftp://example.com/file").is_err());
+        assert!(validate_url_basic("file:///etc/passwd").is_err());
+        assert!(validate_url_basic("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_basic_extracts_port() {
+        match validate_url_basic("http://example.com") {
+            Ok((host, port, _)) => {
+                assert_eq!(host, "example.com");
+                assert_eq!(port, 80);
+            }
+            Err(_) => unreachable!("http://example.com should be valid"),
+        }
+
+        match validate_url_basic("https://example.com") {
+            Ok((host, port, _)) => {
+                assert_eq!(host, "example.com");
+                assert_eq!(port, 443);
+            }
+            Err(_) => unreachable!("https://example.com should be valid"),
+        }
+
+        match validate_url_basic("http://example.com:8080") {
+            Ok((host, port, _)) => {
+                assert_eq!(host, "example.com");
+                assert_eq!(port, 8080);
+            }
+            Err(_) => unreachable!("http://example.com:8080 should be valid"),
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/prism.rs
+++ b/apps/desktop/src-tauri/src/prism.rs
@@ -18,6 +18,7 @@ use clash_prism_script::limits::ScriptLimits;
 use clash_prism_script::{KvStore, SandboxConfig};
 use clash_prism_smart::SmartConfig;
 
+use crate::backend_event::{codes, lock_critical, BackendModule};
 use crate::core_manager::ensure_app_storage;
 
 // ---------------------------------------------------------------------------
@@ -177,7 +178,7 @@ impl PrismState {
     where
         F: FnOnce(&PrismExtension<host::ZephyrPrismHost>) -> Result<R, String>,
     {
-        let lock = self.inner.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let lock = lock_critical(&self.inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)?;
         let ext = lock
             .extension
             .as_ref()
@@ -215,7 +216,7 @@ impl PrismState {
 
     /// Acquire the inner mutex guard.
     pub(crate) fn lock_inner(&self) -> Result<std::sync::MutexGuard<'_, PrismInner>, String> {
-        self.inner.lock().map_err(|e| format!("Lock failed: {e}"))
+        lock_critical(&self.inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)
     }
 
     /// Check rate limit for a command. Returns `Ok(())` if allowed,

--- a/apps/desktop/src-tauri/src/prism/commands_core.rs
+++ b/apps/desktop/src-tauri/src/prism/commands_core.rs
@@ -7,6 +7,7 @@ use tauri::State;
 use clash_prism_extension::{ApplyOptions, PrismExtension, RuleInsertPosition};
 
 use super::types::MAX_INPUT_SIZE;
+use crate::backend_event::{codes, lock_best_effort, lock_critical, BackendModule};
 use crate::core_manager::core::core_process;
 use crate::prism::PrismState;
 
@@ -47,7 +48,7 @@ pub async fn prism_apply(
     // This allows other invoke() calls (e.g. proxy toggle, settings) to proceed
     // while Prism compiles large rule sets.
     tokio::task::spawn_blocking(move || {
-        let mut lock = inner.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let mut lock = lock_critical(&inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)?;
         let ext = lock
             .extension
             .as_ref()
@@ -245,7 +246,7 @@ pub async fn prism_rebuild(
     // (AppHandle::state() is not available inside spawn_blocking closures)
     let (raw_profile, current_secret, global_prefs) = {
         let mihomo = tauri::Manager::state::<crate::core_manager::MihomoState>(&app);
-        let lock = mihomo.0.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let lock = lock_critical(&mihomo.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
         let config_path = lock
             .last_config_path()
             .ok_or_else(|| "No active profile".to_owned())?
@@ -260,10 +261,7 @@ pub async fn prism_rebuild(
 
         // Read global preferences for injection
         let settings_state = tauri::Manager::state::<crate::SettingsState>(&app);
-        let settings_lock = settings_state
-            .0
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let settings_lock = lock_best_effort(&settings_state.0);
         let prefs = settings_lock.to_global_prefs();
         drop(settings_lock);
 
@@ -289,7 +287,7 @@ pub async fn prism_rebuild(
         }
 
         // Step 2: Apply all patches on the clean base
-        let lock = inner.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let lock = lock_critical(&inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)?;
         let ext = lock
             .extension
             .as_ref()

--- a/apps/desktop/src-tauri/src/prism/host.rs
+++ b/apps/desktop/src-tauri/src/prism/host.rs
@@ -4,6 +4,7 @@ use tauri::Manager as _;
 
 use clash_prism_extension::{ApplyStatus, CoreInfo, PrismEvent, PrismHost, ProfileInfo};
 
+use crate::backend_event::{codes, lock_best_effort, lock_critical, BackendModule};
 use crate::core_manager::core::config_sanitizer::validate_path_within_dir;
 use crate::core_manager::core::MAX_RESPONSE_SIZE;
 use crate::core_manager::{ensure_app_storage, write_file_secure, MihomoState};
@@ -112,7 +113,7 @@ impl PrismHost for ZephyrPrismHost {
         // Hot-reload via mihomo REST API (PUT for full config replacement)
         let (port, secret) = {
             let state = self.app.state::<MihomoState>();
-            let lock = state.0.lock().map_err(|e| format!("Lock failed: {e}"))?;
+            let lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
             (
                 lock.last_port().unwrap_or(9090),
                 lock.last_secret().to_owned(),
@@ -199,7 +200,7 @@ impl PrismHost for ZephyrPrismHost {
 
     fn get_core_info(&self) -> Result<CoreInfo, String> {
         let state = self.app.state::<MihomoState>();
-        let lock = state.0.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
         Ok(CoreInfo {
             version: String::from("unknown"), // async get_core_version unavailable in sync trait
             api_port: lock.last_port().unwrap_or(9090),
@@ -209,14 +210,8 @@ impl PrismHost for ZephyrPrismHost {
     }
 
     fn get_current_profile(&self) -> Option<String> {
-        let path = self
-            .app
-            .state::<MihomoState>()
-            .0
-            .lock()
-            .ok()?
-            .last_config_path()?
-            .to_owned();
+        let state = self.app.state::<MihomoState>();
+        let path = lock_best_effort(&state.0).last_config_path()?.to_owned();
         let stem = std::path::Path::new(&path)
             .file_stem()
             .and_then(|s| s.to_str())


### PR DESCRIPTION
- Add lock_critical() for critical paths (returns error + emits event)
- Add lock_best_effort() for non-critical paths (ignores poison)
- Add LOCK_FAILED error codes for all modules
- Replace inconsistent lock handling in prism.rs, host.rs, commands_core.rs, core_process.rs