### PR TITLE
fix: reduce excessive error spam when core is unreachable

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1233,18 +1233,27 @@ pub async fn start_core(
     // If the requested config differs from the current one, we must restart to apply it.
     // Also extract port/secret for drain before killing.
     let drain_info: Option<(u16, String)> = {
-        let lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
+        let mut lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
         if lock.process().is_some() {
             let same_config = lock
                 .last_config_path()
                 .is_some_and(|current| current == config_path);
             if same_config {
-                if let Some(port) = lock.last_port() {
-                    return Ok(CoreStartResult {
-                        secret: lock.last_secret().to_owned(),
-                        port,
-                    });
+                // Check if the process is actually still alive before short-circuiting.
+                // If mihomo crashed, the Child handle still exists but the process
+                // is dead — we must restart instead of returning stale info.
+                let alive = lock
+                    .process_mut()
+                    .is_some_and(|p| p.try_wait().ok().flatten().is_none());
+                if alive {
+                    if let Some(port) = lock.last_port() {
+                        return Ok(CoreStartResult {
+                            secret: lock.last_secret().to_owned(),
+                            port,
+                        });
+                    }
                 }
+                // Process is dead — fall through to restart
             }
             // Core is running with a different config — prepare drain info
             lock.last_port()

--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -14,6 +14,12 @@ let BASE_URL = 'http://127.0.0.1:9090';
 /** 运行时状态（sealed，防止意外扩展） */
 const _state = Object.seal({ secret: '' });
 
+/** @type {boolean} 内核是否可达（连接未被拒绝） */
+let _coreReachable = true;
+
+/** @type {boolean} 是否已输出过一次连接拒绝日志（避免重复报错） */
+let _connectionRefusedLogged = false;
+
 // ═══════════════════════════════════════════════════════════════════════════════
 //  ApiError — 统一错误类型
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -96,12 +102,41 @@ async function apiFetch(endpoint, init = {}) {
       });
     }
 
+    // 请求成功 — 标记内核可达
+    if (!_coreReachable) {
+      _coreReachable = true;
+      _connectionRefusedLogged = false;
+      apiLogger.info('core connection restored');
+    }
+
     return res;
   } catch (err) {
     if (err instanceof ApiError) throw err;
 
     const error = /** @type {Error} */ (err);
     const isAbort = error.name === 'AbortError';
+
+    // 检测连接被拒绝（内核未运行）
+    const isConnectionRefused = !isAbort && (
+      error.message?.includes('Failed to fetch') ||
+      error.message?.includes('NetworkError') ||
+      error.message?.includes('Connection refused') ||
+      error.message?.includes('ERR_CONNECTION_REFUSED') ||
+      error.message?.includes('Load failed') ||
+      error.name === 'TypeError'
+    );
+
+    if (isConnectionRefused) {
+      _coreReachable = false;
+      // 只在首次连接拒绝时输出 warn，后续降级为 debug
+      if (!_connectionRefusedLogged) {
+        _connectionRefusedLogged = true;
+        apiLogger.warn(`core unreachable: ${endpoint}`);
+      } else {
+        apiLogger.debug(`core unreachable: ${endpoint}`);
+      }
+    }
+
     throw new ApiError(
       isAbort ? `Request timeout (${timeout}ms): ${endpoint}` : `Network request failed: ${endpoint}`,
       { endpoint, cause: error },
@@ -224,6 +259,25 @@ export function setBaseUrl(url) {
  */
 export function setSecret(s) {
   _state.secret = s || '';
+}
+
+/**
+ * 查询内核是否可达
+ * @returns {boolean}
+ */
+export function isCoreReachable() {
+  return _coreReachable;
+}
+
+/**
+ * 设置内核可达状态（内核重启成功后调用重置为 true）
+ * @param {boolean} reachable
+ */
+export function setCoreReachable(reachable) {
+  _coreReachable = reachable;
+  if (reachable) {
+    _connectionRefusedLogged = false;
+  }
 }
 
 /**
@@ -536,6 +590,7 @@ export async function restartCore(configPath, customArgs = []) {
   setSecret(coreResult.secret);
   setWsBaseUrl(`ws://127.0.0.1:${coreResult.port}`);
   setWsSecret(coreResult.secret);
+  setCoreReachable(true);
   Bus.emit(Events.CORE_RESTARTED);
   return coreResult;
 }

--- a/apps/desktop/src/api.test.js
+++ b/apps/desktop/src/api.test.js
@@ -3,6 +3,8 @@ import {
     ApiError,
     setBaseUrl,
     setSecret,
+    isCoreReachable,
+    setCoreReachable,
     getProxies,
     switchProxy,
     getConfig,
@@ -132,6 +134,50 @@ describe('setSecret', () => {
 
     it('is a function', () => {
         expect(typeof setSecret).toBe('function');
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  isCoreReachable / setCoreReachable
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('isCoreReachable', () => {
+    afterEach(() => {
+        setCoreReachable(true);
+    });
+
+    it('returns true by default', () => {
+        expect(isCoreReachable()).toBe(true);
+    });
+
+    it('returns false after setCoreReachable(false)', () => {
+        setCoreReachable(false);
+        expect(isCoreReachable()).toBe(false);
+    });
+
+    it('returns true after setCoreReachable(true)', () => {
+        setCoreReachable(false);
+        setCoreReachable(true);
+        expect(isCoreReachable()).toBe(true);
+    });
+
+    it('is a function', () => {
+        expect(typeof isCoreReachable).toBe('function');
+    });
+});
+
+describe('setCoreReachable', () => {
+    afterEach(() => {
+        setCoreReachable(true);
+    });
+
+    it('does not throw', () => {
+        expect(() => setCoreReachable(true)).not.toThrow();
+        expect(() => setCoreReachable(false)).not.toThrow();
+    });
+
+    it('is a function', () => {
+        expect(typeof setCoreReachable).toBe('function');
     });
 });
 

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -10,6 +10,7 @@ import {
   invoke,
   setBaseUrl,
   setSecret,
+  setCoreReachable,
 } from './api.js';
 import {
   setBaseUrl as setWsBaseUrl,
@@ -171,6 +172,7 @@ async function initApp() {
     setWsBaseUrl(`ws://127.0.0.1:${port}`);
     setSecret(secret || '');
     setWsSecret(secret || '');
+    setCoreReachable(true);
 
     // 5b. Initialize Prism engine — compile patches and populate rule annotations.
     // mihomo already started with run_config.yaml (previous compile output), so rules
@@ -348,6 +350,13 @@ async function initApp() {
   // 9. Traffic WebSocket
   _trafficWsHandle = connectTraffic((/** @type {any} */ data) => {
     updateTrafficData(data);
+  });
+
+  // 9b. Reconnect traffic stream when core restarts
+  Bus.on(Events.CORE_RESTARTED, () => {
+    if (_trafficWsHandle) {
+      _trafficWsHandle.reconnect();
+    }
   });
 
   // 11. Cleanup handlers

--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -18,7 +18,7 @@
  *   - destroyConnectionsPage()
  */
 
-import { getConnections, closeConnection, closeAllConnections } from '../api.js';
+import { getConnections, closeConnection, closeAllConnections, isCoreReachable } from '../api.js';
 import { showNotification } from '../ui/notifications.js';
 import { translations, currentLang, applyTranslations } from '../i18n.js';
 import { escapeHtml } from '../utils/sanitize.js';
@@ -190,10 +190,10 @@ const _onThemeChanged = () => updateSortIndicators();
 _unsubI18n = Bus.on(Events.I18N_APPLIED, _onI18nApplied);
 _unsubTheme = Bus.on(Events.THEME_MODE_CHANGED, _onThemeChanged);
 
-    // Auto-refresh every 2 seconds (only when page is visible)
+    // Auto-refresh every 2 seconds (only when page is visible and core is reachable)
     connectionsPollTimer = setInterval(() => {
         const pageEl = document.querySelector('[data-page="connections"]');
-        if (pageEl && !pageEl.classList.contains('hidden')) {
+        if (pageEl && !pageEl.classList.contains('hidden') && isCoreReachable()) {
             fetchAndRenderConnections();
         }
     }, 2000);

--- a/apps/desktop/src/ui/observed-group.js
+++ b/apps/desktop/src/ui/observed-group.js
@@ -10,7 +10,7 @@
  * @module ui/observed-group
  */
 
-import { getConnections } from '../api.js';
+import { getConnections, isCoreReachable } from '../api.js';
 import { getProxiesCached } from './cache.js';
 import { isWritableGroupType } from './proxy-groups.js';
 import { appStore } from './state.js';
@@ -162,6 +162,7 @@ function _scheduleNext() {
 
 async function _poll() {
     if (_polling) return;
+    if (!isCoreReachable()) return; // 内核不可达时跳过轮询
     _polling = true;
     try {
         const [connData, proxiesData] = await Promise.all([

--- a/apps/desktop/src/websocket.js
+++ b/apps/desktop/src/websocket.js
@@ -15,6 +15,7 @@
  */
 
 import { wsLogger as log } from './utils/logger.js';
+import { setCoreReachable } from './api.js';
 
 /* ------------------------------------------------------------------ */
 /*  Connection state enum                                             */
@@ -195,8 +196,12 @@ export function connectTraffic(callback) {
   /** @type {boolean} Guard against double connection during force-reconnect */
   let isForceReconnecting = false;
 
+  /** @type {boolean} Whether the last error was a connection-refused (core not running) */
+  let isConnectionRefused = false;
+
   /* ---- constants ---- */
   const MAX_RETRIES = 15;
+  const MAX_RETRIES_REFUSED = 3; // 内核未运行时最多重试 3 次
   const BASE_DELAY = 1000;
   const MAX_DELAY = 30000;
   const HEARTBEAT_TIMEOUT = 30_000; // 30 s
@@ -338,7 +343,28 @@ export function connectTraffic(callback) {
         return;
       }
       if (error.name === 'AbortError') return;
-      log.error('stream error:', error.message || error);
+
+      // 检测连接被拒绝（内核未运行）
+      isConnectionRefused = (
+        error.message?.includes('Failed to fetch') ||
+        error.message?.includes('NetworkError') ||
+        error.message?.includes('Connection refused') ||
+        error.message?.includes('ERR_CONNECTION_REFUSED') ||
+        error.message?.includes('Load failed') ||
+        error.name === 'TypeError'
+      );
+
+      if (isConnectionRefused) {
+        setCoreReachable(false);
+        // 连接被拒绝时降级日志：首次 warn，后续 debug
+        if (retryCount === 0) {
+          log.warn('stream error: core unreachable');
+        } else {
+          log.debug(`stream error: core unreachable (retry #${retryCount})`);
+        }
+      } else {
+        log.error('stream error:', error.message || error);
+      }
       handleClose();
     }
   };
@@ -352,23 +378,37 @@ export function connectTraffic(callback) {
 
     if (isForceReconnecting || isClosed) return;
 
-    if (retryCount < MAX_RETRIES) {
+    // 内核未运行时使用更少的重试次数
+    const effectiveMaxRetries = isConnectionRefused ? MAX_RETRIES_REFUSED : MAX_RETRIES;
+
+    if (retryCount < effectiveMaxRetries) {
       retryCount++;
       const delay = Math.min(
         MAX_DELAY,
         BASE_DELAY * Math.pow(2, retryCount - 1),
       );
-      log.warn(`reconnect #${retryCount} in ${delay} ms`);
+      // 连接被拒绝时降级重连日志
+      if (isConnectionRefused) {
+        log.debug(`reconnect #${retryCount} in ${delay} ms (core unreachable)`);
+      } else {
+        log.warn(`reconnect #${retryCount} in ${delay} ms`);
+      }
       setState(ConnectionState.RECONNECTING);
       retryTimer = setTimeout(connect, delay);
     } else {
-      log.error('max reconnection attempts reached — giving up');
+      if (isConnectionRefused) {
+        log.warn('core unreachable — traffic stream stopped, restart core to reconnect');
+      } else {
+        log.error('max reconnection attempts reached — giving up');
+      }
       maxRetriesReached = true;
       setState(ConnectionState.DISCONNECTED);
 
       // User-facing notification
       /** @type {any} */ (window).showNotification?.(
-        'Lost connection to core traffic monitor. Click to reconnect.',
+        isConnectionRefused
+          ? 'Core is not running. Restart core to reconnect.'
+          : 'Lost connection to core traffic monitor. Click to reconnect.',
         'warning',
       );
 
@@ -406,6 +446,7 @@ export function connectTraffic(callback) {
       stopHeartbeat();
       maxRetriesReached = false;
       retryCount = 0;
+      isConnectionRefused = false;
       isForceReconnecting = true;
       abortController.abort();
       abortController = new AbortController();


### PR DESCRIPTION
## Problem

When mihomo core is not running (wrong kernel or not restarted after config change), the frontend produces excessive console errors from repeated API failures and WebSocket reconnection attempts:

- `Failed to load resource: Could not connect to 127.0.0.1: Connection refused` (proxies, traffic)
- `[WebSocket] stream error: Load failed`
- 15 reconnection attempts with error-level logs each time
- Connections page polling every 2 seconds while core is down

## Changes

### Frontend (JS)

- **api.js**: Add global `coreReachable` state to track core availability. Connection-refused errors downgrade logs: first occurrence warns, subsequent ones use debug level. Successful requests auto-restore the state.
- **websocket.js**: Reduce traffic stream retries from 15 to 3 when core is unreachable. Downgrade reconnection logs to debug level. Friendlier notification message ("Core is not running. Restart core to reconnect.").
- **connections.js**: Skip 2-second polling when core is unreachable.
- **observed-group.js**: Skip polling when core is unreachable.
- **main.js**: Set `coreReachable(true)` after core starts. Listen for `CORE_RESTARTED` event to auto-reconnect traffic stream.

### Backend (Rust)

- **core_process.rs**: Fix `start_core` returning stale info when mihomo process crashed but the `Child` handle still exists. Now checks process liveness via `try_wait()` before short-circuiting on same-config path.

## Testing

- 362 tests pass (including new `isCoreReachable`/`setCoreReachable` unit tests)
- ESLint, typecheck, cargo fmt, cargo clippy all pass