### PR TITLE
feat: rename core binary to zephyr-mihomo to avoid conflicts with oth…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,13 @@ jobs:
           case "$MIHOMO_EXT" in
             zip)
               unzip -q "mihomo.zip"
-              mv mihomo-windows-amd64-compatible.exe apps/desktop/src-tauri/bundled/mihomo.exe
+              mv mihomo-windows-amd64-compatible.exe apps/desktop/src-tauri/bundled/zephyr-mihomo.exe
               rm mihomo.zip
               ;;
             gz)
               gunzip -f "mihomo.gz"
               chmod +x mihomo
-              mv mihomo apps/desktop/src-tauri/bundled/mihomo
+              mv mihomo apps/desktop/src-tauri/bundled/zephyr-mihomo
               ;;
           esac
           
@@ -240,7 +240,7 @@ jobs:
           else
             exit 1
           fi
-          gunzip -f mihomo.gz && chmod +x mihomo && mv mihomo apps/desktop/src-tauri/bundled/mihomo
+          gunzip -f mihomo.gz && chmod +x mihomo && mv mihomo apps/desktop/src-tauri/bundled/zephyr-mihomo
           # Geo data (same as script)
           for file in geoip.dat geosite.dat Country.mmdb; do
             curl -sL -o "apps/desktop/src-tauri/bundled/${file}" "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/${file}"

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -87,11 +87,11 @@ fn parse_version_output(stdout: &str) -> String {
 pub const fn core_binary_name() -> &'static str {
     #[cfg(target_os = "windows")]
     {
-        "mihomo.exe"
+        "zephyr-mihomo.exe"
     }
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
-        "mihomo"
+        "zephyr-mihomo"
     }
 }
 
@@ -183,27 +183,43 @@ async fn drain_connections_if_alive(port: u16, secret_val: &str) {
     );
 }
 
