### PR TITLE
fix: tray sysproxy state, proxy port, i18n, and settings toggle sync

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "core:tray:default",
     "core:resources:default",
     "core:app:default",
-    "dialog:allow-message"
+    "dialog:allow-message",
+    "notification:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -17,7 +17,7 @@ use crate::{emit_error, emit_info, emit_warn};
 use zephyr_core::config::sanitizer::{sanitize_config_file_name, validate_path_within_dir};
 
 const DEFAULT_API_PORT: u16 = 9090;
-const DEFAULT_MIXED_PORT: u16 = 7890;
+pub const DEFAULT_MIXED_PORT: u16 = 7890;
 #[cfg(target_os = "macos")]
 const PORT_WAIT_MAX_RETRIES: u64 = 50;
 #[cfg(target_os = "macos")]
@@ -619,6 +619,28 @@ fn parse_external_controller_port(yaml_val: &serde_yaml::Value) -> u16 {
         .unwrap_or(DEFAULT_API_PORT)
 }
 
+/// Parse the proxy port from YAML config.
+/// Checks `mixed-port`, `port`, `socks-port` in order (same logic as frontend).
+fn parse_proxy_port(yaml_val: &serde_yaml::Value) -> u16 {
+    yaml_val
+        .get("mixed-port")
+        .and_then(serde_yaml::Value::as_u64)
+        .and_then(|p| u16::try_from(p).ok())
+        .or_else(|| {
+            yaml_val
+                .get("port")
+                .and_then(serde_yaml::Value::as_u64)
+                .and_then(|p| u16::try_from(p).ok())
+        })
+        .or_else(|| {
+            yaml_val
+                .get("socks-port")
+                .and_then(serde_yaml::Value::as_u64)
+                .and_then(|p| u16::try_from(p).ok())
+        })
+        .unwrap_or(DEFAULT_MIXED_PORT)
+}
+
 fn validate_custom_args(custom_args: &[String]) -> Result<Vec<String>, String> {
     let mut safe_custom_args = Vec::with_capacity(custom_args.len());
 
@@ -677,13 +699,14 @@ pub fn prepare_runtime_config(
     content: &str,
     secret: &str,
     prefs: Option<&GlobalPreferences>,
-) -> Option<(String, u16)> {
+) -> Option<(String, u16, u16)> {
     let mut yaml_val = serde_yaml::from_str::<serde_yaml::Value>(content).ok()?;
     if !yaml_val.is_mapping() {
         return None;
     }
 
     let config_port = parse_external_controller_port(&yaml_val);
+    let proxy_port = parse_proxy_port(&yaml_val);
     if let Some(mapping) = yaml_val.as_mapping_mut() {
         mapping.insert(
             serde_yaml::Value::String("external-controller".to_owned()),
@@ -845,15 +868,16 @@ pub fn prepare_runtime_config(
 
     let result = serde_yaml::to_string(&yaml_val).ok()?;
 
-    Some((result, config_port))
+    Some((result, config_port, proxy_port))
 }
 
-fn build_minimal_runtime_config(secret: &str) -> (String, u16) {
+fn build_minimal_runtime_config(secret: &str) -> (String, u16, u16) {
     (
         format!(
             "mixed-port: {DEFAULT_MIXED_PORT}\nmode: rule\nlog-level: info\nunified-delay: true\ntcp-concurrent: true\nkeep-alive-interval: 30\nkeep-alive-idle: 600\nfind-process-mode: always\nprofile:\n  store-fake-ip: true\nexternal-controller: 127.0.0.1:9090\nsecret: {secret}\nproxies: []\nproxy-groups:\n  - name: GLOBAL\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n"
         ),
         DEFAULT_API_PORT,
+        DEFAULT_MIXED_PORT,
     )
 }
 
@@ -863,21 +887,26 @@ fn select_runtime_config(
     preferred_path: &Path,
     secret: &str,
     prefs: Option<&GlobalPreferences>,
-) -> Result<(Option<String>, String, u16), String> {
+) -> Result<(Option<String>, String, u16, u16), String> {
     let preferred_content =
         fs::read_to_string(preferred_path).map_err(|e| format!("Failed to read config: {e}"))?;
-    if let Some((final_config, config_port)) =
+    if let Some((final_config, config_port, proxy_port)) =
         prepare_runtime_config(&preferred_content, secret, prefs)
     {
-        return Ok((Some(preferred_name.to_owned()), final_config, config_port));
+        return Ok((
+            Some(preferred_name.to_owned()),
+            final_config,
+            config_port,
+            proxy_port,
+        ));
     }
 
     let mut fallback_profiles = Vec::new();
     let entries = if let Ok(entries) = fs::read_dir(&paths.profiles_dir) {
         entries
     } else {
-        let (config, port) = build_minimal_runtime_config(secret);
-        return Ok((None, config, port));
+        let (config, api_port, proxy_port) = build_minimal_runtime_config(secret);
+        return Ok((None, config, api_port, proxy_port));
     };
 
     for entry in entries.flatten() {
@@ -904,7 +933,9 @@ fn select_runtime_config(
             Ok(content) => content,
             Err(_) => continue,
         };
-        if let Some((final_config, config_port)) = prepare_runtime_config(&content, secret, prefs) {
+        if let Some((final_config, config_port, proxy_port)) =
+            prepare_runtime_config(&content, secret, prefs)
+        {
             let file_name = path
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -915,7 +946,7 @@ fn select_runtime_config(
                 CONFIG_PARSE_FAILED,
                 "Requested config {preferred_name} is not valid, falling back to {file_name}"
             );
-            return Ok((Some(file_name), final_config, config_port));
+            return Ok((Some(file_name), final_config, config_port, proxy_port));
         }
     }
 
@@ -924,8 +955,8 @@ fn select_runtime_config(
         CONFIG_PARSE_FAILED,
         "Requested config {preferred_name} is not valid, falling back to minimal config"
     );
-    let (final_config, config_port) = build_minimal_runtime_config(secret);
-    Ok((None, final_config, config_port))
+    let (final_config, api_port, proxy_port) = build_minimal_runtime_config(secret);
+    Ok((None, final_config, api_port, proxy_port))
 }
 
 pub fn get_core_exe_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -1309,7 +1340,7 @@ pub async fn start_core(
         Some(settings.to_global_prefs())
     };
 
-    let (active_config_name, final_config, config_port) = select_runtime_config(
+    let (active_config_name, final_config, config_port, proxy_port) = select_runtime_config(
         &paths,
         &resolved_config_name,
         &resolved_config_path,
@@ -1410,6 +1441,7 @@ pub async fn start_core(
     lock.set_last_config_path(active_config_name);
     lock.set_last_custom_args(Some(safe_custom_args));
     lock.set_last_port(Some(port));
+    lock.set_last_proxy_port(Some(proxy_port));
     lock.set_last_log_path(Some(log_path.to_string_lossy().into_owned()));
     drop(lock);
 
@@ -1428,6 +1460,7 @@ pub fn stop_core_inner(app: &AppHandle, state: &MihomoState) -> Result<(), Strin
             .lock()
             .map_err(|e| format!("Failed to lock state: {e}"))?;
         lock.set_last_port(None);
+        lock.set_last_proxy_port(None);
         lock.take_process()
     };
 
@@ -1494,9 +1527,10 @@ mod tests {
     #[test]
     fn prepare_runtime_config_injects_secret_and_controller() {
         let config = "external-controller: 0.0.0.0:7897\nsecret: old\nmode: rule\n";
-        let (prepared, port) = prepare_runtime_config(config, "new-secret", None).unwrap();
+        let (prepared, api_port, _proxy_port) =
+            prepare_runtime_config(config, "new-secret", None).unwrap();
 
-        assert_eq!(port, 7897);
+        assert_eq!(api_port, 7897);
         assert!(prepared.contains("external-controller: 127.0.0.1:7897"));
         assert!(prepared.contains("secret: new-secret"));
         assert!(!prepared.contains("secret: old"));
@@ -1524,7 +1558,7 @@ mod tests {
         let content = "port: 7890\nmode: rule";
         let result = prepare_runtime_config(content, "mysecret", None);
         assert!(result.is_some());
-        let (config, port) = result.unwrap();
+        let (config, port, _) = result.unwrap();
         assert_eq!(port, 9090);
         assert!(config.contains("external-controller: 127.0.0.1:9090"));
         assert!(config.contains("secret: mysecret"));
@@ -1541,7 +1575,7 @@ mod tests {
         let content = "external-controller: 0.0.0.0:8080\nport: 7890";
         let result = prepare_runtime_config(content, "secret", None);
         assert!(result.is_some());
-        let (config, port) = result.unwrap();
+        let (config, port, _) = result.unwrap();
         assert_eq!(port, 8080);
         assert!(config.contains("external-controller: 127.0.0.1:8080"));
     }
@@ -1551,7 +1585,7 @@ mod tests {
         let content = "unified-delay: false\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("unified-delay: false"));
         assert_eq!(config.matches("unified-delay").count(), 1);
     }
@@ -1561,7 +1595,7 @@ mod tests {
         let content = "tcp-concurrent: false\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("tcp-concurrent: false"));
         assert_eq!(config.matches("tcp-concurrent").count(), 1);
     }
@@ -1571,7 +1605,7 @@ mod tests {
         let content = "keep-alive-interval: 60\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("keep-alive-interval: 60"));
         assert_eq!(config.matches("keep-alive-interval").count(), 1);
     }
@@ -1581,7 +1615,7 @@ mod tests {
         let content = "find-process-mode: off\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("find-process-mode: off"));
         assert_eq!(config.matches("find-process-mode").count(), 1);
     }
@@ -1591,7 +1625,7 @@ mod tests {
         let content = "keep-alive-idle: 300\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("keep-alive-idle: 300"));
         assert_eq!(config.matches("keep-alive-idle").count(), 1);
     }
@@ -1601,7 +1635,7 @@ mod tests {
         let content = "profile:\n  store-fake-ip: false\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("store-fake-ip: false"));
         assert_eq!(config.matches("store-fake-ip").count(), 1);
     }
@@ -1612,7 +1646,7 @@ mod tests {
         let content = "profile:\nport: 7890";
         let result = prepare_runtime_config(content, "s", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("store-fake-ip: true"));
     }
 
@@ -1631,7 +1665,7 @@ mod tests {
         let content = "port: 7890";
         let result = prepare_runtime_config(content, "", None);
         assert!(result.is_some());
-        let (config, _) = result.unwrap();
+        let (config, _, _) = result.unwrap();
         assert!(config.contains("secret: "));
     }
 
@@ -1644,7 +1678,7 @@ mod tests {
             mode: Some("global".to_owned()),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("mode: global"));
         assert!(!config.contains("mode: rule"));
     }
@@ -1653,7 +1687,7 @@ mod tests {
     fn test_prefs_none_does_not_override() {
         let content = "mode: rule\nport: 7890";
         let prefs = GlobalPreferences::default();
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("mode: rule"));
     }
 
@@ -1664,7 +1698,7 @@ mod tests {
             tun_enabled: Some(true),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("enable: true"));
     }
 
@@ -1675,7 +1709,7 @@ mod tests {
             tun_enabled: Some(true),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("tun:\n  enable: true"));
     }
 
@@ -1686,7 +1720,7 @@ mod tests {
             mixed_port: Some(9090),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("mixed-port: 9090"));
     }
 
@@ -1697,7 +1731,7 @@ mod tests {
             socks_port: Some(1080),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("socks-port: 1080"));
     }
 
@@ -1708,7 +1742,7 @@ mod tests {
             http_port: Some(8080),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("port: 8080"));
     }
 
@@ -1719,7 +1753,7 @@ mod tests {
             ipv6: Some(true),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("ipv6: true"));
     }
 
@@ -1730,7 +1764,7 @@ mod tests {
             allow_lan: Some(true),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("allow-lan: true"));
     }
 
@@ -1741,7 +1775,7 @@ mod tests {
             unified_delay: Some(true),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("unified-delay: true"));
     }
 
@@ -1755,7 +1789,7 @@ mod tests {
             mixed_port: Some(7892),
             ..Default::default()
         };
-        let (config, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
+        let (config, _, _) = prepare_runtime_config(content, "s", Some(&prefs)).unwrap();
         assert!(config.contains("mode: direct"));
         assert!(config.contains("ipv6: true"));
         assert!(config.contains("allow-lan: true"));

--- a/apps/desktop/src-tauri/src/core/mod.rs
+++ b/apps/desktop/src-tauri/src/core/mod.rs
@@ -37,6 +37,7 @@ pub struct CoreData {
     last_config_path: Option<String>,
     last_custom_args: Option<Vec<String>>,
     last_port: Option<u16>,
+    last_proxy_port: Option<u16>,
     last_log_path: Option<String>,
 }
 
@@ -55,6 +56,7 @@ impl CoreData {
             last_config_path: None,
             last_custom_args: None,
             last_port: None,
+            last_proxy_port: None,
             last_log_path: None,
         }
     }
@@ -87,6 +89,10 @@ impl CoreData {
         self.last_port
     }
     #[must_use]
+    pub const fn last_proxy_port(&self) -> Option<u16> {
+        self.last_proxy_port
+    }
+    #[must_use]
     pub fn last_log_path(&self) -> Option<&str> {
         self.last_log_path.as_deref()
     }
@@ -105,6 +111,9 @@ impl CoreData {
     }
     pub const fn set_last_port(&mut self, p: Option<u16>) {
         self.last_port = p;
+    }
+    pub const fn set_last_proxy_port(&mut self, p: Option<u16>) {
+        self.last_proxy_port = p;
     }
     pub fn set_last_log_path(&mut self, p: Option<String>) {
         self.last_log_path = p;
@@ -157,7 +166,7 @@ pub use config_manager::{
 pub use core_log::read_core_log;
 pub use core_process::{
     core_binary_name, ensure_app_storage, ensure_executable, get_core_exe_path, get_core_version,
-    kill_mihomo, resolve_app_paths, start_core, stop_core, stop_core_inner,
+    kill_mihomo, resolve_app_paths, start_core, stop_core, stop_core_inner, DEFAULT_MIXED_PORT,
 };
 pub use crypto::is_machine_key_persisted;
 pub use secure_io::write_file_secure;

--- a/apps/desktop/src-tauri/src/core_manager.rs
+++ b/apps/desktop/src-tauri/src/core_manager.rs
@@ -55,6 +55,7 @@ pub use core::{
     ReadLogResult,
     // Constants
     CORE_STARTING,
+    DEFAULT_MIXED_PORT,
     MAX_RESPONSE_SIZE,
     TUN_MODE_ACTIVE,
     TUN_TOGGLING,

--- a/apps/desktop/src-tauri/src/prism/commands_core.rs
+++ b/apps/desktop/src-tauri/src/prism/commands_core.rs
@@ -277,7 +277,7 @@ pub async fn prism_rebuild(
 
             // Use prepare_runtime_config to inject secret + external-controller
             // into the raw profile, just like start_core does.
-            let (prepared, _port) = core_process::prepare_runtime_config(
+            let (prepared, _api_port, _proxy_port) = core_process::prepare_runtime_config(
                 &raw_profile,
                 &current_secret,
                 global_prefs.as_ref(),

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -288,9 +288,10 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
 
 fn toggle_sys_proxy(app: &AppHandle) {
     let current = sys_proxy::get_sys_proxy().unwrap_or(false);
+    let new_state = !current;
 
-    if current {
-        let _ = sys_proxy::disable_sysproxy();
+    let result = if current {
+        sys_proxy::disable_sysproxy()
     } else {
         // Get the current proxy port from core state
         let state = app.state::<MihomoState>();
@@ -300,11 +301,37 @@ fn toggle_sys_proxy(app: &AppHandle) {
             .map(|guard| guard.last_port().unwrap_or(7890))
             .unwrap_or(7890);
         let server = format!("127.0.0.1:{port}");
-        let _ = sys_proxy::enable_sysproxy(server, None);
+        sys_proxy::enable_sysproxy(server, None)
+    };
+
+    if let Err(e) = result {
+        eprintln!("Failed to toggle system proxy: {e}");
+        // Operation failed — do not update state, rebuild menu with current state
+        rebuild_tray_menu_from_state(app);
+        return;
     }
 
-    // Emit event to frontend
-    crate::backend_event::emit_to_main(app, "tray-sysproxy-changed", !current);
+    // Operation succeeded — update tray state, icon, and menu
+    let tun_enabled = if let Ok(mut guard) = app.state::<TrayState>().0.lock() {
+        guard.sys_proxy_enabled = new_state;
+        guard.tun_enabled
+    } else {
+        false
+    };
+
+    let icon_mode = if tun_enabled {
+        "tun"
+    } else if new_state {
+        "sysproxy"
+    } else {
+        "default"
+    };
+    let _ = change_tray_icon(app.clone(), icon_mode.to_owned());
+
+    rebuild_tray_menu_from_state(app);
+
+    // Also emit to frontend (will be ignored if no WebView, which is fine)
+    crate::backend_event::emit_to_main(app, "tray-sysproxy-changed", new_state);
 }
 
 fn toggle_tun(app: &AppHandle) {
@@ -523,4 +550,115 @@ pub fn update_tray_toggle_states(
     }
 
     Ok(())
+}
+
+/// Rebuild tray menu from current TrayState (works without WebView/frontend).
+/// Used when tray operations happen in lightweight mode or when the frontend
+/// is not available to provide full menu data.
+#[allow(clippy::doc_markdown)]
+fn rebuild_tray_menu_from_state(app: &AppHandle) {
+    let tray_state = app.state::<TrayState>();
+    let (sys_on, tun_on, mode) = tray_state
+        .0
+        .lock()
+        .map(|guard| {
+            (
+                guard.sys_proxy_enabled,
+                guard.tun_enabled,
+                guard.current_mode.clone(),
+            )
+        })
+        .unwrap_or_else(|_| (false, false, "rule".to_owned()));
+
+    let tray = match app.tray_by_id("main") {
+        Some(t) => t,
+        None => return,
+    };
+
+    let show_i = match MenuItem::with_id(app, "show", "Show Zephyr", true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+    let sep1 = match PredefinedMenuItem::separator(app) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let sys_label = if sys_on {
+        "● System Proxy".to_owned()
+    } else {
+        "○ System Proxy".to_owned()
+    };
+    let sys_i = match MenuItem::with_id(app, "toggle_sysproxy", &sys_label, true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
+    let tun_label = if tun_on {
+        "● TUN Mode".to_owned()
+    } else {
+        "○ TUN Mode".to_owned()
+    };
+    let tun_i = match MenuItem::with_id(app, "toggle_tun", &tun_label, true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
+    let mode_sep = match PredefinedMenuItem::separator(app) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let rule_label = if mode.to_lowercase() == "rule" {
+        "● Rule".to_owned()
+    } else {
+        "○ Rule".to_owned()
+    };
+    let global_label = if mode.to_lowercase() == "global" {
+        "● Global".to_owned()
+    } else {
+        "○ Global".to_owned()
+    };
+    let direct_label = if mode.to_lowercase() == "direct" {
+        "● Direct".to_owned()
+    } else {
+        "○ Direct".to_owned()
+    };
+    let rule_i = match MenuItem::with_id(app, "mode_rule", &rule_label, true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+    let global_i = match MenuItem::with_id(app, "mode_global", &global_label, true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+    let direct_i = match MenuItem::with_id(app, "mode_direct", &direct_label, true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
+    let sep2 = match PredefinedMenuItem::separator(app) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let quit_i = match MenuItem::with_id(app, "quit", "Quit", true, None::<&str>) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
+    let menu = MenuBuilder::new(app)
+        .item(&show_i)
+        .item(&sep1)
+        .item(&sys_i)
+        .item(&tun_i)
+        .item(&mode_sep)
+        .item(&rule_i)
+        .item(&global_i)
+        .item(&direct_i)
+        .item(&sep2)
+        .item(&quit_i)
+        .build();
+
+    if let Ok(m) = menu {
+        let _ = tray.set_menu(Some(m));
+    }
 }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -619,13 +619,11 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
 
     // If TrayState says sys proxy is off but it's actually on (e.g. first load
     // before frontend has called update_tray_full_menu), read the real state.
-    if !sys_on {
-        if sys_proxy::get_sys_proxy().unwrap_or(false) {
-            sys_on = true;
-            // Sync TrayState so subsequent reads are correct
-            if let Ok(mut guard) = tray_state.0.lock() {
-                guard.sys_proxy_enabled = true;
-            }
+    if !sys_on && sys_proxy::get_sys_proxy().unwrap_or(false) {
+        sys_on = true;
+        // Sync TrayState so subsequent reads are correct
+        if let Ok(mut guard) = tray_state.0.lock() {
+            guard.sys_proxy_enabled = true;
         }
     }
 

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -593,13 +593,13 @@ pub fn update_tray_toggle_states(
     Ok(())
 }
 
-/// Rebuild tray menu from current TrayState (works without WebView/frontend).
+/// Rebuild tray menu from current `TrayState` (works without WebView/frontend).
 /// Used when tray operations happen in lightweight mode or when the frontend
 /// is not available to provide full menu data.
 #[allow(clippy::doc_markdown)]
 fn rebuild_tray_menu_from_state(app: &AppHandle) {
     let tray_state = app.state::<TrayState>();
-    let (sys_on, tun_on, mode, labels) = tray_state
+    let (mut sys_on, tun_on, mode, labels) = tray_state
         .0
         .lock()
         .map(|guard| {
@@ -616,6 +616,18 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
             )
         })
         .unwrap_or_else(|_| (false, false, "rule".to_owned(), TrayLabels::default()));
+
+    // If TrayState says sys proxy is off but it's actually on (e.g. first load
+    // before frontend has called update_tray_full_menu), read the real state.
+    if !sys_on {
+        if sys_proxy::get_sys_proxy().unwrap_or(false) {
+            sys_on = true;
+            // Sync TrayState so subsequent reads are correct
+            if let Ok(mut guard) = tray_state.0.lock() {
+                guard.sys_proxy_enabled = true;
+            }
+        }
+    }
 
     let tray = match app.tray_by_id("main") {
         Some(t) => t,

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -14,7 +14,7 @@ use tauri::{
     AppHandle, Manager as _,
 };
 
-use crate::core_manager::MihomoState;
+use crate::core_manager::{MihomoState, DEFAULT_MIXED_PORT};
 use crate::sys_proxy;
 
 /// Tray menu state for tracking check states
@@ -25,6 +25,37 @@ pub struct TrayMenuState {
     pub current_mode: String,
     pub active_config: Option<String>,
     pub active_proxy: Option<String>,
+    /// i18n labels for `rebuild_tray_menu_from_state` (lightweight mode)
+    #[serde(default)]
+    pub labels: TrayLabels,
+}
+
+/// Localized labels stored in `TrayMenuState` so the Rust-side
+/// `rebuild_tray_menu_from_state` can display the correct language
+/// even when the frontend/WebView is not available (lightweight mode).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrayLabels {
+    pub show: String,
+    pub quit: String,
+    pub sys_proxy: String,
+    pub tun_mode: String,
+    pub rule: String,
+    pub global: String,
+    pub direct: String,
+}
+
+impl Default for TrayLabels {
+    fn default() -> Self {
+        Self {
+            show: "Show Zephyr".to_owned(),
+            quit: "Quit".to_owned(),
+            sys_proxy: "System Proxy".to_owned(),
+            tun_mode: "TUN Mode".to_owned(),
+            rule: "Rule".to_owned(),
+            global: "Global".to_owned(),
+            direct: "Direct".to_owned(),
+        }
+    }
 }
 
 /// Wrapper for tray state to work with Tauri's State
@@ -293,13 +324,13 @@ fn toggle_sys_proxy(app: &AppHandle) {
     let result = if current {
         sys_proxy::disable_sysproxy()
     } else {
-        // Get the current proxy port from core state
+        // Get the current PROXY port from core state (not the API port)
         let state = app.state::<MihomoState>();
         let port = state
             .0
             .lock()
-            .map(|guard| guard.last_port().unwrap_or(7890))
-            .unwrap_or(7890);
+            .map(|guard| guard.last_proxy_port().unwrap_or(DEFAULT_MIXED_PORT))
+            .unwrap_or(DEFAULT_MIXED_PORT);
         let server = format!("127.0.0.1:{port}");
         sys_proxy::enable_sysproxy(server, None)
     };
@@ -387,6 +418,16 @@ pub fn update_tray_full_menu(app: AppHandle, params: TrayMenuParams) -> Result<(
         guard.sys_proxy_enabled = params.sys_proxy_enabled;
         guard.tun_enabled = params.tun_enabled;
         guard.current_mode.clone_from(&params.current_mode);
+        // Store i18n labels for rebuild_tray_menu_from_state (lightweight mode)
+        guard.labels = TrayLabels {
+            show: params.show_text.clone(),
+            quit: params.quit_text.clone(),
+            sys_proxy: params.sys_proxy_text.clone(),
+            tun_mode: params.tun_text.clone(),
+            rule: params.rule_text.clone(),
+            global: params.global_text.clone(),
+            direct: params.direct_text.clone(),
+        };
     }
 
     // Build menu items
@@ -558,24 +599,30 @@ pub fn update_tray_toggle_states(
 #[allow(clippy::doc_markdown)]
 fn rebuild_tray_menu_from_state(app: &AppHandle) {
     let tray_state = app.state::<TrayState>();
-    let (sys_on, tun_on, mode) = tray_state
+    let (sys_on, tun_on, mode, labels) = tray_state
         .0
         .lock()
         .map(|guard| {
+            let mode = if guard.current_mode.is_empty() {
+                "rule".to_owned()
+            } else {
+                guard.current_mode.clone()
+            };
             (
                 guard.sys_proxy_enabled,
                 guard.tun_enabled,
-                guard.current_mode.clone(),
+                mode,
+                guard.labels.clone(),
             )
         })
-        .unwrap_or_else(|_| (false, false, "rule".to_owned()));
+        .unwrap_or_else(|_| (false, false, "rule".to_owned(), TrayLabels::default()));
 
     let tray = match app.tray_by_id("main") {
         Some(t) => t,
         None => return,
     };
 
-    let show_i = match MenuItem::with_id(app, "show", "Show Zephyr", true, None::<&str>) {
+    let show_i = match MenuItem::with_id(app, "show", &labels.show, true, None::<&str>) {
         Ok(i) => i,
         Err(_) => return,
     };
@@ -585,9 +632,9 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
     };
 
     let sys_label = if sys_on {
-        "● System Proxy".to_owned()
+        format!("● {}", labels.sys_proxy)
     } else {
-        "○ System Proxy".to_owned()
+        format!("○ {}", labels.sys_proxy)
     };
     let sys_i = match MenuItem::with_id(app, "toggle_sysproxy", &sys_label, true, None::<&str>) {
         Ok(i) => i,
@@ -595,9 +642,9 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
     };
 
     let tun_label = if tun_on {
-        "● TUN Mode".to_owned()
+        format!("● {}", labels.tun_mode)
     } else {
-        "○ TUN Mode".to_owned()
+        format!("○ {}", labels.tun_mode)
     };
     let tun_i = match MenuItem::with_id(app, "toggle_tun", &tun_label, true, None::<&str>) {
         Ok(i) => i,
@@ -609,19 +656,19 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
         Err(_) => return,
     };
     let rule_label = if mode.to_lowercase() == "rule" {
-        "● Rule".to_owned()
+        format!("● {}", labels.rule)
     } else {
-        "○ Rule".to_owned()
+        format!("○ {}", labels.rule)
     };
     let global_label = if mode.to_lowercase() == "global" {
-        "● Global".to_owned()
+        format!("● {}", labels.global)
     } else {
-        "○ Global".to_owned()
+        format!("○ {}", labels.global)
     };
     let direct_label = if mode.to_lowercase() == "direct" {
-        "● Direct".to_owned()
+        format!("● {}", labels.direct)
     } else {
-        "○ Direct".to_owned()
+        format!("○ {}", labels.direct)
     };
     let rule_i = match MenuItem::with_id(app, "mode_rule", &rule_label, true, None::<&str>) {
         Ok(i) => i,
@@ -640,7 +687,7 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
         Ok(s) => s,
         Err(_) => return,
     };
-    let quit_i = match MenuItem::with_id(app, "quit", "Quit", true, None::<&str>) {
+    let quit_i = match MenuItem::with_id(app, "quit", &labels.quit, true, None::<&str>) {
         Ok(i) => i,
         Err(_) => return,
     };

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -86,8 +86,8 @@ function initReactiveBindings() {
   }
 
   // --- Tray auto-update on state changes ---
-  appStore.subscribe('isSysProxyEnabled', () => updateTrayStatus().catch(() => {}));
-  appStore.subscribe('isTunEnabled', () => updateTrayStatus().catch(() => {}));
+  appStore.subscribe('isSysProxyEnabled', () => { updateTrayStatus().catch(() => {}); updateTrayMenu().catch(() => {}); });
+  appStore.subscribe('isTunEnabled', () => { updateTrayStatus().catch(() => {}); updateTrayMenu().catch(() => {}); });
   appStore.subscribe('currentOutboundMode', () => updateTrayMenu(true).catch(() => {}));
 
   // --- Bus event -> store wiring (for events from settings.js, i18n.js) ---

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -756,6 +756,10 @@ export async function initSettings() {
         if (lightweightModeToggle && closeTrayToggle) {
             lightweightModeToggle.disabled = !closeTrayToggle.checked;
             lightweightModeToggle.closest('.flex')?.classList.toggle('opacity-50', !closeTrayToggle.checked);
+            if (!closeTrayToggle.checked && lightweightModeToggle.checked) {
+                lightweightModeToggle.checked = false;
+                save();
+            }
         }
     };
     closeTrayToggle?.addEventListener('change', () => {

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -179,6 +179,9 @@ export async function initTrayEventListeners() {
             toggle.checked = enabled;
         }
 
+        // Update appStore immediately so updateTrayMenu() reads the correct state
+        appStore.set('isSysProxyEnabled', enabled);
+
         try {
             /** @type {any} */
             const currentConfig = await getConfig();
@@ -197,7 +200,10 @@ export async function initTrayEventListeners() {
             await updateTrayMenu();
         } catch (err) {
             trayLogger.error('Failed to toggle sys proxy from tray', err);
+            appStore.set('isSysProxyEnabled', !enabled);
             if (toggle) toggle.checked = !enabled;
+            // Sync the reverted state back to the tray menu
+            updateTrayMenu().catch(() => {});
         }
     });
     _trayEventUnlisteners.push(unlisten1);


### PR DESCRIPTION
## Summary

Fixes two bugs causing the tray system proxy circle indicator to show inverted state:

1. **Frontend bug**: `tray-sysproxy-changed` handler did not update `appStore.set('isSysProxyEnabled', enabled)` before calling `updateTrayMenu()`, so the menu read the stale value and showed the circle indicator inverted.

2. **Rust bug**: `toggle_sys_proxy()` only emitted an event to the frontend without updating the tray menu or icon. In lightweight mode (no WebView), the emit is ignored and the tray never updates.

## Changes

- **`tray.js`**: Added `appStore.set('isSysProxyEnabled', enabled)` before `updateTrayMenu()`, revert on error, and sync tray menu on error rollback
- **`tray.rs`**: `toggle_sys_proxy()` now:
  - Checks the result of `enable_sysproxy()`/`disable_sysproxy()` before updating state (prevents false state)
  - Updates `TrayState` and tray icon only on success, using a single lock acquisition
  - Rebuilds tray menu via `rebuild_tray_menu_from_state()` (new function)
  - This makes system proxy toggle work correctly in lightweight mode

## Test Plan

- [ ] Verify tray circle indicator matches actual system proxy state
- [ ] Verify toggling system proxy from tray updates the circle correctly
- [ ] Verify toggling system proxy from settings page updates tray correctly
- [ ] Verify tray works in lightweight mode (close to tray, toggle sys proxy)