### PR TITLE
fix: unify dropdown menu styles across all selectors

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -420,9 +420,11 @@
                                             <path d="m6 9 6 6 6-6"></path>
                                         </svg>
                                     </button>
-                                    <div id="setting-lang-menu" class="hidden absolute right-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)]/95 backdrop-blur-xl shadow-[var(--zephyr-shadow-md)] p-1 z-30">
-                                        <button type="button" data-lang-value="en" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">English</button>
-                                        <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">简体中文</button>
+                                    <div id="setting-lang-menu" class="hidden absolute right-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                                        <div class="menu-scroll">
+                                            <button type="button" data-lang-value="en" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">English</button>
+                                            <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">简体中文</button>
+                                        </div>
                                     </div>
                                     <select id="setting-lang" class="hidden">
                                         <option value="en">English</option>
@@ -915,12 +917,14 @@
                                                     <span id="fake-client-label">Clash Verge Rev</span>
                                                     <svg class="w-3.5 h-3.5 text-[var(--text-muted)] transition-transform duration-200 dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"></path></svg>
                                                 </button>
-                                                <div id="fake-client-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)]/95 backdrop-blur-xl shadow-[var(--zephyr-shadow-md)] p-1 z-30">
-                                                    <button type="button" data-value="clash-verge/1.6.0" data-label="Clash Verge Rev" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">Clash Verge Rev</button>
-                                                    <button type="button" data-value="mihomo-party/1.0.0" data-label="mihomo-party" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">mihomo-party</button>
-                                                    <button type="button" data-value="Flclash/1.0.0" data-label="Flclash" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">Flclash</button>
-                                                    <button type="button" data-value="Shadowrocket/3.0.0" data-label="Shadowrocket" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">Shadowrocket</button>
-                                                    <button type="button" data-value="custom" data-label="Custom..." data-i18n="custom" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">Custom...</button>
+                                                <div id="fake-client-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                                                    <div class="menu-scroll">
+                                                        <button type="button" data-value="clash-verge/1.6.0" data-label="Clash Verge Rev" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Clash Verge Rev</button>
+                                                        <button type="button" data-value="mihomo-party/1.0.0" data-label="mihomo-party" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">mihomo-party</button>
+                                                        <button type="button" data-value="Flclash/1.0.0" data-label="Flclash" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Flclash</button>
+                                                        <button type="button" data-value="Shadowrocket/3.0.0" data-label="Shadowrocket" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Shadowrocket</button>
+                                                        <button type="button" data-value="custom" data-label="Custom..." data-i18n="custom" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Custom...</button>
+                                                    </div>
                                                 </div>
                                                 <select id="fake-client-select" class="hidden">
                                                     <option value="clash-verge/1.6.0">Clash Verge Rev</option>

