### PR TITLE
perf: apply network TCP best practices for all platforms

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -699,6 +699,42 @@ pub fn prepare_runtime_config(
             mapping.insert(unified_delay_key, serde_yaml::Value::Bool(true));
         }
 
+        // Network performance defaults (Google Cloud TCP best practices)
+        // Only inject when the profile doesn't already specify a value,
+        // so user/subscription overrides are respected.
+
+        // tcp-concurrent: attempt TCP connections to all resolved IPs
+        // simultaneously and use the fastest one. Reduces handshake
+        // latency especially when a proxy node has both IPv4 and IPv6.
+        let tcp_concurrent_key = serde_yaml::Value::String("tcp-concurrent".to_owned());
+        if !mapping.contains_key(&tcp_concurrent_key) {
+            mapping.insert(tcp_concurrent_key, serde_yaml::Value::Bool(true));
+        }
+
+        // keep-alive-interval: TCP keep-alive probe interval in seconds.
+        // Prevents idle connections from being dropped by middleboxes
+        // (NATs, firewalls), aligning with Google's recommendation to
+        // maintain persistent connections and avoid slow-start after idle.
+        let keep_alive_key = serde_yaml::Value::String("keep-alive-interval".to_owned());
+        if !mapping.contains_key(&keep_alive_key) {
+            mapping.insert(
+                keep_alive_key,
+                serde_yaml::Value::Number(serde_yaml::Number::from(30)),
+            );
+        }
+
+        // find-process-mode: always match the originating process for
+        // each connection. Required for accurate rule-based routing in
+        // TUN mode and better connection visibility.
+        // (Not a TCP optimization — improves routing accuracy)
+        let find_process_key = serde_yaml::Value::String("find-process-mode".to_owned());
+        if !mapping.contains_key(&find_process_key) {
+            mapping.insert(
+                find_process_key,
+                serde_yaml::Value::String("always".to_owned()),
+            );
+        }
+
         // Inject global user preferences (override YAML profile values)
         if let Some(p) = prefs {
             if let Some(mode) = &p.mode {
@@ -774,7 +810,7 @@ pub fn prepare_runtime_config(
 fn build_minimal_runtime_config(secret: &str) -> (String, u16) {
     (
         format!(
-            "mixed-port: {DEFAULT_MIXED_PORT}\nmode: rule\nlog-level: info\nunified-delay: true\nexternal-controller: 127.0.0.1:9090\nsecret: {secret}\nproxies: []\nproxy-groups:\n  - name: GLOBAL\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n"
+            "mixed-port: {DEFAULT_MIXED_PORT}\nmode: rule\nlog-level: info\nunified-delay: true\ntcp-concurrent: true\nkeep-alive-interval: 30\nfind-process-mode: always\nexternal-controller: 127.0.0.1:9090\nsecret: {secret}\nproxies: []\nproxy-groups:\n  - name: GLOBAL\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n"
         ),
         DEFAULT_API_PORT,
     )
@@ -1405,6 +1441,9 @@ mod tests {
         assert!(config.contains("external-controller: 127.0.0.1:9090"));
         assert!(config.contains("secret: mysecret"));
         assert!(config.contains("unified-delay: true"));
+        assert!(config.contains("tcp-concurrent: true"));
+        assert!(config.contains("keep-alive-interval: 30"));
+        assert!(config.contains("find-process-mode: always"));
     }
 
     #[test]
@@ -1425,6 +1464,36 @@ mod tests {
         let (config, _) = result.unwrap();
         assert!(config.contains("unified-delay: false"));
         assert_eq!(config.matches("unified-delay").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_config_preserves_tcp_concurrent() {
+        let content = "tcp-concurrent: false\nport: 7890";
+        let result = prepare_runtime_config(content, "s", None);
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert!(config.contains("tcp-concurrent: false"));
+        assert_eq!(config.matches("tcp-concurrent").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_config_preserves_keep_alive_interval() {
+        let content = "keep-alive-interval: 60\nport: 7890";
+        let result = prepare_runtime_config(content, "s", None);
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert!(config.contains("keep-alive-interval: 60"));
+        assert_eq!(config.matches("keep-alive-interval").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_config_preserves_find_process_mode() {
+        let content = "find-process-mode: off\nport: 7890";
+        let result = prepare_runtime_config(content, "s", None);
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert!(config.contains("find-process-mode: off"));
+        assert_eq!(config.matches("find-process-mode").count(), 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/core/tun_manager.rs
+++ b/apps/desktop/src-tauri/src/core/tun_manager.rs
@@ -228,8 +228,14 @@ pub async fn restart_core_as_root(app: &AppHandle, enable_tun: bool) -> Result<S
     let escaped_binary_name = binary_name.replace("'", "'\\''");
     // Kill both new (zephyr-mihomo) and legacy (mihomo) names to handle upgrade scenario
     // where a root-owned legacy process might still be running
+    // Also apply TCP performance optimizations (Google Cloud best practices):
+    //   - MSL=1000: reduce TIME_WAIT from 60s to 2s for faster port reuse
+    //   - tcp.fastopen=3: enable TCP Fast Open for client+server
+    //   - tcp.ecn=1: enable ECN for congestion signaling without drops
+    // Note: macOS BSD kernel has no direct equivalent to Linux's tcp_slow_start_after_idle
+    // or tcp_rto_min_us; these optimizations are Linux-specific.
     let script = format!(
-        r#"do shell script "killall -9 zephyr-mihomo mihomo 2>/dev/null; sysctl -w net.inet.tcp.msl=1000 2>/dev/null; sleep 0.3; cd '{escaped_config_dir}' && './{escaped_binary_name}' -d '.' -f 'run_config.yaml' > '{escaped_log_path}' 2>&1 &" with administrator privileges"#,
+        r#"do shell script "killall -9 zephyr-mihomo mihomo 2>/dev/null; sysctl -w net.inet.tcp.msl=1000 2>/dev/null; sysctl -w net.inet.tcp.fastopen=3 2>/dev/null; sysctl -w net.inet.tcp.ecn=1 2>/dev/null; sleep 0.3; cd '{escaped_config_dir}' && './{escaped_binary_name}' -d '.' -f 'run_config.yaml' > '{escaped_log_path}' 2>&1 &" with administrator privileges"#,
     );
 
     // Spawn osascript without waiting for it to complete
@@ -308,11 +314,11 @@ pub async fn restart_core_as_root(app: &AppHandle, enable_tun: bool) -> Result<S
         return Err("root_start_failed".to_owned());
     }
 
-    // MSL is already set in the root osascript above (sysctl needs root)
+    // MSL and TCP optimizations are already set in the root osascript above (sysctl needs root)
     emit_info!(
         System,
         SYS_TUN_FAILED,
-        "Set MSL=1000 for short TIME_WAIT (via root shell)"
+        "TCP optimizations applied: MSL=1000, FastOpen=3, ECN=1 (via root shell)"
     );
 
     // Mark TUN mode as active
@@ -657,8 +663,13 @@ pub async fn restart_core_as_root_cmd(
 
 /// Grant `CAP_NET_ADMIN` capability to the mihomo binary on Linux and install
 /// a `PolicyKit` rule to allow DNS/route configuration without password prompts.
-/// Uses pkexec to prompt for authentication once, then runs setcap and
-/// installs the polkit rule file.
+/// Also applies TCP performance optimizations following Google Cloud best practices:
+/// - Disable slow-start-after-idle (avoid congestion window reset after idle)
+/// - Lower `MinRTO` for faster loss recovery
+/// - Enable TCP Fast Open for reduced handshake latency
+/// - Enable ECN for congestion signaling without packet loss
+/// Uses pkexec to prompt for authentication once, then runs setcap,
+/// sysctl tuning, and installs the polkit rule file.
 #[tauri::command]
 #[cfg(target_os = "linux")]
 pub async fn grant_linux_tun_permission(app: tauri::AppHandle) -> Result<(), String> {
@@ -671,7 +682,7 @@ pub async fn grant_linux_tun_permission(app: tauri::AppHandle) -> Result<(), Str
     emit_info!(
         System,
         SYS_TUN_FAILED,
-        "Granting CAP_NET_ADMIN and installing polkit rule for: {core_path_str}"
+        "Granting CAP_NET_ADMIN, applying TCP optimizations, and installing polkit rule for: {core_path_str}"
     );
 
     let username = whoami().map_err(|e| format!("Failed to get username: {e}"))?;
@@ -691,9 +702,49 @@ pub async fn grant_linux_tun_permission(app: tauri::AppHandle) -> Result<(), Str
 "#
     );
 
+    // Combined script: setcap + TCP sysctl tuning + polkit rule installation
+    // Google Cloud TCP best practices (lines 3912-4160 of optimization doc):
+    //   1. tcp_slow_start_after_idle=0 — maintain congestion window after idle
+    //   2. tcp_rto_min_us=5000 — lower MinRTO for faster loss recovery (Linux 6.11+)
+    //      Fallback: ip route change default rto_min 5ms for older kernels
+    //   3. tcp_fastopen=3 — enable TCP Fast Open for both client and server
+    //   4. tcp_ecn=1 — enable ECN for congestion signaling without drops
+    //   5. Fair Queueing — required prerequisite for disabling slow-start-after-idle
+    //      (Google warns: without FQ, idle connections may send line-rate bursts)
     let script = r#"set -e
 export PATH="/usr/sbin:/sbin:$PATH"
+
+# Grant network capabilities to mihomo
 setcap cap_net_admin,cap_net_bind_service+ep "$1"
+
+# TCP performance tuning (Google Cloud best practices)
+# All sysctl writes are idempotent and safe for general use.
+
+# Fair Queueing MUST be installed before disabling slow-start-after-idle.
+# Without FQ, idle connections may send line-rate bursts causing packet loss.
+# Only disable slow-start-after-idle if FQ was successfully applied.
+FQ_APPLIED=0
+DEFAULT_IF="$(ip route show default 2>/dev/null | awk '/default/ {print $5; exit}')"
+if [ -n "$DEFAULT_IF" ] && tc qdisc replace dev "$DEFAULT_IF" root fq 2>/dev/null; then
+    FQ_APPLIED=1
+fi
+
+if [ "$FQ_APPLIED" -eq 1 ]; then
+    sysctl -w net.ipv4.tcp_slow_start_after_idle=0 2>/dev/null || true
+fi
+sysctl -w net.ipv4.tcp_fastopen=3 2>/dev/null || true
+sysctl -w net.ipv4.tcp_ecn=1 2>/dev/null || true
+
+# Lower MinRTO — Linux 6.11+ uses tcp_rto_min_us, older kernels use ip route
+if ! sysctl -w net.ipv4.tcp_rto_min_us=5000 2>/dev/null; then
+    # ip route change requires full route spec (via + dev) to uniquely identify the route
+    DEFAULT_ROUTE="$(ip route show default 2>/dev/null | head -1)"
+    if [ -n "$DEFAULT_ROUTE" ]; then
+        ip route change $DEFAULT_ROUTE rto_min 5ms 2>/dev/null || true
+    fi
+fi
+
+# Install polkit rule for passwordless DNS/route operations
 mkdir -p /etc/polkit-1/rules.d
 printf '%s' "$2" > /etc/polkit-1/rules.d/50-zephyr-tun.rules
 chmod 644 /etc/polkit-1/rules.d/50-zephyr-tun.rules"#;
@@ -707,7 +758,7 @@ chmod 644 /etc/polkit-1/rules.d/50-zephyr-tun.rules"#;
         emit_info!(
             System,
             SYS_TUN_FAILED,
-            "CAP_NET_ADMIN granted and polkit rule installed successfully"
+            "CAP_NET_ADMIN granted, TCP optimizations applied, and polkit rule installed successfully"
         );
         Ok(())
     } else {
@@ -751,5 +802,117 @@ fn whoami() -> Result<String, String> {
 #[tauri::command]
 #[cfg(not(target_os = "linux"))]
 pub async fn grant_linux_tun_permission(_app: tauri::AppHandle) -> Result<(), String> {
+    Ok(())
+}
+
+/// Apply Windows TCP performance optimizations following Google Cloud best practices.
+/// These netsh commands require administrator privileges, which is typically already
+/// available when TUN mode is active (WinTUN requires admin to install driver).
+///
+/// Optimizations applied:
+/// - autotuninglevel=normal: enable TCP receive window auto-tuning (optimal throughput)
+/// - heuristics disabled: prevent Windows from artificially limiting window size
+/// - initialRto=300: reduce initial retransmission timeout from 1000ms to 300ms
+///   (Google recommends low MinRTO for faster loss recovery)
+/// - fastopen=enabled: enable TCP Fast Open for reduced handshake latency
+/// - ecncapability=enabled: enable ECN for congestion signaling without drops
+#[tauri::command]
+#[cfg(target_os = "windows")]
+pub fn apply_windows_tcp_optimizations() -> Result<(), String> {
+    use super::TUN_MODE_ACTIVE;
+    use std::os::windows::process::CommandExt;
+    use std::sync::atomic::Ordering;
+
+    // Only apply when TUN mode is active
+    if !TUN_MODE_ACTIVE.load(Ordering::SeqCst) {
+        return Ok(());
+    }
+
+    let optimizations: [(&str, &[&str]); 5] = [
+        // Enable TCP receive window auto-tuning (normal = optimal for most cases)
+        (
+            "autotuninglevel",
+            &["int", "tcp", "set", "global", "autotuninglevel=normal"],
+        ),
+        // Disable heuristics that may artificially limit window size
+        (
+            "heuristics",
+            &["int", "tcp", "set", "heuristics", "disabled"],
+        ),
+        // Reduce initial RTO from 1000ms to 300ms (Google: lower MinRTO for faster loss recovery)
+        (
+            "initialRto",
+            &["int", "tcp", "set", "global", "initialRto=300"],
+        ),
+        // Enable TCP Fast Open
+        (
+            "fastopen",
+            &["int", "tcp", "set", "global", "fastopen=enabled"],
+        ),
+        // Enable ECN for congestion signaling without packet drops
+        (
+            "ecncapability",
+            &["int", "tcp", "set", "global", "ecncapability=enabled"],
+        ),
+    ];
+
+    let mut failed = Vec::new();
+    for (name, args) in &optimizations {
+        let mut cmd = std::process::Command::new("netsh");
+        cmd.args(args);
+        // Prevent console window from flashing on screen
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        let result = cmd.output();
+        match result {
+            Ok(output) if output.status.success() => {
+                emit_info!(
+                    System,
+                    SYS_TUN_FAILED,
+                    "Windows TCP optimization applied: {name}"
+                );
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                // Not fatal — some settings may not be supported on older Windows
+                emit_warn!(
+                    System,
+                    SYS_TUN_FAILED,
+                    "Windows TCP optimization skipped ({name}): {stderr}"
+                );
+                failed.push(*name);
+            }
+            Err(e) => {
+                emit_warn!(
+                    System,
+                    SYS_TUN_FAILED,
+                    "Windows TCP optimization failed ({name}): {e}"
+                );
+                failed.push(*name);
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        emit_info!(
+            System,
+            SYS_TUN_FAILED,
+            "All Windows TCP optimizations applied successfully"
+        );
+    } else {
+        emit_info!(
+            System,
+            SYS_TUN_FAILED,
+            "Windows TCP optimizations applied (skipped: {})",
+            failed.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+/// On non-Windows platforms, this is a no-op
+#[tauri::command]
+#[cfg(not(target_os = "windows"))]
+pub const fn apply_windows_tcp_optimizations() -> Result<(), String> {
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -835,6 +835,7 @@ pub fn run() {
             kill_all_mihomo_as_root_cmd,
             disable_tun_cmd,
             grant_linux_tun_permission,
+            core_manager::core::tun_manager::apply_windows_tcp_optimizations,
             // Re-export tray commands
             tray::get_tray_menu_state,
             tray::set_tray_menu_state,

--- a/apps/desktop/src/ui/dns-shared.js
+++ b/apps/desktop/src/ui/dns-shared.js
@@ -186,7 +186,30 @@ export async function buildDnsRewritePayload() {
             ipv6: false,
             'enhanced-mode': 'fake-ip',
             'fake-ip-range': '198.18.0.1/16',
-            'fake-ip-filter': ['*.lan', 'localhost.ptlogin2.qq.com'],
+            // Domains that must resolve to real IPs (not fake-ip).
+            // These are services that break or behave incorrectly with fake IPs,
+            // such as captive portals, game consoles, and LAN discovery.
+            'fake-ip-filter': [
+                '*.lan',
+                '*.local',
+                '*.localhost',
+                '*.localdomain',
+                'localhost.ptlogin2.qq.com',
+                '*.msftncsi.com',
+                '*.srv.nintendo.net',
+                '*.stun.playstation.net',
+                'xbox.*.microsoft.com',
+                '*.xboxlive.com',
+                '*.stun.steamwire.com',
+                'stun.*',
+            ],
+            // Base DNS servers used to resolve DoH/DoT hostnames themselves.
+            // Without this, mihomo cannot resolve the DoH server domain (e.g. dns.google)
+            // because it needs DNS to reach the DoH server — a circular dependency.
+            'default-nameserver': [
+                '223.5.5.5',
+                '119.29.29.29',
+            ],
             nameserver: dnsConfig.nameserver,
             fallback: dnsConfig.fallback,
         },

--- a/apps/desktop/src/ui/tun.js
+++ b/apps/desktop/src/ui/tun.js
@@ -114,6 +114,18 @@ export function initTunToggle() {
 
             await closeAllConnections();
 
+            // Apply Windows TCP optimizations when TUN is enabled
+            if (enable) {
+                const isWindows = navigator.platform.toLowerCase().includes('win');
+                if (isWindows) {
+                    try {
+                        await invoke(COMMANDS.APPLY_WINDOWS_TCP_OPTIMIZATIONS);
+                    } catch (e) {
+                        tunLogger.warn('Windows TCP optimization failed', e);
+                    }
+                }
+            }
+
             appStore.set('isTunEnabled', enable);
 
             showNotification(t.configSuccess, 'success');

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -70,6 +70,7 @@ export const TUN = Object.freeze({
     KILL_ALL_AS_ROOT: "kill_all_mihomo_as_root_cmd",
     DISABLE_CMD: "disable_tun_cmd",
     GRANT_LINUX_PERMISSION: "grant_linux_tun_permission",
+    APPLY_WINDOWS_TCP_OPTIMIZATIONS: "apply_windows_tcp_optimizations",
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three-layer network performance optimization following industry TCP best practices.

### Layer 1 — mihomo config defaults (cross-platform, no privileges)
- `tcp-concurrent: true` — parallel TCP to all resolved IPs, pick fastest
- `keep-alive-interval: 30` — prevent idle connection drops by middleboxes
- `find-process-mode: always` — accurate process-based routing in TUN mode

### Layer 2 — OS TCP tuning (applied when TUN is enabled with elevated privileges)
- **Linux**: Fair Queueing (conditionally applied; slow-start-after-idle only disabled if FQ succeeds), `tcp_rto_min_us=5000` (fallback `ip route` with full spec), `tcp_fastopen=3`, `tcp_ecn=1` — via existing pkexec grant flow
- **macOS**: `net.inet.tcp.fastopen=3`, `net.inet.tcp.ecn=1` — via existing osascript administrator privileges (MSL=1000 already present)
- **Windows**: `autotuninglevel=normal`, `heuristics disabled`, `initialRto=300`, `fastopen=enabled`, `ecncapability=enabled` — via netsh with CREATE_NO_WINDOW flag

### Layer 3 — DNS optimization (cross-platform, no privileges)
- Expanded `fake-ip-filter` from 2 to 11 entries (captive portals, game consoles, STUN, LAN discovery)
- Added `default-nameserver` (223.5.5.5, 119.29.29.29) to break DoH resolution circular dependency

## Changed files
- `core_process.rs` — inject mihomo config defaults
- `tun_manager.rs` — Linux/macOS/Windows TCP tuning
- `lib.rs` — register new command
- `dns-shared.js` — expanded fake-ip-filter + default-nameserver
- `tun.js` — call Windows TCP optimization on TUN enable
- `packages/shared/src/index.js` — register command constant

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] 51 unit tests pass (including 3 new preservation tests)
- [ ] Manual: enable TUN on Linux, verify sysctl values applied
- [ ] Manual: enable TUN on macOS, verify sysctl values applied
- [ ] Manual: enable TUN on Windows, verify netsh values applied
- [ ] Manual: verify mihomo config contains new defaults when not specified by subscription