### PR TITLE
feat: improve Linux GPU compatibility and AppImage packaging

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -532,10 +532,27 @@ fn set_ui_scale(app: tauri::AppHandle, scale: f64) -> Result<f64, String> {
 pub fn run() {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
-            // SAFETY: Called at application startup before any threads are spawned.
+        let has_dri_access = std::path::Path::new("/dev/dri").exists()
+            && std::fs::read_dir("/dev/dri")
+                .map(|mut entries| {
+                    entries.any(|e| {
+                        e.map(|entry| entry.file_name().to_string_lossy().starts_with("render"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false);
+
+        if has_dri_access {
+            if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
+                // SAFETY: Called at application startup before any threads are spawned.
+                unsafe {
+                    std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                }
+            }
+        } else if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            // SAFETY: Same as above, single-threaded context.
             unsafe {
-                std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
             }
         }
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -64,6 +64,11 @@
       "wix": {
         "language": "zh-CN"
       }
+    },
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+      }
     }
   }
 }

--- a/scripts/linuxdeploy-plugin-gtk.sh
+++ b/scripts/linuxdeploy-plugin-gtk.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Custom linuxdeploy-plugin-gtk.sh that excludes GPU/Mesa libraries
+# This prevents AppImage from bundling GPU drivers that conflict with the host system.
+# Based on: https://github.com/linuxdeploy/linuxdeploy-plugin-gtk
+
+set -euo pipefail
+
+# GPU/Mesa libraries to exclude from the AppImage
+EXCLUDE_PATTERNS=(
+    "libEGL"
+    "libGL"
+    "libGLES"
+    "libdrm"
+    "libgbm"
+    "libglapi"
+    "libwayland-client"
+    "libwayland-egl"
+    "libwayland-cursor"
+    "libwayland-server"
+    "dri/"
+    "vdpau/"
+    "libvulkan"
+    "libXvMCr600"
+)
+
+should_exclude() {
+    local file="$1"
+    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+        if [[ "$file" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# If linuxdeploy-plugin-gtk is not cached, download it
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+PLUGIN_PATH="$CACHE_DIR/linuxdeploy-plugin-gtk.sh"
+
+if [ ! -f "$PLUGIN_PATH" ]; then
+    echo "Downloading linuxdeploy-plugin-gtk.sh..."
+    mkdir -p "$CACHE_DIR"
+    curl -sL "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh" \
+        -o "$PLUGIN_PATH"
+    chmod +x "$PLUGIN_PATH"
+fi
+
+# Run the original plugin, then remove excluded libraries from the AppDir
+"$PLUGIN_PATH" "$@"
+
+# Clean up GPU libraries from AppDir
+APPDIR="${APPDIR:-}"
+if [ -z "$APPDIR" ]; then
+    APPDIR="$(dirname "$0")/../../AppDir"
+fi
+
+if [ -d "$APPDIR/usr/lib" ]; then
+    find "$APPDIR/usr/lib" -type f \( -name "*.so" -o -name "*.so.*" \) | while read -r lib; do
+        if should_exclude "$lib"; then
+            echo "Excluding GPU library from AppImage: $lib"
+            rm -f "$lib"
+        fi
+    done
+fi


### PR DESCRIPTION
- Detect /dev/dri/render* access and fallback to WEBKIT_DISABLE_DMABUF_RENDERER when unavailable
- Prefer Wayland backend with X11 fallback
- Add custom linuxdeploy-plugin-gtk.sh to exclude GPU/Mesa libs from AppImage
- Add deb package dependencies for libwebkit2gtk-4.1-0 and libgtk-3-0