--- a/apps/desktop/src/ui/global-shortcut.js
+++ b/apps/desktop/src/ui/global-shortcut.js
@@ -346,7 +346,10 @@ function addShortcutRow(t, actionId, existingAccelerator) {
     `;
 
     const dropdownMenu = document.createElement('div');
-    dropdownMenu.className = 'shortcut-dropdown-menu hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg p-1 z-30';
+    dropdownMenu.className = 'shortcut-dropdown-menu hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30';
+
+    const menuScroll = document.createElement('div');
+    menuScroll.className = 'menu-scroll max-h-[200px]';
 
     // Populate options: filter out already-bound actions when adding new row
     const currentShortcuts = loadShortcuts();
@@ -359,7 +362,7 @@ function addShortcutRow(t, actionId, existingAccelerator) {
         const opt = document.createElement('button');
         opt.type = 'button';
         opt.dataset.value = actionDef.id;
-        opt.className = 'dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] transition-colors';
+        opt.className = 'dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
         if (actionDef.id === actionId) opt.classList.add('active');
         opt.textContent = getActionLabel(actionDef.id, t);
         opt.addEventListener('click', () => {
@@ -369,8 +372,10 @@ function addShortcutRow(t, actionId, existingAccelerator) {
             dropdownMenu.classList.add('hidden');
             checkChanged();
         });
-        dropdownMenu.appendChild(opt);
+        menuScroll.appendChild(opt);
     }
+
+    dropdownMenu.appendChild(menuScroll);
 
     selectBtn.addEventListener('click', (e) => {
         e.stopPropagation();

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1119,7 +1119,7 @@ function renderGroupSelector(groups, currentGroup) {
     groups.forEach(groupName => {
         const btn = document.createElement('button');
         btn.type = 'button';
-btn.className = 'proxy-group-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
+        btn.className = 'proxy-group-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
         if (groupName === currentGroup) {
             btn.classList.add('active');
         }
@@ -1152,9 +1152,29 @@ btn.className = 'proxy-group-option w-full text-left px-3 py-2 rounded-[var(--ra
         menuScroll.appendChild(btn);
     });
 
+    // Store current group for mouseleave restore
+    menuScroll.dataset.currentGroup = currentGroup;
+
+    // Hover highlight: same behavior as initCustomDropdown
+    // mouseenter removes all active, highlights hovered item
+    menuScroll.querySelectorAll('.proxy-group-option').forEach(btn => {
+        btn.addEventListener('mouseenter', () => {
+            menuScroll.querySelectorAll('.proxy-group-option').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+        });
+    });
+
     // Initialize event listeners once
     if (!_groupSelectorInitialized) {
         _groupSelectorInitialized = true;
+
+        // mouseleave restores active on the current group (registered once)
+        menuScroll.addEventListener('mouseleave', () => {
+            const current = menuScroll.dataset.currentGroup;
+            menuScroll.querySelectorAll('.proxy-group-option').forEach(b => {
+                b.classList.toggle('active', b.textContent === current);
+            });
+        });
 
         // Toggle menu
         trigger.addEventListener('click', (e) => {

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -107,7 +107,7 @@ async function showEditPanel(configInfo) {
 
     // Build dropdown menu items (escape labels for XSS safety)
     const dropdownMenuItems = autoUpdateOptions.map(opt => 
-        `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(opt.label)}" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-primary)] transition-colors">${escapeHtml(opt.label)}</button>`
+        `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(opt.label)}" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">${escapeHtml(opt.label)}</button>`
     ).join('');
 
     // Remove any existing modal to prevent duplicate IDs
@@ -157,8 +157,10 @@ async function showEditPanel(configInfo) {
                             <span id="edit-auto-update-label">${escapeHtml(currentIntervalLabel)}</span>
                             <svg class="w-3.5 h-3.5 text-[var(--text-muted)] transition-transform duration-200 dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"></path></svg>
                         </button>
-                        <div id="edit-auto-update-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] backdrop-blur-xl shadow-[var(--zephyr-shadow-md)] p-1 z-30 w-40">
-                            ${dropdownMenuItems}
+                        <div id="edit-auto-update-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30 w-40">
+                            <div class="menu-scroll">
+                                ${dropdownMenuItems}
+                            </div>
                         </div>
                         <select id="edit-auto-update" class="hidden">
                             ${autoUpdateOptions.map(opt => `<option value="${opt.value}" ${opt.value === String(currentInterval) ? 'selected' : ''}>${escapeHtml(opt.label)}</option>`).join('')}


### PR DESCRIPTION
## Summary

Unify all dropdown menu styles to match the proxy group selector's visual style and hover behavior.

## Changes

- **Language & fake-client menus**: Replace `backdrop-blur-xl/95` + `shadow-md` + `p-1` with solid `bg-elevated` + `shadow-2xl` + `menu-scroll` wrapper (consistent padding via `--zephyr-dropdown-padding`)
- **Subscription auto-update menu**: Same treatment
- **Global shortcut action menu**: Add border/bg/shadow + `menu-scroll` wrapper
- **Proxy group selector**: Add `mouseenter`/`mouseleave` hover highlight matching `initCustomDropdown` behavior (hover removes other active states, mouseleave restores current selection)
- **Menu item text color**: Unified to `text-secondary` + `hover:bg-muted`

## Files Changed

- `apps/desktop/src/index.html` — Language & fake-client menu HTML
- `apps/desktop/src/ui/global-shortcut.js` — Shortcut action menu
- `apps/desktop/src/ui/settings/subscriptions.js` — Auto-update menu
- `apps/desktop/src/ui/proxies.js` — Proxy group selector hover behavior