### PR TITLE
chore: add Husky git hooks and DevContainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Zephyr Dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "stable"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tauri-apps.tauri-vscode",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  libappindicator3-dev \
+  librsvg2-dev \
+  patchelf \
+  build-essential \
+  pkg-config \
+  libssl-dev \
+  libgtk-3-dev \
+  libayatana-appindicator3-dev
+
+corepack enable
+
+pnpm install

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+cargo fmt --check --all
+pnpm lint
+pnpm typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+cargo clippy --all-targets -- -D warnings
+cargo test
+pnpm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck",
     "tauri": "pnpm --filter @zephyr/desktop tauri",
-    "check:i18n": "node packages/scripts/check-i18n.js"
+    "check:i18n": "node packages/scripts/check-i18n.js",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@tailwindcss/cli": "4.3.0",
@@ -20,6 +21,7 @@
     "eslint": "10.4.0",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",
+    "husky": "^9.1.7",
     "style-dictionary": "^5.4.2",
     "tailwindcss": "4.3.0",
     "typescript": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       style-dictionary:
         specifier: ^5.4.2
         version: 5.4.2(tslib@2.8.1)
@@ -1217,6 +1220,11 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
@@ -2815,6 +2823,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  husky@9.1.7: {}
 
   hyperdyperid@1.2.0: {}
 


### PR DESCRIPTION
## Changes

### Husky Git Hooks
- **pre-commit**: `cargo fmt --check`, `pnpm lint`, `pnpm typecheck` (fast, ~seconds)
- **pre-push**: `cargo clippy`, `cargo test`, `pnpm test` (slower, ~tens of seconds)
- Hooks are installed automatically via `pnpm install` (prepare script)
- Both hooks use `set -e` to fail fast on any error

### DevContainer
- Ubuntu 22.04 base image with Rust stable + Node.js LTS
- Installs all Tauri system dependencies (webkit2gtk, GTK3, etc.)
- Configures pnpm via corepack (reads version from packageManager in package.json)
- Runs `pnpm install` on container creation
- VS Code extensions: rust-analyzer, tauri-vscode, eslint, tailwindcss

## Why

- **Husky**: Catches formatting/lint/test errors locally before they reach CI, saving CI time and reducing failed builds
- **DevContainer**: Enables one-click dev environment setup for new contributors -- no manual toolchain installation needed