### PR TITLE
fix: warn on appStore set/update with unregistered keys

### DIFF
--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -171,7 +171,7 @@ export function createStore(storeName, initialState, { persist = true, transient
             if (typeof keyOrPartial === 'object' && keyOrPartial !== null) {
                 // Batch update — '*' key, always notify
                 for (const k of Object.keys(keyOrPartial)) {
-                    if (Object.hasOwn(state, k)) {
+                    if (Object.prototype.hasOwnProperty.call(state, k)) {
                         state[k] = keyOrPartial[k];
                         scheduleNotify(k);
                     } else {
@@ -180,7 +180,7 @@ export function createStore(storeName, initialState, { persist = true, transient
                 }
             } else {
                 const key = keyOrPartial;
-                if (Object.hasOwn(state, key)) {
+                if (Object.prototype.hasOwnProperty.call(state, key)) {
                     // Skip notification when value is unchanged
                     if (!Object.is(state[key], value)) {
                         state[key] = value;
@@ -205,7 +205,7 @@ export function createStore(storeName, initialState, { persist = true, transient
          */
         update(key, updater) {
             if (frozen) return;
-            if (!Object.hasOwn(state, key)) {
+            if (!Object.prototype.hasOwnProperty.call(state, key)) {
                 storeLogger.warn(`update() ignored unknown key "${key}" — not in initial state`);
                 return;
             }

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -8,6 +8,9 @@
  */
 
 import { detectSystemLanguage } from '../i18n.js';
+import { createLogger } from '../utils/logger.js';
+
+const storeLogger = createLogger('Store', 'warn');
 
 function lsGet(key) {
     try {
@@ -171,6 +174,8 @@ export function createStore(storeName, initialState, { persist = true, transient
                     if (k in state) {
                         state[k] = keyOrPartial[k];
                         scheduleNotify(k);
+                    } else {
+                        storeLogger.warn(`set() ignored unknown key "${k}" — not in initial state`);
                     }
                 }
             } else {
@@ -181,6 +186,8 @@ export function createStore(storeName, initialState, { persist = true, transient
                         state[key] = value;
                         scheduleNotify(key);
                     }
+                } else {
+                    storeLogger.warn(`set() ignored unknown key "${key}" — not in initial state`);
                 }
             }
 
@@ -198,7 +205,10 @@ export function createStore(storeName, initialState, { persist = true, transient
          */
         update(key, updater) {
             if (frozen) return;
-            if (!(key in state)) return;
+            if (!(key in state)) {
+                storeLogger.warn(`update() ignored unknown key "${key}" — not in initial state`);
+                return;
+            }
 
             const prev = state[key];
             const next = updater(prev);

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -171,7 +171,7 @@ export function createStore(storeName, initialState, { persist = true, transient
             if (typeof keyOrPartial === 'object' && keyOrPartial !== null) {
                 // Batch update — '*' key, always notify
                 for (const k of Object.keys(keyOrPartial)) {
-                    if (k in state) {
+                    if (Object.hasOwn(state, k)) {
                         state[k] = keyOrPartial[k];
                         scheduleNotify(k);
                     } else {
@@ -180,7 +180,7 @@ export function createStore(storeName, initialState, { persist = true, transient
                 }
             } else {
                 const key = keyOrPartial;
-                if (key in state) {
+                if (Object.hasOwn(state, key)) {
                     // Skip notification when value is unchanged
                     if (!Object.is(state[key], value)) {
                         state[key] = value;
@@ -205,7 +205,7 @@ export function createStore(storeName, initialState, { persist = true, transient
          */
         update(key, updater) {
             if (frozen) return;
-            if (!(key in state)) {
+            if (!Object.hasOwn(state, key)) {
                 storeLogger.warn(`update() ignored unknown key "${key}" — not in initial state`);
                 return;
             }


### PR DESCRIPTION
## Problem

`appStore.set()` silently ignores keys that are not in the initial state definition. This caused the `failoverEnabled` setting to be a complete no-op — the toggle appeared to work but the value was never actually stored, making the entire Failover feature non-functional.

## Fix

Add `storeLogger.warn()` calls in `set()` and `update()` when an unknown key is encountered. This makes such bugs immediately visible in the developer console during development.

## Example output

```
[Store] set() ignored unknown key "failoverEnabled" — not in initial state
```

## Root cause

When adding a new setting, three places must be updated in sync:
1. `Settings` struct in `lib.rs`
2. `patch_settings` in `lib.rs` (patch_field macro)
3. `appStore` initial state in `state.js`

Missing step 3 causes `appStore.set()` to silently skip the key with no error or warning.
