### PR TITLE
fix: skip Husky pre-push checks for delete-only pushes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,24 @@
 #!/bin/sh
 set -e
+
+# Skip checks for delete-only pushes (e.g. git push --delete origin branch)
+# Only skip if ALL refs being pushed are deletions (handles multi-ref pushes)
+has_non_delete=false
+if [ -t 0 ]; then
+  has_non_delete=true
+else
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    if [ "$local_sha" != "0000000000000000000000000000000000000000" ] && \
+       [ "$local_sha" != "0000000000000000000000000000000000000000000000000000000000000000" ]; then
+      has_non_delete=true
+    fi
+  done
+fi
+
+if [ "$has_non_delete" = false ]; then
+  exit 0
+fi
+
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 pnpm test


### PR DESCRIPTION
## Summary

When running `git push --delete origin branch`, the Husky pre-push hook was unnecessarily running cargo clippy, cargo test, and pnpm test. This adds a check at the beginning of the pre-push hook to detect delete-only pushes and exit early, skipping all checks.

## Changes

- **Modified `.husky/pre-push`**: Added a `while read` loop that reads all refs being pushed. Only exits early if ALL refs are deletions (handles multi-ref pushes like `git push origin :branch1 branch2`). Supports both SHA-1 (40-char) and SHA-256 (64-char) zero hashes.

## Test Plan

- [ ] Verify `git push --delete origin some-branch` completes instantly without running tests
- [ ] Verify normal `git push` still runs clippy/test as expected
- [ ] Verify multi-ref push with mixed delete+push still runs checks