### PR TITLE
fix: enable custom titlebar on Linux to match other platforms

### DIFF
--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -1,14 +1,5 @@
 {
   "build": {
     "beforeBundleCommand": "mkdir -p \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri\" && cp ../../../scripts/linuxdeploy-plugin-gtk.sh \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-gtk.sh\" && chmod +x \"${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-gtk.sh\""
-  },
-  "app": {
-    "windows": [
-      {
-        "label": "main",
-        "decorations": true,
-        "transparent": false
-      }
-    ]
   }
 }


### PR DESCRIPTION
## Summary

On Linux, the window was using the system native titlebar (`decorations: true`) and non-transparent background (`transparent: false`), while Windows and macOS use the custom titlebar with `decorations: false` and `transparent: true`.

This caused an inconsistent UI experience on Linux:
- System titlebar was visible instead of the custom Zephyr titlebar
- Rounded corners showed a semi-transparent rectangular mask behind them (due to non-transparent window background)

## Changes

- Removed the `app.windows` override from `tauri.linux.conf.json` since the main `tauri.conf.json` already has `decorations: false` and `transparent: true`, which now work correctly on Linux with modern WebKitGTK

Now all platforms (Windows, macOS, Linux) have a consistent UI with the custom titlebar and proper rounded corners.