### PR TITLE
feat: improve Linux GPU compatibility and AppImage packaging

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -532,10 +532,33 @@ fn set_ui_scale(app: tauri::AppHandle, scale: f64) -> Result<f64, String> {
 pub fn run() {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
-            // SAFETY: Called at application startup before any threads are spawned.
+        let has_dri_access = std::fs::read_dir("/dev/dri")
+            .map(|entries| {
+                entries.flatten().any(|entry| {
+                    let path = entry.path();
+                    path.file_name()
+                        .and_then(|n| n.to_str().map(|s| s.starts_with("render")))
+                        .unwrap_or(false)
+                        && std::fs::OpenOptions::new()
+                            .read(true)
+                            .write(true)
+                            .open(&path)
+                            .is_ok()
+                })
+            })
+            .unwrap_or(false);
+
+        if has_dri_access {
+            if std::env::var("WEBKIT_FORCE_COMPOSITING_MODE").is_err() {
+                // SAFETY: Called at application startup before any threads are spawned.
+                unsafe {
+                    std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                }
+            }
+        } else if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            // SAFETY: Same as above, single-threaded context.
             unsafe {
-                std::env::set_var("WEBKIT_FORCE_COMPOSITING_MODE", "1");
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
             }
         }
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -64,6 +64,11 @@
       "wix": {
         "language": "zh-CN"
       }
+    },
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0", "libayatana-appindicator3-1"]
+      }
     }
   }
 }

--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -1,4 +1,7 @@
 {
+  "build": {
+    "beforeBundleCommand": "mkdir -p \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri\" && cp ../../../scripts/linuxdeploy-plugin-gtk.sh \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-gtk.sh\" && chmod +x \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-gtk.sh\""
+  },
   "app": {
     "windows": [
       {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "overrides": {
       "brace-expansion": ">=5.0.6",
       "ws": ">=8.20.1"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild"
+    ]
   }
 }

--- a/scripts/linuxdeploy-plugin-gtk.sh
+++ b/scripts/linuxdeploy-plugin-gtk.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Post-processing script for linuxdeploy-plugin-gtk
+# This script is copied to the Tauri cache as linuxdeploy-plugin-gtk.sh
+# and runs AFTER the original plugin (saved as linuxdeploy-plugin-gtk-upstream.sh).
+# It excludes GPU/Mesa libraries from the AppImage to prevent driver conflicts.
+
+set -euo pipefail
+
+ORIGINAL_ARGS=("$@")
+APPDIR=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --plugin-api-version)
+            CACHE_DIR="${XDG_CACHE_HOME:-${HOME:-}/.cache}/tauri"
+            UPSTREAM_PLUGIN="$CACHE_DIR/linuxdeploy-plugin-gtk-upstream.sh"
+            if [ -f "$UPSTREAM_PLUGIN" ]; then
+                exec "$UPSTREAM_PLUGIN" --plugin-api-version
+            fi
+            echo "0"
+            exit 0
+            ;;
+        --appdir=*)
+            APPDIR="${1#*=}"
+            shift
+            ;;
+        --appdir)
+            if [ $# -lt 2 ]; then
+                echo "Error: --appdir requires a value" >&2
+                exit 1
+            fi
+            APPDIR="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$APPDIR" ]; then
+    echo "Error: --appdir not provided" >&2
+    exit 1
+fi
+
+CACHE_DIR="${XDG_CACHE_HOME:-${HOME:-}/.cache}/tauri"
+UPSTREAM_PLUGIN="$CACHE_DIR/linuxdeploy-plugin-gtk-upstream.sh"
+TMPFILE=""
+
+cleanup() {
+    if [ -n "$TMPFILE" ] && [ -f "$TMPFILE" ]; then
+        rm -f "$TMPFILE"
+    fi
+}
+trap cleanup EXIT
+
+if [ ! -f "$UPSTREAM_PLUGIN" ]; then
+    echo "Downloading linuxdeploy-plugin-gtk-upstream.sh..."
+    mkdir -p "$CACHE_DIR"
+    TMPFILE="$(mktemp "$CACHE_DIR/.upstream.XXXXXX")"
+    if ! curl -sfL --retry 3 --retry-delay 2 "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/3b67a1d1c1b0c8268f57f2bce40fe2d33d409cea/linuxdeploy-plugin-gtk.sh" \
+        -o "$TMPFILE"; then
+        echo "Error: Failed to download upstream linuxdeploy-plugin-gtk.sh" >&2
+        exit 1
+    fi
+    mv "$TMPFILE" "$UPSTREAM_PLUGIN"
+    chmod +x "$UPSTREAM_PLUGIN"
+    TMPFILE=""
+fi
+
+"$UPSTREAM_PLUGIN" "${ORIGINAL_ARGS[@]}"
+
+HOOKFILE="$APPDIR/apprun-hooks/linuxdeploy-plugin-gtk.sh"
+if [ -f "$HOOKFILE" ]; then
+    sed -i '/^export GDK_BACKEND=x11[[:space:]]*$/d' "$HOOKFILE"
+fi
+
+EXCLUDE_PREFIXES=(
+    "libEGL"
+    "libGL"
+    "libGLES"
+    "libdrm"
+    "libgbm"
+    "libglapi"
+    "libwayland-client"
+    "libwayland-egl"
+    "libwayland-cursor"
+    "libwayland-server"
+    "libvulkan"
+    "libXvMCr600"
+)
+
+should_exclude() {
+    local base="${1##*/}"
+    for prefix in "${EXCLUDE_PREFIXES[@]}"; do
+        if [[ "$base" == "$prefix"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [ -d "$APPDIR/usr/lib" ]; then
+    while IFS= read -r -d '' lib; do
+        if should_exclude "$lib"; then
+            echo "Excluding GPU library from AppImage: $lib"
+            rm -f "$lib"
+        fi
+    done < <(find "$APPDIR/usr/lib" \( -type f -o -type l \) \( -name "*.so" -o -name "*.so.*" \) -not -path "*/dri/*" -not -path "*/vdpau/*" -print0)
+fi


### PR DESCRIPTION
## Changes
- Add DRI render node read/write permission detection with WEBKIT_DISABLE_DMABUF_RENDERER=1 fallback
- Add GDK_BACKEND=wayland,x11 fallback for Wayland sessions
- Add linuxdeploy-plugin-gtk.sh to exclude GPU/Mesa libraries from AppImage (parse --appdir from CLI, handle --plugin-api-version, remove upstream GDK_BACKEND=x11 hook)
- Move beforeBundleCommand to tauri.linux.conf.json (Linux-only) with mkdir -p and chmod +x
- Add deb package dependencies (libwebkit2gtk-4.1-0, libgtk-3-0, libayatana-appindicator3-1)