### PR TITLE
feat: display actual node name in home page capsule

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -99,7 +99,7 @@
                     <div id="node-wheel-container" class="absolute top-0 left-0 right-0 flex justify-center z-[var(--z-sticky)] perspective-1000 h-8 mt-2">
                         <div id="node-wheel-trigger" class="absolute top-0 px-4 py-1.5 rounded-full bg-white/5 border border-white/10 flex items-center gap-2 backdrop-blur-md cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:bg-white/10 hover:shadow-[0_4px_20px_rgba(0,0,0,0.2)] z-20">
                             <div class="w-2 h-2 rounded-full bg-accent animate-pulse shadow-[0_0_8px_var(--color-accent-glow)]"></div>
-                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[180px]">Loading...</span>
+                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[280px]">Loading...</span>
                         </div>
                         
                         <!-- Wheel Dropdown -->

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -8,7 +8,7 @@ import { getProxies, switchProxy, abortLatencyTests, closeAllConnections } from 
 import { nodeWheelLogger } from '../utils/logger.js';
 import { translations, currentLang } from '../i18n.js';
 import { fetchProxyGroups } from './proxy-groups.js';
-import { sortProxiesByLatency } from './proxies.js';
+import { sortProxiesByLatency, syncCoreConfig, renderProxies } from './proxies.js';
 import { appStore } from './state.js';
 import { invalidateProxiesCache, getSettingsCached } from './cache.js';
 import { saveProxySelection } from './proxy-memory.js';
@@ -88,19 +88,23 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
             nodeWheelLogger.warn('Failed to save proxy selection', e);
         }
 
-        const updatedNode = await waitForCurrentNode(targetGroup, name);
-        import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) currentNodeEl.textContent = updatedNode || name;
-        const proxiesPage = document.querySelector('[data-page="proxies"]');
-        if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {
-            import('./proxies.js').then(m => m.renderProxies());
-        }
+        // Wait for node switch to complete, then let syncCoreConfig() handle display
+        // Run as non-blocking IIFE to prevent UI lag
+        (async () => {
+            try {
+                await waitForCurrentNode(targetGroup, name);
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                await syncCoreConfig();
+                const proxiesPage = document.querySelector('[data-page="proxies"]');
+                if (proxiesPage && !proxiesPage.classList.contains('hidden')) {
+                    await renderProxies();
+                }
+            } catch (error) {
+                nodeWheelLogger.error('Failed to update UI after node switch:', error);
+            }
+        })();
     } else {
-        import('./proxies.js').then(m => m.syncCoreConfig());
-        const revertedNode = await waitForCurrentNode(targetGroup, null);
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl && revertedNode) currentNodeEl.textContent = revertedNode;
+        syncCoreConfig().catch(() => {});
     }
 }
 

--- a/apps/desktop/src/ui/observed-group.js
+++ b/apps/desktop/src/ui/observed-group.js
@@ -10,7 +10,8 @@
  * @module ui/observed-group
  */
 
-import { getConnections, getProxies } from '../api.js';
+import { getConnections } from '../api.js';
+import { getProxiesCached } from './cache.js';
 import { isWritableGroupType } from './proxy-groups.js';
 import { appStore } from './state.js';
 import { observedGroupLogger } from '../utils/logger.js';
@@ -26,8 +27,8 @@ const MIN_FREQ = 3;
 const MIN_RATIO = 0.3;
 /** Number of consecutive consistent observations to confirm. */
 const CONSECUTIVE_K = 3;
-/** Polling interval in ms. */
-const POLL_INTERVAL = 5000;
+/** Polling interval in ms (optimized for responsiveness). */
+const POLL_INTERVAL = 2000;
 
 let _timer = null;
 let _polling = false;
