### PR TITLE
feat: enable WebKitGTK GPU compositing and Wayland support on Linux

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -530,6 +530,18 @@ fn set_ui_scale(app: tauri::AppHandle, scale: f64) -> Result<f64, String> {
 // This is a false positive — cargo build/clippy sets OUT_DIR correctly and compiles fine.
 #[allow(rust_analyzer::proc_macro_unresolved)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+
+        if (std::env::var("WAYLAND_DISPLAY").is_ok()
+            || std::env::var("XDG_SESSION_TYPE").as_deref() == Ok("wayland"))
+            && std::env::var("GDK_BACKEND").is_err()
+        {
+            std::env::set_var("GDK_BACKEND", "wayland,x11");
+        }
+    }
+
     // Setup panic hook to cleanup child processes
     let default_panic = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -27,6 +27,10 @@ html:not(.dark) * {
   scrollbar-color: rgba(0, 0, 0, 0.05) transparent;
 }
 
+.custom-scrollbar {
+    will-change: scroll-position;
+}
+
 :root {
   --ui-scale: 1;
 }


### PR DESCRIPTION
- Set WEBKIT_FORCE_COMPOSITING_MODE=1 to force GPU-accelerated rendering
- Prefer Wayland backend with X11 fallback when running under Wayland session
- Add will-change: scroll-position to .custom-scrollbar for smoother scrolling