### PR TITLE
feat: display actual node name in home page capsule

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -99,7 +99,7 @@
                     <div id="node-wheel-container" class="absolute top-0 left-0 right-0 flex justify-center z-[var(--z-sticky)] perspective-1000 h-8 mt-2">
                         <div id="node-wheel-trigger" class="absolute top-0 px-4 py-1.5 rounded-full bg-white/5 border border-white/10 flex items-center gap-2 backdrop-blur-md cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:bg-white/10 hover:shadow-[0_4px_20px_rgba(0,0,0,0.2)] z-20">
                             <div class="w-2 h-2 rounded-full bg-accent animate-pulse shadow-[0_0_8px_var(--color-accent-glow)]"></div>
-                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[180px]">Loading...</span>
+                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[280px]">Loading...</span>
                         </div>
                         
                         <!-- Wheel Dropdown -->

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -8,7 +8,7 @@ import { getProxies, switchProxy, abortLatencyTests, closeAllConnections } from 
 import { nodeWheelLogger } from '../utils/logger.js';
 import { translations, currentLang } from '../i18n.js';
 import { fetchProxyGroups } from './proxy-groups.js';
-import { sortProxiesByLatency } from './proxies.js';
+import { sortProxiesByLatency, syncCoreConfig, renderProxies } from './proxies.js';
 import { appStore } from './state.js';
 import { invalidateProxiesCache, getSettingsCached } from './cache.js';
 import { saveProxySelection } from './proxy-memory.js';
@@ -88,19 +88,27 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
             nodeWheelLogger.warn('Failed to save proxy selection', e);
         }
 
-        const updatedNode = await waitForCurrentNode(targetGroup, name);
-        import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) currentNodeEl.textContent = updatedNode || name;
-        const proxiesPage = document.querySelector('[data-page="proxies"]');
-        if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {
-            import('./proxies.js').then(m => m.renderProxies());
-        }
+        // Wait for node switch to complete, then let syncCoreConfig() handle display
+        // Run as non-blocking IIFE to prevent UI lag
+        // Track latest switch target to prevent race conditions
+        handleWheelProxySwitch.latestTarget = name;
+        (async () => {
+            try {
+                await waitForCurrentNode(targetGroup, name);
+                if (handleWheelProxySwitch.latestTarget !== name) return;
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                await syncCoreConfig();
+                if (handleWheelProxySwitch.latestTarget !== name) return;
+                const proxiesPage = document.querySelector('[data-page="proxies"]');
+                if (proxiesPage && !proxiesPage.classList.contains('hidden')) {
+                    await renderProxies();
+                }
+            } catch (error) {
+                nodeWheelLogger.error('Failed to update UI after node switch:', error);
+            }
+        })();
     } else {
-        import('./proxies.js').then(m => m.syncCoreConfig());
-        const revertedNode = await waitForCurrentNode(targetGroup, null);
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl && revertedNode) currentNodeEl.textContent = revertedNode;
+        syncCoreConfig().catch(() => {});
     }
 }
 

--- a/apps/desktop/src/ui/observed-group.js
+++ b/apps/desktop/src/ui/observed-group.js
@@ -10,10 +10,12 @@
  * @module ui/observed-group
  */
 
-import { getConnections, getProxies } from '../api.js';
+import { getConnections } from '../api.js';
+import { getProxiesCached } from './cache.js';
 import { isWritableGroupType } from './proxy-groups.js';
 import { appStore } from './state.js';
 import { observedGroupLogger } from '../utils/logger.js';
+import { Bus, Events } from './events.js';
 
 /** Special groups to exclude from observed group detection (DIRECT, REJECT, etc.) */
 const SPECIAL_GROUPS = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE', '🎯 DIRECT']);
@@ -26,14 +28,20 @@ const MIN_FREQ = 3;
 const MIN_RATIO = 0.3;
 /** Number of consecutive consistent observations to confirm. */
 const CONSECUTIVE_K = 3;
-/** Polling interval in ms. */
-const POLL_INTERVAL = 5000;
+/** Polling interval in ms (optimized for responsiveness). */
+const POLL_INTERVAL = 2000;
 
 let _timer = null;
 let _polling = false;
 let _active = false;
 let _consecutiveCount = 0;
 let _lastCandidate = null;
