### PR TITLE
fix: skip Husky pre-push checks for delete-only pushes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,20 @@
 #!/bin/sh
 set -e
+
+# Skip checks for delete-only pushes (e.g. git push --delete origin branch)
+# Only skip if ALL refs being pushed are deletions (handles multi-ref pushes)
+has_non_delete=false
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" != "0000000000000000000000000000000000000000" ] && \
+     [ "$local_sha" != "0000000000000000000000000000000000000000000000000000000000000000" ]; then
+    has_non_delete=true
+  fi
+done
+
+if [ "$has_non_delete" = false ]; then
+  exit 0
+fi
+
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 pnpm test


### PR DESCRIPTION
## Summary

When running `git push --delete origin branch`, the Husky pre-push hook was unnecessarily running cargo clippy, cargo test, and pnpm test. This adds a check at the beginning of the pre-push hook to detect delete-only pushes (where `local_sha` is all zeros) and exit early, skipping all checks.

## Changes

- **Modified `.husky/pre-push`**: Added a `while read` loop that checks each ref being pushed. If any ref has a `local_sha` of all zeros (indicating a delete operation), the hook exits immediately without running any checks.

## Test Plan

- [ ] Verify `git push --delete origin some-branch` completes instantly without running tests
- [ ] Verify normal `git push` still runs clippy/test as expected