### PR TITLE
fix: enable custom titlebar on Linux to match other platforms

### DIFF
--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -6,8 +6,8 @@
     "windows": [
       {
         "label": "main",
-        "decorations": true,
-        "transparent": false
+        "decorations": false,
+        "transparent": true
       }
     ]
   }


### PR DESCRIPTION
## Summary

On Linux, the window was using the system native titlebar (`decorations: true`) and non-transparent background (`transparent: false`), while Windows and macOS use the custom titlebar with `decorations: false` and `transparent: true`.

This caused an inconsistent UI experience on Linux:
- System titlebar was visible instead of the custom Zephyr titlebar
- Rounded corners showed a semi-transparent rectangular mask behind them (due to non-transparent window background)

## Changes

- Set `decorations: false` in `tauri.linux.conf.json` to use the custom titlebar
- Set `transparent: true` in `tauri.linux.conf.json` to allow rounded corners to render correctly

Now all platforms (Windows, macOS, Linux) have a consistent UI with the custom titlebar and proper rounded corners.