### PR TITLE
perf: disable HyStart ACK train detection on Linux

### DIFF
--- a/apps/desktop/src-tauri/src/core/tun_manager.rs
+++ b/apps/desktop/src-tauri/src/core/tun_manager.rs
@@ -706,6 +706,9 @@ pub async fn grant_linux_tun_permission(app: tauri::AppHandle) -> Result<(), Str
     // TCP optimizations (safe for WAN/residential networks):
     //   1. tcp_fastopen=3 — enable TCP Fast Open for both client and server
     //   2. tcp_ecn=1 — enable ECN for congestion signaling without drops
+    //   3. hystart_detect=2 — disable unreliable ACK train detection in HyStart,
+    //      keeping RTT delay detection only. Prevents premature slow-start exit
+    //      on WAN paths. (Windows HyStart++ already removed ACK train by default)
     // Note: FQ, slow-start-after-idle, and MinRTO tuning are intentionally
     // omitted — they target intra-datacenter networks and can degrade WAN
     // performance or override distro qdisc preferences (fq_codel, cake).
@@ -722,6 +725,14 @@ setcap cap_net_admin,cap_net_bind_service+ep "$1"
 # or override the user's distro qdisc preferences (e.g. fq_codel, cake).
 sysctl -w net.ipv4.tcp_fastopen=3 2>/dev/null || true
 sysctl -w net.ipv4.tcp_ecn=1 2>/dev/null || true
+
+# Disable HyStart ACK train detection (value 2 = RTT delay only, no ACK train).
+# ACK train detection is an unreliable congestion signal that can cause
+# premature exit from TCP slow start, limiting throughput on WAN paths.
+# Windows HyStart++ already removed ACK train by default since 2021.
+# Ensure tcp_cubic module is loaded before writing its parameter.
+modprobe tcp_cubic 2>/dev/null || true
+echo 2 > /sys/module/tcp_cubic/parameters/hystart_detect 2>/dev/null || true
 
 # Install polkit rule for passwordless DNS/route operations
 mkdir -p /etc/polkit-1/rules.d


### PR DESCRIPTION
## Summary

Disable the unreliable HyStart ACK train congestion signal on Linux, following Google's TCP optimization best practices.

### Change
Set `hystart_detect=2` (RTT delay only, no ACK train) during Linux TUN permission grant, alongside existing `tcp_fastopen` and `tcp_ecn` optimizations. Also adds `modprobe tcp_cubic` to ensure the module is loaded before writing its parameter.

### Document reference (lines 4061-4080)
> "ACK train detection has proven to be an unreliable congestion signal and is now considered obsolete."
> "To optimize performance, disable ACK packet train detection while keeping the RTT delay mechanism enabled."

### Cross-platform consistency
- **Linux**: Actively disabled via `hystart_detect=2`
- **Windows**: HyStart++ already removed ACK train detection by default since 2021
- **macOS**: Uses different congestion control implementation without HyStart

## Changed files
- `tun_manager.rs` — add `modprobe tcp_cubic` + `hystart_detect=2` to Linux TUN grant script

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [ ] Manual: enable TUN on Linux, verify `cat /sys/module/tcp_cubic/parameters/hystart_detect` returns `2`