### PR TITLE
feat: enable WebKitGTK GPU compositing and optimize scroll performance on Linux

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -530,6 +530,19 @@ fn set_ui_scale(app: tauri::AppHandle, scale: f64) -> Result<f64, String> {
 // This is a false positive — cargo build/clippy sets OUT_DIR correctly and compiles fine.
 #[allow(rust_analyzer::proc_macro_unresolved)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+
+        if std::env::var("WAYLAND_DISPLAY").is_ok()
+            || std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland") == Ok(true)
+        {
+            if std::env::var("GDK_BACKEND").is_err() {
+                std::env::set_var("GDK_BACKEND", "wayland,x11");
+            }
+        }
+    }
+
     // Setup panic hook to cleanup child processes
     let default_panic = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -27,6 +27,10 @@ html:not(.dark) * {
   scrollbar-color: rgba(0, 0, 0, 0.05) transparent;
 }
 
+.custom-scrollbar {
+    will-change: scroll-position;
+}
+
 :root {
   --ui-scale: 1;
 }


### PR DESCRIPTION
## Summary

Force-enable WebKitGTK hardware-accelerated compositing mode on Linux to improve rendering performance, and optimize scroll containers for smoother scrolling.

## Changes

### Rust backend (lib.rs)
- Set `WEBKIT_FORCE_COMPOSITING_MODE=1` on Linux to force GPU compositing in WebKitGTK (documented in [WebKit Environment Variables](https://trac.webkit.org/wiki/EnvironmentVariables), available since WebKitGTK 2.10.5)
- Prefer native Wayland backend (`GDK_BACKEND=wayland,x11`) when running under a Wayland session, with X11 fallback to avoid startup failures on X11-only systems
- Only set `GDK_BACKEND` if not already configured by the user
- All changes are gated behind `#[cfg(target_os = "linux")]` — zero impact on Windows/macOS

### CSS (styles.css)
- Add `will-change: scroll-position` to `.custom-scrollbar` class to hint the rendering engine to optimize scroll composition layers

## Not included (and why)
- ~~`WEBKIT_DISABLE_COMPOSITING_MODE=0`~~ — This variable's value `0` does NOT mean "enable compositing"; the correct way to force compositing is `WEBKIT_FORCE_COMPOSITING_MODE=1`
- ~~`transform: translateZ(0)`~~ — Modern WebKitGTK (2.40+) already creates compositing layers automatically; this hack is unnecessary and wastes GPU memory
- ~~`-webkit-overflow-scrolling: touch`~~ — iOS-only property, has no effect on Linux
- ~~`WEBKIT_DISABLE_DMABUF_RENDERER`~~ — This is a fallback/disabling mechanism, not an optimization

## Testing
- ✅ `pnpm test`: 17 test files, 356 tests passed
- ✅ `cargo check`: compiles without errors
- ✅ Linux-only code paths verified with `#[cfg(target_os = "linux")]`