### PR TITLE
feat: display actual node name in home page capsule

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -99,7 +99,7 @@
                     <div id="node-wheel-container" class="absolute top-0 left-0 right-0 flex justify-center z-[var(--z-sticky)] perspective-1000 h-8 mt-2">
                         <div id="node-wheel-trigger" class="absolute top-0 px-4 py-1.5 rounded-full bg-white/5 border border-white/10 flex items-center gap-2 backdrop-blur-md cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:bg-white/10 hover:shadow-[0_4px_20px_rgba(0,0,0,0.2)] z-20">
                             <div class="w-2 h-2 rounded-full bg-accent animate-pulse shadow-[0_0_8px_var(--color-accent-glow)]"></div>
-                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[180px]">Loading...</span>
+                            <span id="current-node-name" class="text-xs text-zinc-200 font-semibold tracking-wide truncate max-w-[280px]">Loading...</span>
                         </div>
                         
                         <!-- Wheel Dropdown -->

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -8,7 +8,7 @@ import { getProxies, switchProxy, abortLatencyTests, closeAllConnections } from 
 import { nodeWheelLogger } from '../utils/logger.js';
 import { translations, currentLang } from '../i18n.js';
 import { fetchProxyGroups } from './proxy-groups.js';
-import { sortProxiesByLatency } from './proxies.js';
+import { sortProxiesByLatency, syncCoreConfig, renderProxies } from './proxies.js';
 import { appStore } from './state.js';
 import { invalidateProxiesCache, getSettingsCached } from './cache.js';
 import { saveProxySelection } from './proxy-memory.js';
@@ -70,6 +70,13 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
     closeWheel();
     abortLatencyTests();
 
+    // Use session counter to prevent race conditions on rapid switches
+    // Increment BEFORE async operations to maintain click order
+    if (!handleWheelProxySwitch.sessionCounter) {
+        handleWheelProxySwitch.sessionCounter = 0;
+    }
+    const currentSession = ++handleWheelProxySwitch.sessionCounter;
+
     // Use uiGroupName from appStore for accurate group targeting
     const targetGroup = appStore.get('uiGroupName') || mainGroup;
     const success = await switchProxy(targetGroup, name);
@@ -88,19 +95,25 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
             nodeWheelLogger.warn('Failed to save proxy selection', e);
         }
 
-        const updatedNode = await waitForCurrentNode(targetGroup, name);
-        import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) currentNodeEl.textContent = updatedNode || name;
-        const proxiesPage = document.querySelector('[data-page="proxies"]');
-        if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {
-            import('./proxies.js').then(m => m.renderProxies());
-        }
+        // Wait for node switch to complete, then let syncCoreConfig() handle display
+        // Run as non-blocking IIFE to prevent UI lag
+        (async () => {
+            try {
+                await waitForCurrentNode(targetGroup, name);
+                if (handleWheelProxySwitch.sessionCounter !== currentSession) return;
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                await syncCoreConfig();
+                if (handleWheelProxySwitch.sessionCounter !== currentSession) return;
+                const proxiesPage = document.querySelector('[data-page="proxies"]');
+                if (proxiesPage && !proxiesPage.classList.contains('hidden')) {
+                    await renderProxies();
+                }
+            } catch (error) {
+                nodeWheelLogger.error('Failed to update UI after node switch:', error);
+            }
+        })();
     } else {
-        import('./proxies.js').then(m => m.syncCoreConfig());
-        const revertedNode = await waitForCurrentNode(targetGroup, null);
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl && revertedNode) currentNodeEl.textContent = revertedNode;
+        syncCoreConfig().catch(() => {});
     }
 }
 

--- a/apps/desktop/src/ui/observed-group.js
+++ b/apps/desktop/src/ui/observed-group.js
@@ -10,10 +10,12 @@
  * @module ui/observed-group
  */
 
