### PR TITLE
perf: optimize persistent connections and DNS caching via mihomo defaults

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -723,6 +723,40 @@ pub fn prepare_runtime_config(
             );
         }
 
+        // keep-alive-idle: maximum idle time (seconds) before TCP keep-alive
+        // probes begin. Default is 15s which is too aggressive — connections
+        // are probed and potentially closed after just 15s of inactivity.
+        // Setting to 600 (10 minutes) keeps connections alive through typical
+        // web browsing pauses, reducing TCP+TLS handshake round-trips.
+        // (Google: persistent connections reduced TTFB from 230ms to 123ms)
+        let keep_alive_idle_key = serde_yaml::Value::String("keep-alive-idle".to_owned());
+        if !mapping.contains_key(&keep_alive_idle_key) {
+            mapping.insert(
+                keep_alive_idle_key,
+                serde_yaml::Value::Number(serde_yaml::Number::from(600)),
+            );
+        }
+
+        // profile.store-fake-ip: persist fake-ip mapping table to disk so
+        // that on restart, previously resolved domains reuse the same fake-ip
+        // address. This avoids DNS re-resolution and connection disruption,
+        // aligning with Google's recommendation to minimize DNS queries
+        // as a key latency contributor.
+        let profile_key = serde_yaml::Value::String("profile".to_owned());
+        if let Some(serde_yaml::Value::Mapping(profile_map)) = mapping.get_mut(&profile_key) {
+            let store_fake_ip_key = serde_yaml::Value::String("store-fake-ip".to_owned());
+            if !profile_map.contains_key(&store_fake_ip_key) {
+                profile_map.insert(store_fake_ip_key, serde_yaml::Value::Bool(true));
+            }
+        } else if !mapping.contains_key(&profile_key) {
+            let mut profile_map = serde_yaml::Mapping::new();
+            profile_map.insert(
+                serde_yaml::Value::String("store-fake-ip".to_owned()),
+                serde_yaml::Value::Bool(true),
+            );
+            mapping.insert(profile_key, serde_yaml::Value::Mapping(profile_map));
+        }
+
         // find-process-mode: always match the originating process for
         // each connection. Required for accurate rule-based routing in
         // TUN mode and better connection visibility.
@@ -810,7 +844,7 @@ pub fn prepare_runtime_config(
 fn build_minimal_runtime_config(secret: &str) -> (String, u16) {
     (
         format!(
-            "mixed-port: {DEFAULT_MIXED_PORT}\nmode: rule\nlog-level: info\nunified-delay: true\ntcp-concurrent: true\nkeep-alive-interval: 30\nfind-process-mode: always\nexternal-controller: 127.0.0.1:9090\nsecret: {secret}\nproxies: []\nproxy-groups:\n  - name: GLOBAL\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n"
+            "mixed-port: {DEFAULT_MIXED_PORT}\nmode: rule\nlog-level: info\nunified-delay: true\ntcp-concurrent: true\nkeep-alive-interval: 30\nkeep-alive-idle: 600\nfind-process-mode: always\nprofile:\n  store-fake-ip: true\nexternal-controller: 127.0.0.1:9090\nsecret: {secret}\nproxies: []\nproxy-groups:\n  - name: GLOBAL\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n"
         ),
         DEFAULT_API_PORT,
     )
@@ -1443,6 +1477,8 @@ mod tests {
         assert!(config.contains("unified-delay: true"));
         assert!(config.contains("tcp-concurrent: true"));
         assert!(config.contains("keep-alive-interval: 30"));
+        assert!(config.contains("keep-alive-idle: 600"));
+        assert!(config.contains("store-fake-ip: true"));
         assert!(config.contains("find-process-mode: always"));
     }
 
@@ -1494,6 +1530,26 @@ mod tests {
         let (config, _) = result.unwrap();
         assert!(config.contains("find-process-mode: off"));
         assert_eq!(config.matches("find-process-mode").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_config_preserves_keep_alive_idle() {
+        let content = "keep-alive-idle: 300\nport: 7890";
+        let result = prepare_runtime_config(content, "s", None);
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert!(config.contains("keep-alive-idle: 300"));
+        assert_eq!(config.matches("keep-alive-idle").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_config_preserves_store_fake_ip() {
+        let content = "profile:\n  store-fake-ip: false\nport: 7890";
+        let result = prepare_runtime_config(content, "s", None);
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert!(config.contains("store-fake-ip: false"));
+        assert_eq!(config.matches("store-fake-ip").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two mihomo config optimizations following network performance best practices.

### 1. `keep-alive-idle: 600` (default: 15)
The default 15s idle timeout is too aggressive — connections are probed and potentially closed after just 15s of inactivity, forcing new TCP+TLS handshakes. Setting to 600s (10 minutes) keeps connections alive through typical web browsing pauses.

Document reference: persistent connections reduced TTFB from 230ms to 123ms.

### 2. `profile.store-fake-ip: true` (default: unset/false)
Persists the fake-ip mapping table to disk so that on restart, previously resolved domains reuse the same fake-ip address. This avoids DNS re-resolution and connection disruption.

Document reference: DNS is a key latency contributor — minimize queries.

### Excluded parameters (with reasons)
- `global-client-fingerprint`: **Deprecated** per mihomo docs — "Global TLS fingerprinting has been deprecated, please set client-fingerprint directly within the proxy"
- `sniffer`: Nested structure with `override-destination: true` default that may alter user routing behavior; too invasive as a default injection

## Changed files
- `core_process.rs` — inject `keep-alive-idle` and `profile.store-fake-ip` defaults

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] 376 unit tests pass (including 2 new preservation tests)
- [ ] Manual: verify mihomo config contains `keep-alive-idle: 600` when not specified by subscription
- [ ] Manual: verify mihomo config contains `store-fake-ip: true` when not specified by subscription
- [ ] Manual: verify existing `keep-alive-idle` / `store-fake-ip` values are preserved when set by subscription