### PR TITLE
feat: improve Linux GPU compatibility and AppImage packaging

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -532,10 +532,32 @@ fn set_ui_scale(app: tauri::AppHandle, scale: f64) -> Result<f64, String> {
 pub fn run() {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
-            // SAFETY: Called at application startup before any threads are spawned.
+        let has_dri_access = std::fs::read_dir("/dev/dri")
+            .map(|mut entries| {
+                entries.any(|e| {
+                    e.map(|entry| {
+                        let path = entry.path();
+                        path.file_name()
+                            .map(|n| n.to_string_lossy().starts_with("render"))
+                            .unwrap_or(false)
+                            && std::fs::File::open(&path).map(|_| true).unwrap_or(false)
+                    })
+                    .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+        if has_dri_access {
+            if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
+                // SAFETY: Called at application startup before any threads are spawned.
+                unsafe {
+                    std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                }
+            }
+        } else if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            // SAFETY: Same as above, single-threaded context.
             unsafe {
-                std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
             }
         }
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,6 +6,7 @@
   "build": {
     "beforeDevCommand": "pnpm run dev:css",
     "beforeBuildCommand": "pnpm run build:css",
+    "beforeBundleCommand": "cp ../../scripts/linuxdeploy-plugin-gtk.sh ${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-gtk.sh",
     "frontendDist": "../src"
   },
   "app": {
@@ -63,6 +64,11 @@
       },
       "wix": {
         "language": "zh-CN"
+      }
+    },
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
       }
     }
   }

--- a/scripts/linuxdeploy-plugin-gtk.sh
+++ b/scripts/linuxdeploy-plugin-gtk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Custom linuxdeploy-plugin-gtk.sh that excludes GPU/Mesa libraries
+# This prevents AppImage from bundling GPU drivers that conflict with the host system.
+# Based on: https://github.com/linuxdeploy/linuxdeploy-plugin-gtk
+
+set -euo pipefail
+
+EXCLUDE_PATTERNS=(
+    "libEGL"
+    "libGL"
+    "libGLES"
+    "libdrm"
+    "libgbm"
+    "libglapi"
+    "libwayland-client"
+    "libwayland-egl"
+    "libwayland-cursor"
+    "libwayland-server"
+    "dri/"
+    "vdpau/"
+    "libvulkan"
+    "libXvMCr600"
+)
+
+should_exclude() {
+    local file="$1"
+    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+        if [[ "$file" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+PLUGIN_PATH="$CACHE_DIR/linuxdeploy-plugin-gtk.sh"
+
+if [ ! -f "$PLUGIN_PATH" ]; then
+    echo "Downloading linuxdeploy-plugin-gtk.sh..."
+    mkdir -p "$CACHE_DIR"
+    curl -sfL "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/3b67a1d1c1b0c8268f57f2bce40fe2d33d409cea/linuxdeploy-plugin-gtk.sh" \
+        -o "$PLUGIN_PATH"
+    chmod +x "$PLUGIN_PATH"
+fi
+
+"$PLUGIN_PATH" "$@"
+
+if [ -z "${APPDIR:-}" ]; then
+    echo "Error: APPDIR environment variable is not set." >&2
+    exit 1
+fi
+
+if [ -d "$APPDIR/usr/lib" ]; then
+    find "$APPDIR/usr/lib" \( -type f -o -type l \) \( -name "*.so" -o -name "*.so.*" \) -print0 | while IFS= read -r -d '' lib; do
+        if should_exclude "$lib"; then
+            echo "Excluding GPU library from AppImage: $lib"
+            rm -f "$lib"
+        fi
+    done
+fi


### PR DESCRIPTION
- Detect /dev/dri/render* accessibility (verify read permission) and fallback to WEBKIT_DISABLE_DMABUF_RENDERER
- Prefer Wayland backend with X11 fallback
- Add custom linuxdeploy-plugin-gtk.sh to exclude GPU/Mesa libs from AppImage
- Wire linuxdeploy script into beforeBundleCommand
- Add deb package dependencies for libwebkit2gtk-4.1-0 and libgtk-3-0