-import { getConnections, getProxies } from '../api.js';
+import { getConnections } from '../api.js';
+import { getProxiesCached } from './cache.js';
 import { isWritableGroupType } from './proxy-groups.js';
 import { appStore } from './state.js';
 import { observedGroupLogger } from '../utils/logger.js';
+import { Bus, Events } from './events.js';
 
 /** Special groups to exclude from observed group detection (DIRECT, REJECT, etc.) */
 const SPECIAL_GROUPS = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE', '🎯 DIRECT']);
@@ -26,14 +28,20 @@ const MIN_FREQ = 3;
 const MIN_RATIO = 0.3;
 /** Number of consecutive consistent observations to confirm. */
 const CONSECUTIVE_K = 3;
-/** Polling interval in ms. */
-const POLL_INTERVAL = 5000;
+/** Polling interval in ms (optimized for responsiveness). */
+const POLL_INTERVAL = 2000;
 
 let _timer = null;
 let _polling = false;
 let _active = false;
 let _consecutiveCount = 0;
 let _lastCandidate = null;
+/** Module-level cache for static proxy group structures */
+let _staticProxiesCache = null;
+
+// Invalidate cache on config/core changes
+Bus.on(Events.CONFIG_UPDATED, () => { _staticProxiesCache = null; });
+Bus.on(Events.CORE_RESTARTED, () => { _staticProxiesCache = null; });
 
 /**
  * Compute the observed group and node from active connections.
@@ -213,8 +221,12 @@ async function _poll() {
 }
 
 async function _getProxiesData() {
+    if (_staticProxiesCache) return _staticProxiesCache;
     try {
-        return await getProxies();
+        // Cache proxy data at module level to avoid redundant API calls during 2s polling
+        // Proxy group structures are static and only change on config/core updates
+        _staticProxiesCache = await getProxiesCached();
+        return _staticProxiesCache;
     } catch {
         return null;
     }

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -466,10 +466,21 @@ export async function syncCoreConfig() {
             if (currentUiGroup && proxyMap && !proxyMap[currentUiGroup]) {
                 appStore.set('uiGroupName', null);
             }
-        }
-        const currentNodeEl = document.getElementById('current-node-name');
-        if (currentNodeEl) {
-            currentNodeEl.textContent = currentNode;
+
+            // Resolve to leaf node and display with suffix if needed
+            const leafNode = resolveLeafNode(currentNode, proxyMap);
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                // Store the group name in data attribute for robust observed node updates
+                currentNodeEl.dataset.group = currentNode;
+                currentNodeEl.textContent = formatNodeDisplayName(currentNode, leafNode);
+            }
+        } else {
+            // Fallback to Direct when no proxy groups available
+            const currentNodeEl = document.getElementById('current-node-name');
+            if (currentNodeEl) {
+                currentNodeEl.textContent = 'Direct';
+            }
         }
     } catch (e) {
         proxyLogger.warn('Failed to sync current node display', e);
@@ -1634,9 +1645,69 @@ const _renderExplanationBarFromStore = debounce(async () => {
             renderGroupExplanationBar(uiGroupName, effectiveGroupName, observedGroupName, observedNodeName, data?.proxies);
         } catch { /* ignore */ }
     }
+    // Removed syncCoreConfig() from here - it's already called on proxy switch events and config updates
+    // Calling it here would trigger unnecessary API requests every 2s when observed node changes
 }, 50);
 appStore.subscribe('observedGroupName', _renderExplanationBarFromStore);
 appStore.subscribe('observedNodeName', _renderExplanationBarFromStore);
