### PR TITLE
feat: add TCP buffer tuning for high-RTT paths on Linux

### DIFF
--- a/apps/desktop/src-tauri/src/core/tun_manager.rs
+++ b/apps/desktop/src-tauri/src/core/tun_manager.rs
@@ -709,9 +709,19 @@ pub async fn grant_linux_tun_permission(app: tauri::AppHandle) -> Result<(), Str
     //   3. hystart_detect=2 — disable unreliable ACK train detection in HyStart,
     //      keeping RTT delay detection only. Prevents premature slow-start exit
     //      on WAN paths. (Windows HyStart++ already removed ACK train by default)
+    //   4. Increase TCP buffer limits (recommended safe defaults):
+    //      - rmem_max: 16MB, wmem_max: 32MB — match auto-tuned TCP maximums so
+    //        that applications using SO_RCVBUF/SO_SNDBUF can fully utilize them
+    //      - tcp_rmem: 4K/256K/16MB — auto-tuned receive buffer (max 16MB for high RTT)
+    //      - tcp_wmem: 4K/256K/32MB — auto-tuned send buffer (max 32MB for high RTT)
+    //      - tcp_notsent_lowat: 128KB — limit unsent data queue to prevent bufferbloat
+    //      These only affect high-RTT connections; low-RTT traffic uses minimal memory.
+    //      Safe for desktop use (Google: "little risk unless millions of connections").
     // Note: FQ, slow-start-after-idle, and MinRTO tuning are intentionally
     // omitted — they target intra-datacenter networks and can degrade WAN
     // performance or override distro qdisc preferences (fq_codel, cake).
+    // Shell ${var:-default} syntax triggers clippy::literal_string_with_formatting_args
+    #[allow(clippy::literal_string_with_formatting_args)]
     let script = r#"set -e
 export PATH="/usr/sbin:/sbin:$PATH"
 
@@ -733,6 +743,40 @@ sysctl -w net.ipv4.tcp_ecn=1 2>/dev/null || true
 # Ensure tcp_cubic module is loaded before writing its parameter.
 modprobe tcp_cubic 2>/dev/null || true
 echo 2 > /sys/module/tcp_cubic/parameters/hystart_detect 2>/dev/null || true
+
+# Increase TCP buffer limits (recommended safe defaults).
+# Default Linux tcp_rmem max is only 6MB, which limits throughput on high-RTT
+# paths (e.g. user far from proxy entry). Increasing to 16MB/32MB allows the
+# TCP stack to auto-tune larger windows when needed, while tcp_moderate_rcvbuf
+# (enabled by default) ensures low-RTT connections still use minimal memory.
+# Only raise values — never downgrade existing higher limits (e.g. on servers
+# or soft-routers with custom tunings already applied).
+# rmem_max/wmem_max must match or exceed tcp_rmem/tcp_wmem maximums so that
+# applications using SO_RCVBUF/SO_SNDBUF can fully utilize the auto-tuned limits.
+# tcp_notsent_lowat: 128KB cap on unsent data queue to prevent bufferbloat.
+# Note: use || echo 0 to prevent set -e from aborting on sysctl failure,
+# and strip non-numeric chars to guard against error messages in output.
+curr_rmem_max=$(sysctl -n net.core.rmem_max 2>/dev/null | tr -cd '0-9' || echo 0)
+curr_rmem_max=${curr_rmem_max:-0}
+if [ "$curr_rmem_max" -lt 16777216 ] 2>/dev/null; then
+    sysctl -w net.core.rmem_max=16777216 2>/dev/null || true
+fi
+curr_wmem_max=$(sysctl -n net.core.wmem_max 2>/dev/null | tr -cd '0-9' || echo 0)
+curr_wmem_max=${curr_wmem_max:-0}
+if [ "$curr_wmem_max" -lt 33554432 ] 2>/dev/null; then
+    sysctl -w net.core.wmem_max=33554432 2>/dev/null || true
+fi
+read -r r_min r_def r_max <<< "$(sysctl -n net.ipv4.tcp_rmem 2>/dev/null || echo "4096 262144 16777216")"
+r_min=${r_min:-4096}; r_def=${r_def:-262144}; r_max=${r_max:-16777216}
+[ "$r_def" -lt 262144 ] 2>/dev/null && r_def=262144
+[ "$r_max" -lt 16777216 ] 2>/dev/null && r_max=16777216
+sysctl -w "net.ipv4.tcp_rmem=$r_min $r_def $r_max" 2>/dev/null || true
+read -r w_min w_def w_max <<< "$(sysctl -n net.ipv4.tcp_wmem 2>/dev/null || echo "4096 262144 33554432")"
+w_min=${w_min:-4096}; w_def=${w_def:-262144}; w_max=${w_max:-33554432}
+[ "$w_def" -lt 262144 ] 2>/dev/null && w_def=262144
+[ "$w_max" -lt 33554432 ] 2>/dev/null && w_max=33554432
+sysctl -w "net.ipv4.tcp_wmem=$w_min $w_def $w_max" 2>/dev/null || true
+sysctl -w net.ipv4.tcp_notsent_lowat=131072 2>/dev/null || true
 
 # Install polkit rule for passwordless DNS/route operations
 mkdir -p /etc/polkit-1/rules.d


### PR DESCRIPTION
## Summary

Increase TCP socket buffer limits in the Linux TUN grant script to improve single-thread throughput for users far from proxy entry points (RTT > 25ms). Default Linux `tcp_rmem` max (6MB) limits throughput on high-RTT paths; increasing to 16MB/32MB allows the TCP stack to auto-tune larger windows.

## Changes

Added the following sysctl parameters to the TUN grant script (`grant_linux_tun_permission`):

- `net.core.rmem_max=16777216` (16MB) — match tcp_rmem max for SO_RCVBUF
- `net.core.wmem_max=33554432` (32MB) — match tcp_wmem max for SO_SNDBUF
- `net.ipv4.tcp_rmem` — raise default to 256K, max to 16MB (only if current values are lower)
- `net.ipv4.tcp_wmem` — raise default to 256K, max to 32MB (only if current values are lower)
- `net.ipv4.tcp_notsent_lowat=131072` (128KB) — limit unsent data queue to prevent bufferbloat

All buffer limits use **raise-only** logic: existing higher values (e.g. from soft-router custom tunings) are never downgraded.

## Safety

- Conservative values aligned with TCP best practices
- `tcp_moderate_rcvbuf` (enabled by default on Linux) ensures low-RTT connections use minimal memory
- Only high-RTT connections will see larger buffer allocations
- `rmem_max`/`wmem_max` match `tcp_rmem`/`tcp_wmem` maximums so auto-tuning can fully utilize them
- `tcp_notsent_lowat=128KB` prevents bufferbloat from unsent data accumulation
- Raise-only logic preserves existing higher limits on servers/soft-routers
- All commands use `2>/dev/null || true` for graceful failure
- `set -e` safe: sysctl reads use `|| echo 0` fallback and `tr -cd '0-9'` to strip non-numeric output

## Platform Coverage

| Platform | Status |
|----------|--------|
| Linux | Implemented (this PR) |
| macOS | Not possible (sysctl locked since Monterey) |
| Windows | Already covered by `autotuninglevel=normal` |

## Test Plan

- [x] `cargo clippy --lib -- -D warnings` passes
- [x] `cargo test --lib` passes (377 tests)
- [ ] Manual: enable TUN on Linux, verify sysctl values applied via `sysctl net.ipv4.tcp_rmem`