@@ -214,7 +215,9 @@ async function _poll() {
 
 async function _getProxiesData() {
     try {
-        return await getProxies();
+        // Use cached proxy data to reduce API overhead
+        // Group structures and types are static, so caching is safe
+        return await getProxiesCached();
     } catch {
         return null;
     }

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -466,10 +466,25 @@ export async function syncCoreConfig() {
             if (currentUiGroup && proxyMap && !proxyMap[currentUiGroup]) {
                 appStore.set('uiGroupName', null);
             }
-        }
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) {
-            currentNodeEl.textContent = currentNode;
+
+            // Resolve to leaf node and display with suffix if needed
+            const leafNode = resolveLeafNode(currentNode, proxyMap);
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                // If leaf node differs from current display name, it means we're showing a group name
+                // Append the actual node name with a dash suffix
+                if (leafNode && leafNode !== currentNode) {
+                    currentNodeEl.textContent = `${currentNode} - ${leafNode}`;
+                } else {
+                    currentNodeEl.textContent = leafNode || currentNode;
+                }
+            }
+        } else {
+            // Fallback to Direct when no proxy groups available
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                currentNodeEl.textContent = 'Direct';
+            }
         }
     } catch (e) {
         proxyLogger.warn('Failed to sync current node display', e);
@@ -1634,9 +1649,38 @@ const _renderExplanationBarFromStore = debounce(async () => {
             renderGroupExplanationBar(uiGroupName, effectiveGroupName, observedGroupName, observedNodeName, data?.proxies);
         } catch { /* ignore */ }
     }
+    // Removed syncCoreConfig() from here - it's already called on proxy switch events and config updates
+    // Calling it here would trigger unnecessary API requests every 2s when observed node changes
 }, 50);
 appStore.subscribe('observedGroupName', _renderExplanationBarFromStore);
 appStore.subscribe('observedNodeName', _renderExplanationBarFromStore);
+
+// Update capsule display when observed node changes (avoid full syncCoreConfig API calls)
+appStore.subscribe('observedNodeName', () => {
+    try {
+        const observedNodeName = appStore.get('observedNodeName');
+        const observedGroupName = appStore.get('observedGroupName');
+        if (!observedNodeName || !observedGroupName) return;
+        
+        const currentNodeEl = document.getElementById('current-node-name');
+        if (!currentNodeEl) return;
+        
+        // Get current display text
+        const currentText = currentNodeEl.textContent || '';
+        
+        // Only update if the current display shows the observed group
+        // This prevents showing "WrongGroup - ObservedNode" when groups don't match
+        const lastDashIndex = currentText.lastIndexOf(' - ');
+        if (lastDashIndex !== -1) {
+            const currentGroupName = currentText.substring(0, lastDashIndex);
+            // Only update if showing the observed group or a related auto-select group
+            if (currentGroupName === observedGroupName || currentGroupName.includes('自动') || currentGroupName.toLowerCase().includes('auto')) {
+                currentNodeEl.textContent = currentGroupName + ' - ' + observedNodeName;
+            }
+        }
+        // Otherwise, don't override - let syncCoreConfig handle it on next config update
+    } catch { /* ignore */ }
+});
 
 // ═══════════════════════════════════════════════════════════════════════
 //  Smart Auto-Test Scheduler

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -285,10 +285,8 @@ export async function initTrayEventListeners() {
                 }
 
                 await closeAllConnections();
-                import('./proxies.js').then(m => m.syncCoreConfig());
-
-                const currentNodeEl = document.getElementById('current-node-name');
-                if (currentNodeEl) currentNodeEl.textContent = proxy;
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
 
                 const proxiesPage = document.querySelector('[data-page="proxies"]');
                 if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {


### PR DESCRIPTION
## 功能说明

在主页顶部胶囊显示实际使用的节点名称，提升用户对代理路由的可见性。

## 改动内容

### 核心逻辑（proxies.js）
- 在 syncCoreConfig() 中使用 resolveLeafNode() 递归解析到叶子节点
- 当组名与实际节点名不同时，显示为 `组名 - 实际节点` 格式
- 移除 _renderExplanationBarFromStore 中冗余的 syncCoreConfig() 调用
- 订阅 observedNodeName 变化，使用 lastIndexOf 直接更新胶囊显示（避免频繁 API 请求）
- 验证 observedGroupName 匹配，避免错误的组-节点配对
- 添加 Direct fallback 处理代理组不可用的情况

### UI 调整
- index.html: 胶囊最大宽度从 180px 增加到 280px

### 统一更新入口
- node-wheel.js: 
  - 使用静态导入替代动态 import
  - 将 waitForCurrentNode 改为非阻塞 IIFE
- tray.js: 移除手动覆盖胶囊文本的代码

### 性能优化
- observed-group.js: 
  - 轮询间隔从 5s 优化到 2s
  - 使用 getProxiesCached() 替代 getProxies()
  - 移除轮询中的 syncCoreConfig() 调用

## 测试场景
- 选择自动选择组 → 显示：自动选择 - HK-Node1
- 直接选择节点 → 显示：US-Node2
- 负载均衡场景 → 实时显示实际出口节点