+/** Module-level cache for static proxy group structures */
+let _staticProxiesCache = null;
+
+// Invalidate cache on config/core changes
+Bus.on(Events.CONFIG_UPDATED, () => { _staticProxiesCache = null; });
+Bus.on(Events.CORE_RESTARTED, () => { _staticProxiesCache = null; });
 
 /**
  * Compute the observed group and node from active connections.
@@ -213,8 +221,12 @@ async function _poll() {
 }
 
 async function _getProxiesData() {
+    if (_staticProxiesCache) return _staticProxiesCache;
     try {
-        return await getProxies();
+        // Cache proxy data at module level to avoid redundant API calls during 2s polling
+        // Proxy group structures are static and only change on config/core updates
+        _staticProxiesCache = await getProxiesCached();
+        return _staticProxiesCache;
     } catch {
         return null;
     }

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -466,10 +466,27 @@ export async function syncCoreConfig() {
             if (currentUiGroup && proxyMap && !proxyMap[currentUiGroup]) {
                 appStore.set('uiGroupName', null);
             }
-        }
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) {
-            currentNodeEl.textContent = currentNode;
+
+            // Resolve to leaf node and display with suffix if needed
+            const leafNode = resolveLeafNode(currentNode, proxyMap);
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                // Store the group name in data attribute for robust observed node updates
+                currentNodeEl.dataset.group = currentNode;
+                // If leaf node differs from current display name, it means we're showing a group name
+                // Append the actual node name with a dash suffix
+                if (leafNode && leafNode !== currentNode) {
+                    currentNodeEl.textContent = currentNode + ' - ' + leafNode;
+                } else {
+                    currentNodeEl.textContent = leafNode || currentNode;
+                }
+            }
+        } else {
+            // Fallback to Direct when no proxy groups available
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                currentNodeEl.textContent = 'Direct';
+            }
         }
     } catch (e) {
         proxyLogger.warn('Failed to sync current node display', e);
@@ -1634,9 +1651,46 @@ const _renderExplanationBarFromStore = debounce(async () => {
             renderGroupExplanationBar(uiGroupName, effectiveGroupName, observedGroupName, observedNodeName, data?.proxies);
         } catch { /* ignore */ }
     }
+    // Removed syncCoreConfig() from here - it's already called on proxy switch events and config updates
+    // Calling it here would trigger unnecessary API requests every 2s when observed node changes
 }, 50);
 appStore.subscribe('observedGroupName', _renderExplanationBarFromStore);
 appStore.subscribe('observedNodeName', _renderExplanationBarFromStore);
+
+// Update capsule display when observed node changes (avoid full syncCoreConfig API calls)
+appStore.subscribe('observedNodeName', () => {
+    const observedNodeName = appStore.get('observedNodeName');
+    const observedGroupName = appStore.get('observedGroupName');
+    if (!observedNodeName || !observedGroupName) return;
+    
+    const currentNodeEl = document.getElementById('current-node-name');
+    if (!currentNodeEl) return;
+    
+    const currentGroupName = currentNodeEl.dataset.group;
+    if (!currentGroupName) return;
+
+    // Check if observed node is in the current group (supports nested groups)
+    const isNodeInGroup = (node, group, proxyMap, visited = new Set()) => {
+        if (!group || !proxyMap || visited.has(group)) return false;
+        visited.add(group);
+        const entry = proxyMap[group];
+        if (!entry || !entry.all) return false;
+        if (entry.all.includes(node)) return true;
+        return entry.all.some(member => isNodeInGroup(node, member, proxyMap, visited));
+    };
+
+    getProxiesCached().then(data => {
+        const proxyMap = data?.proxies;
+        const isRelated = currentGroupName === observedGroupName || 
+            currentGroupName.includes('自动') || 
+            currentGroupName.toLowerCase().includes('auto') ||
+            (proxyMap && isNodeInGroup(observedNodeName, currentGroupName, proxyMap));
+
+        if (isRelated && currentNodeEl.textContent.startsWith(currentGroupName + ' - ')) {
+            currentNodeEl.textContent = currentGroupName + ' - ' + observedNodeName;
+        }
+    }).catch(() => {});
+});
 
 // ═══════════════════════════════════════════════════════════════════════
 //  Smart Auto-Test Scheduler

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -285,10 +285,8 @@ export async function initTrayEventListeners() {
                 }
 
                 await closeAllConnections();
-                import('./proxies.js').then(m => m.syncCoreConfig());
-
-                const currentNodeEl = document.getElementById('current-node-name');
-                if (currentNodeEl) currentNodeEl.textContent = proxy;
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
 
                 const proxiesPage = document.querySelector('[data-page="proxies"]');
                 if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {


### PR DESCRIPTION
## 功能说明

在主页顶部胶囊显示实际使用的节点名称，提升用户对代理路由的可见性。

## 改动内容

### 核心逻辑
- 使用 data-group 属性存储组名，避免解析文本错误
- 使用 isNodeInGroup 递归检查节点是否属于当前组（支持嵌套组）
- 支持 load-balance/fallback 等动态子组的 observed 更新

### 性能优化
- observed-group.js: 添加模块级缓存，避免每 2 秒请求 /proxies
- 移除冗余的 syncCoreConfig() 调用
- 轮询间隔从 5s 优化到 2s

### 代码质量
- 添加 race condition 保护，避免快速切换节点时 UI 错误
- 使用静态导入替代动态 import
- 非阻塞 IIFE 处理后台任务

## 测试场景
- 自动选择组 → 显示：自动选择 - HK-Node1
- 直接选择节点 → 显示：US-Node2
- 嵌套组/负载均衡 → 正确显示实际出口节点
- 节点名包含横杠 → 正确解析