-/// Kill all mihomo processes gracefully (SIGTERM first, SIGKILL after timeout).
+/// Kill all zephyr-mihomo processes gracefully (SIGTERM first, SIGKILL after timeout).
+/// Also kills legacy 'mihomo' processes for backward compatibility with Lite version users.
 ///
 /// On Unix: sends SIGTERM, waits up to 2s for exit, then SIGKILL.
 /// On Windows: uses taskkill /F (no graceful option).
 pub fn kill_mihomo() {
+    let exe_name = core_binary_name();
+    #[cfg(target_os = "windows")]
+    let legacy_name = "mihomo.exe";
+    #[cfg(not(target_os = "windows"))]
+    let legacy_name = "mihomo";
+
     #[cfg(unix)]
     {
         // Step 1: SIGTERM — allow mihomo to close connections gracefully
+        // Kill both new and legacy binary names for backward compatibility
         let _ = std::process::Command::new("killall")
             .arg("-15") // SIGTERM
-            .arg("mihomo")
+            .arg(exe_name)
+            .output();
+        let _ = std::process::Command::new("killall")
+            .arg("-15")
+            .arg(legacy_name)
             .output();
 
         // Step 2: Wait up to 2s for graceful exit
         for _ in 0..20 {
             let output = std::process::Command::new("pgrep")
                 .arg("-x")
-                .arg("mihomo")
+                .arg(exe_name)
                 .output();
-            if let Ok(out) = output {
-                if out.stdout.is_empty() {
+            let legacy_output = std::process::Command::new("pgrep")
+                .arg("-x")
+                .arg(legacy_name)
+                .output();
+            if let (Ok(out), Ok(legacy_out)) = (output, legacy_output) {
+                if out.stdout.is_empty() && legacy_out.stdout.is_empty() {
                     return; // Process has exited gracefully
                 }
             }
@@ -214,7 +230,11 @@ pub fn kill_mihomo() {
         for _ in 0..3 {
             let _ = std::process::Command::new("killall")
                 .arg("-9")
-                .arg("mihomo")
+                .arg(exe_name)
+                .output();
+            let _ = std::process::Command::new("killall")
+                .arg("-9")
+                .arg(legacy_name)
                 .output();
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
@@ -222,8 +242,13 @@ pub fn kill_mihomo() {
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt as _;
+        // Kill both new and legacy binary names for backward compatibility
         let _ = std::process::Command::new("taskkill")
-            .args(["/F", "/IM", "mihomo.exe"])
+            .args(["/F", "/IM", exe_name])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output();
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/IM", legacy_name])
             .creation_flags(CREATE_NO_WINDOW)
             .output();
     }
@@ -834,13 +859,24 @@ fn select_runtime_config(
 
 pub fn get_core_exe_path(app: &AppHandle) -> Result<PathBuf, String> {
     let binary_name = core_binary_name();
-    let core_path = ensure_app_storage(app)?.core_dir.join(binary_name);
+    let core_dir = ensure_app_storage(app)?.core_dir;
+    let core_path = core_dir.join(binary_name);
     if core_path.exists() {
         return Ok(core_path);
     }
 
+    // Fallback: check for legacy binary name (mihomo.exe / mihomo) for backward compatibility
+    #[cfg(target_os = "windows")]
+    let legacy_name = "mihomo.exe";
+    #[cfg(not(target_os = "windows"))]
+    let legacy_name = "mihomo";
+    let legacy_path = core_dir.join(legacy_name);
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+
     Err(format!(
-        "Could not find {binary_name} in app data core directory"
+        "Could not find {binary_name} (or legacy {legacy_name}) in app data core directory"
     ))
 }
 
@@ -1332,9 +1368,9 @@ mod tests {
     fn test_core_binary_name() {
         let name = core_binary_name();
         #[cfg(target_os = "windows")]
-        assert_eq!(name, "mihomo.exe");
+        assert_eq!(name, "zephyr-mihomo.exe");
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(name, "mihomo");
+        assert_eq!(name, "zephyr-mihomo");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/core/tun_manager.rs
+++ b/apps/desktop/src-tauri/src/core/tun_manager.rs
@@ -4,7 +4,9 @@ use tauri::AppHandle;
 #[cfg(not(target_os = "macos"))]
 use super::core_process::resolve_app_paths;
 #[cfg(target_os = "macos")]
-use super::core_process::{ensure_executable, generate_secret, resolve_app_paths};
+use super::core_process::{
+    ensure_executable, generate_secret, get_core_exe_path, resolve_app_paths,
+};
 use super::secure_io::write_file_secure;
 use super::{TUN_MODE_ACTIVE, TUN_TOGGLING};
 
@@ -143,7 +145,7 @@ fn extract_tun_enabled_from_yaml(content: &str) -> bool {
 #[cfg(target_os = "macos")]
 pub async fn restart_core_as_root(app: &AppHandle, enable_tun: bool) -> Result<String, String> {
     let paths = resolve_app_paths(app)?;
-    let core_path = paths.core_dir.join("mihomo");
+    let core_path = get_core_exe_path(app)?;
     ensure_executable(&core_path)?;
 
     let config_dir_str = paths.core_dir.to_string_lossy();
@@ -218,8 +220,16 @@ pub async fn restart_core_as_root(app: &AppHandle, enable_tun: bool) -> Result<S
     let escaped_config_dir = config_dir_str.replace("'", "'\\''");
     let escaped_log_path = log_path.replace("'", "'\\''");
 
+    // Get binary name from resolved core_path to ensure backward compatibility
+    let binary_name = core_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "Invalid core binary name".to_string())?;
+    let escaped_binary_name = binary_name.replace("'", "'\\''");
+    // Kill both new (zephyr-mihomo) and legacy (mihomo) names to handle upgrade scenario
+    // where a root-owned legacy process might still be running
     let script = format!(
-        r#"do shell script "killall -9 mihomo 2>/dev/null; sysctl -w net.inet.tcp.msl=1000 2>/dev/null; sleep 0.3; cd '{escaped_config_dir}' && './mihomo' -d '.' -f 'run_config.yaml' > '{escaped_log_path}' 2>&1 &" with administrator privileges"#,
+        r#"do shell script "killall -9 zephyr-mihomo 2>/dev/null; killall -9 mihomo 2>/dev/null; sysctl -w net.inet.tcp.msl=1000 2>/dev/null; sleep 0.3; cd '{escaped_config_dir}' && './{escaped_binary_name}' -d '.' -f 'run_config.yaml' > '{escaped_log_path}' 2>&1 &" with administrator privileges"#,
     );
 
     // Spawn osascript without waiting for it to complete
@@ -464,6 +474,7 @@ mod tests {
 }
 
 /// Check if there's a root-owned mihomo process running
+/// Checks for both zephyr-mihomo (new) and mihomo (legacy) for backward compatibility
 #[cfg(target_os = "macos")]
 fn has_root_mihomo() -> bool {
     if let Ok(output) = std::process::Command::new("ps")
@@ -471,8 +482,11 @@ fn has_root_mihomo() -> bool {
         .output()
     {
         let text = String::from_utf8_lossy(&output.stdout);
-        text.lines()
-            .any(|line| line.trim_start().starts_with("root ") && line.contains("mihomo"))
+        text.lines().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("root ")
+                && (trimmed.contains("zephyr-mihomo") || trimmed.contains("mihomo"))
+        })
     } else {
         false
     }
@@ -490,7 +504,8 @@ const fn has_root_mihomo() -> bool {
 #[cfg(target_os = "macos")]
 pub fn kill_all_mihomo_as_root() -> Result<(), String> {
     // Reduce MSL to 1s so TIME_WAIT expires quickly (default 15s = 30s TIME_WAIT)
-    let script = r#"do shell script "killall -9 mihomo 2>/dev/null; sleep 0.3; sysctl -w net.inet.tcp.msl=1000; route delete 0.0.0.0/1 2>/dev/null; route delete 128.0.0.0/1 2>/dev/null; true" with administrator privileges"#;
+    // Kill both zephyr-mihomo (new) and mihomo (legacy) for backward compatibility
+    let script = r#"do shell script "killall -9 zephyr-mihomo 2>/dev/null; killall -9 mihomo 2>/dev/null; sleep 0.3; sysctl -w net.inet.tcp.msl=1000; route delete 0.0.0.0/1 2>/dev/null; route delete 128.0.0.0/1 2>/dev/null; true" with administrator privileges"#;
     let status = std::process::Command::new("osascript")
         .args(["-e", script])
         .status()


### PR DESCRIPTION
…er clients

Problem:
- Zephyr and other mihomo-based clients (e.g., Mihomo Party) use the same executable name 'mihomo.exe'/'mihomo'
- When Zephyr starts, it kills all 'mihomo' processes, interfering with other running clients
- Other clients may also kill Zephyr's core process
- This causes 'Core started but health check failed' errors

Solution:
- Rename core binary from 'mihomo' to 'zephyr-mihomo' (platform-specific)
  - Windows: zephyr-mihomo.exe
  - macOS/Linux: zephyr-mihomo
- Update all process management code to use dynamic binary name via core_binary_name() function
- Maintain backward compatibility: fallback to legacy 'mihomo' name if new name not found (for Lite version users)
- Update CI/CD pipeline to rename binary after download

Files changed:
- .github/workflows/release.yml: rename binary in build pipeline
- core/core_process.rs: new binary name, dynamic kill commands, backward compatibility fallback, test updates
- core/tun_manager.rs: macOS TUN mode uses dynamic binary name
- ui/proxies.js: transport protocol indicator feature (separate)

Testing:
- Verified all hardcoded 'mihomo' references replaced with dynamic name
- macOS TUN mode process detection and kill commands updated
- Backward compatibility ensures Lite version continues to work