### PR TITLE
fix: improve subscription download error reporting with detailed diagnostics

### DIFF
--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -177,6 +177,14 @@ pub mod codes {
     pub const SUB_ALL_FAILED: u16 = 2004;
     pub const SUB_UPDATE_SUCCESS: u16 = 2005;
     pub const SUB_LOCK_FAILED: u16 = 2006;
+    pub const SUB_SSRF_BLOCKED: u16 = 2007;
+    pub const SUB_NAME_INVALID: u16 = 2008;
+    pub const SUB_URL_INVALID: u16 = 2009;
+    pub const SUB_DNS_FAILED: u16 = 2010;
+    pub const SUB_HTTP_ERROR: u16 = 2011;
+    pub const SUB_NETWORK_ERROR: u16 = 2012;
+    pub const SUB_RESPONSE_TOO_LARGE: u16 = 2013;
+    pub const SUB_YAML_INVALID: u16 = 2014;
 
     // Prism: 3000-3999
     pub const PRISM_APPLY_FAILED: u16 = 3001;

--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -54,7 +54,8 @@ fn validate_config_for_update(
 }
 
 /// Mask URL for safe display in UI (hide sensitive host, path, and query parts)
-pub(super) fn mask_url(url: &str) -> String {
+#[must_use]
+pub fn mask_url(url: &str) -> String {
     if let Ok(parsed) = reqwest::Url::parse(url) {
         let host = parsed.host_str().unwrap_or("???");
         let masked_host = if host.len() > 6 {

--- a/apps/desktop/src-tauri/src/core/fetch_util.rs
+++ b/apps/desktop/src-tauri/src/core/fetch_util.rs
@@ -310,7 +310,10 @@ async fn resolve_and_pin(host: &str, port: u16) -> Result<std::net::SocketAddr, 
     for addr in &addrs {
         if is_private_ip(addr.ip()) {
             // Public domain resolving to a private IP = SSRF, always block.
-            return Err("Access to private/local resolved addresses is not allowed".to_owned());
+            return Err(format!(
+                "SSRF protection: host '{}' resolved to private IP {} — access to private/local addresses is not allowed",
+                host, addr.ip()
+            ));
         }
         if resolved_addr.is_none() {
             resolved_addr = Some(*addr);

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -357,7 +357,7 @@ pub(crate) fn validate_subscription_url_with_ip(
     let default_port = if scheme == "https" { 443 } else { 80 };
     let addrs: Vec<std::net::SocketAddr> =
         std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{default_port}"))
-            .map_err(|e| format!("Failed to resolve host: {e}"))?
+            .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
             .collect();
 
     validate_public_host_addrs(host, &addrs)
@@ -374,7 +374,11 @@ fn validate_public_host_addrs(
     for addr in addrs {
         if is_private_ip(addr.ip()) {
             // Public domain resolving to a private IP = SSRF, always block.
-            return Err("Access to private/local resolved addresses is not allowed".to_owned());
+            return Err(format!(
+                "SSRF protection: host '{}' resolved to private IP {} — access to private/local addresses is not allowed. \
+                 If this is a trusted internal subscription, enter the private address directly (e.g. http://192.168.x.x) instead of using a domain name.",
+                host, addr.ip()
+            ));
         }
         if resolved_addr.is_none() {
             resolved_addr = Some(*addr);
@@ -469,12 +473,8 @@ pub(crate) async fn download_sub_inner(
 
         if !resp.status().is_success() {
             let status = resp.status();
-            emit_warn!(
-                Subscription,
-                SUB_UPDATE_FAILED,
-                "Download failed with status: {status}"
-            );
-            return Err("Download failed with error status".to_owned());
+            let url_display = resp.url().to_string();
+            return Err(format!("HTTP {status} from {url_display}"));
         }
 
         if let Some(content_length) = resp.content_length() {
@@ -517,19 +517,17 @@ pub(crate) async fn download_sub_inner(
     let mut result: Option<(Vec<u8>, String, String, Option<String>)> = None;
 
     // Try direct connection first
-    match build_http_client_with_proxy(user_agent.as_deref(), resolve_pin.clone(), None) {
-        Ok(client) => match do_download(client, url.clone()).await {
-            Ok(data) => result = Some(data),
-            Err(e) => {
-                println!("[download_sub] Direct connection failed: {e}");
-                last_error = e;
-            }
-        },
-        Err(e) => {
-            println!("[download_sub] Failed to build direct client: {e}");
-            last_error = e;
-        }
-    }
+    let direct_error =
+        match build_http_client_with_proxy(user_agent.as_deref(), resolve_pin.clone(), None) {
+            Ok(client) => match do_download(client, url.clone()).await {
+                Ok(data) => {
+                    result = Some(data);
+                    None
+                }
+                Err(e) => Some(format!("Direct: {e}")),
+            },
+            Err(e) => Some(format!("Direct client build: {e}")),
+        };
 
     if result.is_none() {
         // Get proxy port from state, then immediately release the lock
@@ -559,8 +557,8 @@ pub(crate) async fn download_sub_inner(
                 match do_download(client, url.clone()).await {
                     Ok(data) => result = Some(data),
                     Err(e) => {
-                        println!("[download_sub] Mihomo proxy failed: {e}");
-                        last_error = e;
+                        last_error =
+                            format!("{} | Proxy: {}", direct_error.as_deref().unwrap_or(""), e);
                     }
                 }
             }
@@ -572,10 +570,12 @@ pub(crate) async fn download_sub_inner(
     // The Mihomo proxy path is trusted (user-configured), while system proxy
     // could be set by any application/malware on the system.
     let (bytes, sub_info_header, final_url, disp_filename) = result.ok_or_else(|| {
-        if last_error.is_empty() {
-            "Network error occurred during download".to_owned()
-        } else {
+        if !last_error.is_empty() {
             last_error
+        } else if let Some(de) = direct_error {
+            de
+        } else {
+            "Network error occurred during download".to_owned()
         }
     })?;
 
@@ -759,6 +759,104 @@ pub(crate) async fn download_sub_inner(
     Ok(format!("Config saved as {clean_name}"))
 }
 
+/// Determine the appropriate error code based on the error message content.
+fn classify_sub_error(e: &str) -> u16 {
+    use crate::backend_event::codes::{
+        SUB_DNS_FAILED, SUB_HTTP_ERROR, SUB_NAME_INVALID, SUB_NETWORK_ERROR,
+        SUB_RESPONSE_TOO_LARGE, SUB_SSRF_BLOCKED, SUB_UPDATE_FAILED, SUB_UPDATE_TIMEOUT,
+        SUB_URL_INVALID, SUB_YAML_INVALID,
+    };
+    if e.contains("SSRF protection") {
+        SUB_SSRF_BLOCKED
+    } else if e.contains("DNS resolution failed") || e.contains("Could not resolve") {
+        SUB_DNS_FAILED
+    } else if e.contains("Invalid URL")
+        || e.contains("Only HTTP")
+        || e.contains("must have a host")
+        || e.contains("URL must not be empty")
+    {
+        SUB_URL_INVALID
+    } else if e.contains("Subscription name")
+        || e.contains("Path traversal detected")
+        || e.contains("Invalid character in filename")
+        || e.contains("Filename too long")
+        || e.contains("Reserved filename")
+        || e.contains("Invalid file type")
+    {
+        SUB_NAME_INVALID
+    } else if e.contains("HTTP ") {
+        SUB_HTTP_ERROR
+    } else if e.contains("timeout") || e.contains("Timeout") {
+        SUB_UPDATE_TIMEOUT
+    } else if e.contains("Response too large") || e.contains("exceeded size limit") {
+        SUB_RESPONSE_TOO_LARGE
+    } else if e.contains("Invalid YAML")
+        || e.contains("YAML structure")
+        || e.contains("neither a valid Clash YAML")
+    {
+        SUB_YAML_INVALID
+    } else if e.contains("Connection failed")
+        || e.contains("Network error")
+        || e.contains("Request error")
+        || e.contains("Direct:")
+        || e.contains("Proxy:")
+    {
+        SUB_NETWORK_ERROR
+    } else {
+        SUB_UPDATE_FAILED
+    }
+}
+
+fn redact_url_in_string(s: &str) -> String {
+    // Strip query parameters, username, and password from any http(s) URL in the string.
+    // This prevents leaking subscription tokens to logs and frontend.
+    // Reuses the same reqwest::Url parsing as config_manager::mask_url.
+    let mut result = s.to_owned();
+    let mut start_idx = 0;
+    while start_idx < result.len() {
+        let remaining = &result[start_idx..];
+        let found_http = remaining.find("http://");
+        let found_https = remaining.find("https://");
+        let found_offset = match (found_http, found_https) {
+            (Some(h), Some(hs)) => Some(h.min(hs)),
+            (Some(h), None) => Some(h),
+            (None, Some(hs)) => Some(hs),
+            (None, None) => None,
+        };
+        let Some(offset) = found_offset else {
+            break;
+        };
+        let start = start_idx + offset;
+        // Find end of URL (whitespace or end of string)
+        let url_end = result[start..]
+            .find(|c: char| c.is_whitespace())
+            .map(|pos| start + pos)
+            .unwrap_or(result.len());
+        let url_str = &result[start..url_end];
+        if let Ok(mut url) = reqwest::Url::parse(url_str) {
+            url.set_query(None);
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            let redacted = url.to_string();
+            result.replace_range(start..url_end, &redacted);
+            start_idx = start + redacted.len();
+        } else {
+            start_idx = start + 4; // Skip past "http" to avoid infinite loop
+        }
+    }
+    result
+}
+
+fn log_sub_update_failure(name: &str, err: &str) {
+    let code = classify_sub_error(err);
+    let redacted_err = redact_url_in_string(err);
+    crate::backend_event::emit_backend_event(&crate::backend_event::BackendEvent::error(
+        crate::backend_event::BackendModule::Subscription,
+        code,
+        format!("Failed to update '{name}': {redacted_err}"),
+    ));
+}
+
 /// Tauri command wrapper: single subscription download with rate limiting.
 /// If `url` is None, the URL is resolved internally from metadata.
 #[tauri::command]
@@ -772,14 +870,20 @@ pub async fn download_sub(
 ) -> Result<String, String> {
     crate::rate_limit!(rate_limiter, "download_sub", 5000);
     let resolved_url = resolve_url_from_metadata(&app, &name, url)?;
-    download_sub_inner(
+    let result = download_sub_inner(
         &app,
         resolved_url,
-        name,
+        name.clone(),
         user_agent,
         overwrite.unwrap_or(false),
     )
-    .await
+    .await;
+
+    if let Err(e) = &result {
+        log_sub_update_failure(&name, e);
+    }
+
+    result.map_err(|e| redact_url_in_string(&e))
 }
 
 /// Batch update result for a single subscription.
@@ -804,10 +908,11 @@ pub async fn download_sub_batch(
         let resolved_url = match resolve_url_from_metadata(&app, &name, item.url) {
             Ok(u) => u,
             Err(e) => {
+                log_sub_update_failure(&name, &e);
                 results.push(BatchUpdateResult {
                     name,
                     success: false,
-                    error: Some(e),
+                    error: Some(redact_url_in_string(&e)),
                 });
                 continue;
             }
@@ -820,11 +925,14 @@ pub async fn download_sub_batch(
                 success: true,
                 error: None,
             }),
-            Err(e) => results.push(BatchUpdateResult {
-                name,
-                success: false,
-                error: Some(e),
-            }),
+            Err(e) => {
+                log_sub_update_failure(&name, &e);
+                results.push(BatchUpdateResult {
+                    name,
+                    success: false,
+                    error: Some(redact_url_in_string(&e)),
+                });
+            }
         }
     }
     Ok(results)
@@ -1012,7 +1120,7 @@ mod tests {
         let addrs: Vec<std::net::SocketAddr> = vec!["192.168.1.1:80".parse().unwrap()];
         let result = validate_public_host_addrs("attacker.com", &addrs);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("private/local resolved"));
+        assert!(result.unwrap_err().contains("SSRF protection"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -435,8 +435,20 @@ fn resolve_url_from_metadata(
     super::config_manager::get_config_url(app, name)
 }
 
-#[allow(clippy::cognitive_complexity)]
 pub(crate) async fn download_sub_inner(
+    app: &AppHandle,
+    url: String,
+    name: String,
+    user_agent: Option<String>,
+    overwrite: bool,
+) -> Result<String, String> {
+    download_sub_inner_raw(app, url, name, user_agent, overwrite)
+        .await
+        .map_err(|e| redact_url_in_string(&e))
+}
+
+#[allow(clippy::cognitive_complexity)]
+async fn download_sub_inner_raw(
     app: &AppHandle,
     url: String,
     name: String,
@@ -473,7 +485,7 @@ pub(crate) async fn download_sub_inner(
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let url_display = resp.url().to_string();
+            let url_display = super::config_manager::mask_url(resp.url().as_ref());
             return Err(format!("HTTP {status} from {url_display}"));
         }
 
@@ -553,13 +565,21 @@ pub(crate) async fn download_sub_inner(
             //     Mitigate by only configuring trusted proxies.
             let client_mihomo =
                 build_http_client_with_proxy(user_agent.as_deref(), None, Some(proxy_url_val));
-            if let Ok(client) = client_mihomo {
-                match do_download(client, url.clone()).await {
+            match client_mihomo {
+                Ok(client) => match do_download(client, url.clone()).await {
                     Ok(data) => result = Some(data),
                     Err(e) => {
-                        last_error =
-                            format!("{} | Proxy: {}", direct_error.as_deref().unwrap_or(""), e);
+                        last_error = match direct_error.as_deref() {
+                            Some(de) => format!("{de} | Proxy: {e}"),
+                            None => format!("Proxy: {e}"),
+                        };
                     }
+                },
+                Err(e) => {
+                    last_error = match direct_error.as_deref() {
+                        Some(de) => format!("{de} | Proxy client build: {e}"),
+                        None => format!("Proxy client build: {e}"),
+                    };
                 }
             }
         }
@@ -817,24 +837,36 @@ fn redact_url_in_string(s: &str) -> String {
         let remaining = &result[start_idx..];
         let found_http = remaining.find("http://");
         let found_https = remaining.find("https://");
-        let found_offset = match (found_http, found_https) {
-            (Some(h), Some(hs)) => Some(h.min(hs)),
-            (Some(h), None) => Some(h),
-            (None, Some(hs)) => Some(hs),
-            (None, None) => None,
-        };
+        let found_offset = found_http.into_iter().chain(found_https).min();
         let Some(offset) = found_offset else {
             break;
         };
         let start = start_idx + offset;
         // Find end of URL (whitespace or end of string)
-        let url_end = result[start..]
+        let mut url_end = result[start..]
             .find(|c: char| c.is_whitespace())
             .map(|pos| start + pos)
             .unwrap_or(result.len());
+        // Trim trailing punctuation/delimiters that are likely not part of the URL
+        while url_end > start {
+            let last_char = result[..url_end].chars().next_back();
+            if let Some(c) = last_char {
+                if matches!(
+                    c,
+                    ')' | ']' | '}' | '>' | '"' | '\'' | ',' | '.' | ';' | ':'
+                ) {
+                    url_end -= c.len_utf8();
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
         let url_str = &result[start..url_end];
         if let Ok(mut url) = reqwest::Url::parse(url_str) {
             url.set_query(None);
+            url.set_fragment(None);
             let _ = url.set_username("");
             let _ = url.set_password(None);
             let redacted = url.to_string();
@@ -883,7 +915,7 @@ pub async fn download_sub(
         log_sub_update_failure(&name, e);
     }
 
-    result.map_err(|e| redact_url_in_string(&e))
+    result
 }
 
 /// Batch update result for a single subscription.
@@ -930,7 +962,7 @@ pub async fn download_sub_batch(
                 results.push(BatchUpdateResult {
                     name,
                     success: false,
-                    error: Some(redact_url_in_string(&e)),
+                    error: Some(e),
                 });
             }
         }


### PR DESCRIPTION
## Summary

Aubscription download failures now report detailed, stage-specific error messages to the frontend App Logs tab, so users can diagnose exactly which step failed.

## Changes

- **Fine-grained error codes (2007-2014)** for each failure stage: SSRF blocked, DNS failed, URL invalid, name invalid, HTTP error, network error, response too large, YAML invalid
- **Manual download failures** now emit backend events (previously only scheduler failures did)
- **Detailed error messages** include context: host/IP for SSRF, hostname for DNS, status code for HTTP, direct vs proxy for network
- **Centralized URL redaction** in `download_sub_inner` — errors are guaranteed redacted at the boundary, callers don't need to remember to redact
- **HTTP error URLs use `mask_url`** — fully masks host/path to prevent leaking tokens embedded in URL paths
- **URL redaction** strips query parameters, fragments, and credentials to prevent leaking subscription tokens
- **Trailing punctuation trimming** prevents parse failures when URLs are wrapped in parentheses/quotes
- **Proxy client build errors** now captured and reported (previously silently ignored)
- **`mask_url` promoted to `pub`** for cross-module reuse

## Test plan

- [x] All 27 subscription tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] SSRF test assertion updated to match new error message format