+
+// Helper to format the display name with an optional suffix
+function formatNodeDisplayName(group, leaf) {
+    return (leaf && leaf !== group) ? `${group} - ${leaf}` : (leaf || group);
+}
+
+// Check if observed node is in the current group (supports nested groups)
+const isNodeInGroup = (node, group, proxyMap, visited = new Set()) => {
+    if (!group || !proxyMap || visited.has(group)) return false;
+    visited.add(group);
+    const entry = proxyMap[group];
+    if (!entry || !entry.all) return false;
+    if (entry.all.includes(node)) return true;
+    return entry.all.some(member => isNodeInGroup(node, member, proxyMap, visited));
+};
+
+// Update capsule display when observed node or group changes (avoid full syncCoreConfig API calls)
+const updateCapsuleDisplay = () => {
+    const currentNodeEl = document.getElementById('current-node-name');
+    if (!currentNodeEl) return;
+    
+    const currentGroupName = currentNodeEl.dataset.group;
+    if (!currentGroupName) return;
+
+    getProxiesCached().then(data => {
+        // Verify the group hasn't changed during the async API call to prevent race conditions
+        if (currentNodeEl.dataset.group !== currentGroupName) return;
+
+        const proxyMap = data?.proxies;
+        // Read latest values inside the callback to prevent stale closures
+        const observedNodeName = appStore.get('observedNodeName');
+        const observedGroupName = appStore.get('observedGroupName');
+        
+        // If no observed node or group, revert to default leaf node display
+        if (!observedNodeName || !observedGroupName) {
+            const leafNode = resolveLeafNode(currentGroupName, proxyMap);
+            currentNodeEl.textContent = formatNodeDisplayName(currentGroupName, leafNode);
+            return;
+        }
+
+        // Check if observed node is related to current group
+        // Only use exact group match or membership check
+        const isRelated = currentGroupName === observedGroupName ||
+            (proxyMap && isNodeInGroup(observedNodeName, currentGroupName, proxyMap));
+
+        if (isRelated) {
+            // Dynamically append observed node name when it differs from group name
+            currentNodeEl.textContent = formatNodeDisplayName(currentGroupName, observedNodeName);
+        } else {
+            // Revert to default leaf node display if not related
+            const leafNode = resolveLeafNode(currentGroupName, proxyMap);
+            currentNodeEl.textContent = formatNodeDisplayName(currentGroupName, leafNode);
+        }
+    }).catch(() => {});
+};
+
+appStore.subscribe('observedNodeName', updateCapsuleDisplay);
+appStore.subscribe('observedGroupName', updateCapsuleDisplay);
 
 // ═══════════════════════════════════════════════════════════════════════
 //  Smart Auto-Test Scheduler

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -285,10 +285,8 @@ export async function initTrayEventListeners() {
                 }
 
                 await closeAllConnections();
-                import('./proxies.js').then(m => m.syncCoreConfig());
-
-                const currentNodeEl = document.getElementById('current-node-name');
-                if (currentNodeEl) currentNodeEl.textContent = proxy;
+                // Let syncCoreConfig() handle the display update with leaf node resolution
+                import('./proxies.js').then(m => m.syncCoreConfig()).catch(() => {});
 
                 const proxiesPage = document.querySelector('[data-page="proxies"]');
                 if (proxiesPage && proxiesPage.classList.contains('hidden') === false) {


### PR DESCRIPTION
## 功能说明

在主页顶部胶囊显示实际使用的节点名称，提升用户对代理路由的可见性。

## 核心优化

### 动态显示逻辑
- formatNodeDisplayName 统一处理节点显示格式
- 当检测到 observedNodeName 时动态追加后缀
- 当 observedNodeName 为 null 或无关时恢复默认显示
- data-group 属性 + isNodeInGroup 递归检查

### Race Condition 保护
- node-wheel: session counter 在 switchProxy 之前递增，保证点击顺序
- capsule: 在 .then() 回调内部读取最新 observed 值，避免 stale closure
- 验证 group 未变化后再更新 DOM
- 订阅 observedGroupName 和 observedNodeName 两个事件

### 性能优化
- observed-group 模块级缓存
- 轮询间隔 5s → 2s
- 提取 isNodeInGroup 到模块级别

### 代码质量
- 静态导入 + 非阻塞 IIFE
- 完整的错误处理