### PR TITLE
chore: add FUNDING.yml and fix window recreate error code

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Juwan-Hwang

--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -209,6 +209,7 @@ pub mod codes {
     pub const SYS_TUN_FAILED: u16 = 6002;
     pub const SYS_DNS_FAILED: u16 = 6003;
     pub const SYS_LOCK_FAILED: u16 = 6004;
+    pub const SYS_WINDOW_RECREATE_FAILED: u16 = 6005;
 
     // Updater: 7000-7999
     pub const UPDATE_CHECK_FAILED: u16 = 7001;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -452,7 +452,7 @@ fn show_main_window(app: tauri::AppHandle) {
                 eprintln!("Failed to recreate main window: {e}");
                 emit_error!(
                     System,
-                    SYS_PROXY_FAILED,
+                    SYS_WINDOW_RECREATE_FAILED,
                     "Failed to recreate main window: {e}"
                 );
             }


### PR DESCRIPTION
## Changes

- Add `.github/FUNDING.yml` to enable GitHub Sponsors button on the repository
- Add `SYS_WINDOW_RECREATE_FAILED` (6005) error code for window recreation failures, replacing the incorrect `SYS_PROXY_FAILED` (6001) that was semantically wrong