### PR TITLE
feat: add Minisign Ed25519 signature verification for client updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,6 +394,36 @@ jobs:
           cd portable && tar czf ../dist-artifacts/Zephyr-linux-portable.tar.gz . && cd ..
         shell: bash
 
+      # ── Minisign: sign all release artifacts ──
+      - name: Install minisign
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y minisign
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install minisign
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install minisign
+          fi
+        shell: bash
+
+      - name: Sign release artifacts
+        run: |
+          # Write private key to temp file (minisign requires a file path)
+          KEY_FILE=$(mktemp)
+          printf '%s' "${{ secrets.MINISIGN_PRIVATE_KEY }}" > "$KEY_FILE"
+          trap 'rm -f "$KEY_FILE"' EXIT
+
+          shopt -s nullglob
+          for f in dist-artifacts/*; do
+            if [ -f "$f" ] && [ ! -f "${f}.minisig" ]; then
+              echo "Signing $(basename "$f")..."
+              minisign -S -s "$KEY_FILE" -m "$f" -x "${f}.minisig" -W
+            fi
+          done
+          echo "Signed artifacts:"
+          ls -la dist-artifacts/*.minisig 2>/dev/null || echo "No signatures generated"
+        shell: bash
+
       - name: Upload All Release Assets
         uses: softprops/action-gh-release@v2
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "glib 0.22.7",
  "hex",
  "hmac",
+ "minisign",
  "mockall",
  "pbkdf2",
  "rand 0.10.1",
@@ -1064,6 +1065,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
 name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,11 +1863,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2937,6 +2946,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aefd422a7a8b5efced01cd7cdf3771e62ebecbc90e3d27695002d3af6af94586"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.4.2",
+ "rpassword",
+ "scrypt",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -4104,6 +4125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rquickjs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,6 +4163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4249,6 +4291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,6 +4392,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ clash-prism-smart = "0.1.1"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "1.1"
 dashmap = "6.0"
+minisign = "0.9"
 
 [target.'cfg(unix)'.dependencies]
 # Force upgrade glib to address known vulnerability (indirect dep via webkit2gtk/gtk on Linux/macOS)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod core_event_bridge;
 pub mod core_manager;
 pub mod deep_link;
 pub mod global_shortcut;
+pub mod minisign_verify;
 pub mod os_notification;
 pub mod prism;
 pub mod sys_proxy;

--- a/apps/desktop/src-tauri/src/minisign_verify.rs
+++ b/apps/desktop/src-tauri/src/minisign_verify.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+/// Hardcoded Minisign Ed25519 public key for verifying Zephyr release signatures.
+const ZEPHYR_PUBLIC_KEY: &str = "RWRkVQqGWolsGBbhZRpFQ3sPG/i4A2dGlf2E0NXJvZAviVd/I+sUzw1Z";
+
+/// Verify a Minisign Ed25519 signature against a file.
+///
+/// # Arguments
+/// * `file_path` - Path to the file whose signature is being verified.
+/// * `signature_content` - The full content of the `.minisig` signature file.
+///
+/// # Errors
+/// Returns an error string if the public key cannot be parsed, the signature
+/// cannot be decoded, the file cannot be read, or the signature verification fails.
+pub fn verify_minisign_signature(file_path: &Path, signature_content: &str) -> Result<(), String> {
+    let public_key = minisign::PublicKey::from_base64(ZEPHYR_PUBLIC_KEY)
+        .map_err(|e| format!("Failed to parse Minisign public key: {e}"))?;
+
+    let signature_box = minisign::SignatureBox::from_string(signature_content)
+        .map_err(|e| format!("Failed to decode Minisign signature: {e}"))?;
+
+    let mut file = std::fs::File::open(file_path)
+        .map_err(|e| format!("Failed to open file for signature verification: {e}"))?;
+
+    // We need to read the file content and provide it to verify.
+    // minisign::verify requires Read + Seek, and File implements both.
+    minisign::verify(&public_key, &signature_box, &mut file, true, false, false)
+        .map_err(|e| format!("Minisign signature verification failed: {e}"))?;
+
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -1198,7 +1198,38 @@ pub async fn update_client(window: Window) -> Result<String, String> {
         );
     }
 
-    emit_core_download_status(&window, "Opening installer...", 95);
+    // Verify Minisign Ed25519 signature
+    let minisig_url = format!("{}.minisig", info.download_url);
+    emit_core_download_status(&window, "Downloading signature...", 94);
+
+    let sig_client = build_github_client()?;
+    let sig_response = sig_client.get(&minisig_url).send().await.map_err(|e| {
+        let _ = std::fs::remove_file(&dest_path);
+        format!("Failed to download signature: {e}. Installer deleted for security.")
+    })?;
+
+    if !sig_response.status().is_success() {
+        let _ = std::fs::remove_file(&dest_path);
+        return Err(
+            "Minisign signature not available for this release. Installer was deleted for security."
+                .to_owned(),
+        );
+    }
+
+    let signature_content = sig_response.text().await.map_err(|e| {
+        let _ = std::fs::remove_file(&dest_path);
+        format!("Failed to read signature content: {e}. Installer deleted for security.")
+    })?;
+
+    emit_core_download_status(&window, "Verifying signature...", 95);
+    crate::minisign_verify::verify_minisign_signature(&dest_path, &signature_content).map_err(
+        |e| {
+            let _ = std::fs::remove_file(&dest_path);
+            format!("{e}. Installer deleted for security.")
+        },
+    )?;
+
+    emit_core_download_status(&window, "Opening installer...", 96);
 
     // Open the installer with the system default application
     tauri_plugin_opener::open_path(&dest_path, None::<&str>)

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -1216,9 +1216,26 @@ pub async fn update_client(window: Window) -> Result<String, String> {
         );
     }
 
-    let signature_content = sig_response.text().await.map_err(|e| {
+    // Stream signature with size limit (4 KB is more than enough for a Minisign signature)
+    let mut sig_stream = sig_response.bytes_stream();
+    let mut sig_bytes = Vec::new();
+    const MAX_SIG_SIZE: usize = 4096;
+    while let Some(chunk_result) = sig_stream.next().await {
+        let chunk = chunk_result.map_err(|e| {
+            let _ = std::fs::remove_file(&dest_path);
+            format!("Failed to download signature chunk: {e}. Installer deleted for security.")
+        })?;
+        if sig_bytes.len() + chunk.len() > MAX_SIG_SIZE {
+            let _ = std::fs::remove_file(&dest_path);
+            return Err(
+                "Signature file exceeded size limit. Installer deleted for security.".to_owned(),
+            );
+        }
+        sig_bytes.extend_from_slice(&chunk);
+    }
+    let signature_content = String::from_utf8(sig_bytes).map_err(|e| {
         let _ = std::fs::remove_file(&dest_path);
-        format!("Failed to read signature content: {e}. Installer deleted for security.")
+        format!("Invalid UTF-8 in signature: {e}. Installer deleted for security.")
     })?;
 
     emit_core_download_status(&window, "Verifying signature...", 95);


### PR DESCRIPTION
## Summary

Add cryptographic signature verification to the auto-update flow using Minisign (Ed25519). After SHA256 hash verification, the updater now downloads a `.minisig` signature file and verifies it against a hardcoded public key before allowing installation.

## Changes

- **New module `minisign_verify.rs`**: Verifies Minisign Ed25519 signatures against a hardcoded public key (`RWRkVQqGWolsGBbhZRpFQ3sPG/i4A2dGlf2E0NXJvZAviVd/I+sUzw1Z`)
- **Modified `updater.rs`**: After SHA256 verification, streams `.minisig` file with a 4 KB size limit and verifies signature. If missing, too large, or invalid, deletes the installer for security.
- **Modified `release.yml`**: Added CI steps to install minisign and sign all release artifacts using `MINISIGN_PRIVATE_KEY` secret
- **Added `minisign` crate dependency** (v0.9)

## Security Model

- Public key is hardcoded in the binary (cannot be modified without recompilation)
- Private key is stored as `MINISIGN_PRIVATE_KEY` GitHub repository secret
- Signature download is streamed with a 4 KB size limit to prevent OOM attacks
- Signature verification failure → installer is deleted, update is rejected
- No signature available for a release → installer is deleted, update is rejected

## Post-merge Action Required

Add the Minisign private key to GitHub repository Secrets:
- Key name: `MINISIGN_PRIVATE_KEY`
- Value: Contents of the generated private key file