### PR TITLE
feat: add mihomo -t config preflight check before core startup

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1324,20 +1324,27 @@ pub async fn start_core(
     // This catches syntax errors, missing proxy references, etc. early and prevents
     // the core from entering a crash-restart loop due to an invalid config.
     {
-        let mut cmd = Command::new(&exe_path);
-        #[cfg(target_os = "windows")]
-        use std::os::windows::process::CommandExt as _;
-        #[cfg(target_os = "windows")]
-        cmd.creation_flags(CREATE_NO_WINDOW);
-        cmd.current_dir(&paths.core_dir);
-        cmd.args(["-d", "."]);
-        cmd.args(["-t", "-f", "run_config.yaml"]);
-        for arg in &safe_custom_args {
-            cmd.arg(arg);
-        }
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Preflight check failed to execute: {e}"))?;
+        let exe_path_clone = exe_path.clone();
+        let core_dir_clone = paths.core_dir.clone();
+        let safe_custom_args_clone = safe_custom_args.clone();
+        let output = tokio::task::spawn_blocking(move || {
+            let mut cmd = Command::new(&exe_path_clone);
+            #[cfg(target_os = "windows")]
+            use std::os::windows::process::CommandExt as _;
+            #[cfg(target_os = "windows")]
+            cmd.creation_flags(CREATE_NO_WINDOW);
+            cmd.current_dir(&core_dir_clone);
+            cmd.args(["-d", "."]);
+            cmd.args(["-t", "-f", "run_config.yaml"]);
+            for arg in &safe_custom_args_clone {
+                cmd.arg(arg);
+            }
+            cmd.output()
+        })
+        .await
+        .map_err(|e| format!("Preflight check task panicked: {e}"))?
+        .map_err(|e| format!("Preflight check failed to execute: {e}"))?;
+
         if !output.status.success() {
             let err_msg = redact_error_message(&String::from_utf8_lossy(&output.stderr));
             emit_error!(

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1329,7 +1329,12 @@ pub async fn start_core(
         use std::os::windows::process::CommandExt as _;
         #[cfg(target_os = "windows")]
         cmd.creation_flags(CREATE_NO_WINDOW);
-        cmd.args(["-t", "-f"]).arg(&run_config_path);
+        cmd.current_dir(&paths.core_dir);
+        cmd.args(["-d", "."]);
+        cmd.args(["-t", "-f", "run_config.yaml"]);
+        for arg in &safe_custom_args {
+            cmd.arg(arg);
+        }
         let output = cmd
             .output()
             .map_err(|e| format!("Preflight check failed to execute: {e}"))?;

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1326,6 +1326,8 @@ pub async fn start_core(
     {
         let mut cmd = Command::new(&exe_path);
         #[cfg(target_os = "windows")]
+        use std::os::windows::process::CommandExt as _;
+        #[cfg(target_os = "windows")]
         cmd.creation_flags(CREATE_NO_WINDOW);
         cmd.args(["-t", "-f"]).arg(&run_config_path);
         let output = cmd

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1320,6 +1320,30 @@ pub async fn start_core(
     let run_config_path = paths.core_dir.join("run_config.yaml");
     write_file_secure(&run_config_path, &final_config)?;
 
+    // Preflight: validate config with `mihomo -t` before spawning the process.
+    // This catches syntax errors, missing proxy references, etc. early and prevents
+    // the core from entering a crash-restart loop due to an invalid config.
+    {
+        let mut cmd = Command::new(&exe_path);
+        #[cfg(target_os = "windows")]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd.args(["-t", "-f"]).arg(&run_config_path);
+        let output = cmd
+            .output()
+            .map_err(|e| format!("Preflight check failed to execute: {e}"))?;
+        if !output.status.success() {
+            let err_msg = redact_error_message(&String::from_utf8_lossy(&output.stderr));
+            emit_error!(
+                Config,
+                CONFIG_PARSE_FAILED,
+                "Config preflight failed: {err_msg}"
+            );
+            return Err(format!(
+                "Config preflight check failed. The config file has errors and the core will not be started. Details: {err_msg}"
+            ));
+        }
+    }
+
     // Debug: show mihomo processes before spawn
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## Summary

Add a config preflight check using `mihomo -t` before spawning the mihomo process. After writing `run_config.yaml` but before starting the core, run `mihomo -t -f run_config.yaml` to validate the config. If validation fails, the core is not started and the error is reported to the user.

## Changes

- **Modified `core_process.rs`**: Added preflight check block between `write_file_secure()` and `spawn_with_cache_retry()` in `start_core()`. The preflight uses the same working directory (`core_dir`), `-d .`, and custom args as the actual spawn to ensure mihomo can find resources like `Country.mmdb`.

## Why

Without this check, an invalid config (syntax errors, missing proxy references, etc.) causes mihomo to crash immediately, potentially entering a crash-restart loop. The preflight check catches these errors early and provides a clear error message instead.