### PR TITLE
fix: reduce excessive error spam when core is unreachable

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -1233,22 +1233,33 @@ pub async fn start_core(
     // If the requested config differs from the current one, we must restart to apply it.
     // Also extract port/secret for drain before killing.
     let drain_info: Option<(u16, String)> = {
-        let lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
+        let mut lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
         if lock.process().is_some() {
             let same_config = lock
                 .last_config_path()
                 .is_some_and(|current| current == config_path);
             if same_config {
-                if let Some(port) = lock.last_port() {
-                    return Ok(CoreStartResult {
-                        secret: lock.last_secret().to_owned(),
-                        port,
-                    });
+                // Check if the process is actually still alive before short-circuiting.
+                // If mihomo crashed, the Child handle still exists but the process
+                // is dead — we must restart instead of returning stale info.
+                let alive = lock
+                    .process_mut()
+                    .is_some_and(|p| matches!(p.try_wait(), Ok(None)));
+                if alive {
+                    if let Some(port) = lock.last_port() {
+                        return Ok(CoreStartResult {
+                            secret: lock.last_secret().to_owned(),
+                            port,
+                        });
+                    }
                 }
+                // Process is dead — skip drain (no point draining a dead port)
+                None
+            } else {
+                // Core is running with a different config — prepare drain info
+                lock.last_port()
+                    .map(|port| (port, lock.last_secret().to_owned()))
             }
-            // Core is running with a different config — prepare drain info
-            lock.last_port()
-                .map(|port| (port, lock.last_secret().to_owned()))
         } else {
             None
         }

--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -14,6 +14,12 @@ let BASE_URL = 'http://127.0.0.1:9090';
 /** 运行时状态（sealed，防止意外扩展） */
 const _state = Object.seal({ secret: '' });
 
+/** @type {boolean} 内核是否可达（连接未被拒绝） */
+let _coreReachable = true;
+
+/** @type {boolean} 是否已输出过一次连接拒绝日志（避免重复报错） */
+let _connectionRefusedLogged = false;
+
 // ═══════════════════════════════════════════════════════════════════════════════
 //  ApiError — 统一错误类型
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -96,12 +102,34 @@ async function apiFetch(endpoint, init = {}) {
       });
     }
 
+    // 请求成功 — 标记内核可达
+    if (!_coreReachable) {
+      _coreReachable = true;
+      _connectionRefusedLogged = false;
+      apiLogger.info('core connection restored');
+    }
+
     return res;
   } catch (err) {
     if (err instanceof ApiError) throw err;
 
     const error = /** @type {Error} */ (err);
     const isAbort = error.name === 'AbortError';
+
+    // 检测连接被拒绝（内核未运行）
+    const isConnectionRefused = !isAbort && isConnectionRefusedError(error);
+
+    if (isConnectionRefused) {
+      _coreReachable = false;
+      // 只在首次连接拒绝时输出 warn，后续降级为 debug
+      if (!_connectionRefusedLogged) {
+        _connectionRefusedLogged = true;
+        apiLogger.warn(`core unreachable: ${endpoint}`);
+      } else {
+        apiLogger.debug(`core unreachable: ${endpoint}`);
+      }
+    }
+
     throw new ApiError(
       isAbort ? `Request timeout (${timeout}ms): ${endpoint}` : `Network request failed: ${endpoint}`,
       { endpoint, cause: error },
@@ -224,6 +252,44 @@ export function setBaseUrl(url) {
  */
 export function setSecret(s) {
   _state.secret = s || '';
+}
+
+/**
+ * 判断错误是否为"连接被拒绝"（内核未运行）
+ * 用于 apiFetch 和 websocket.js 共享同一检测逻辑。
+ *
+ * @param {Error} error
+ * @returns {boolean}
+ */
+export function isConnectionRefusedError(error) {
+  const msg = error?.message;
+  if (!msg) return false;
+  return (
+    msg.includes('Failed to fetch') ||
+    msg.includes('NetworkError') ||
+    msg.includes('Connection refused') ||
+    msg.includes('ERR_CONNECTION_REFUSED') ||
+    msg.includes('Load failed')
+  );
+}
+
+/**
+ * 查询内核是否可达
+ * @returns {boolean}
+ */
+export function isCoreReachable() {
+  return _coreReachable;
+}
+
+/**
+ * 设置内核可达状态（内核重启成功后调用重置为 true）
+ * @param {boolean} reachable
+ */
+export function setCoreReachable(reachable) {
+  _coreReachable = reachable;
+  if (reachable) {
+    _connectionRefusedLogged = false;
+  }
 }
 
 /**
@@ -536,6 +602,7 @@ export async function restartCore(configPath, customArgs = []) {
   setSecret(coreResult.secret);
   setWsBaseUrl(`ws://127.0.0.1:${coreResult.port}`);
   setWsSecret(coreResult.secret);
+  setCoreReachable(true);
   Bus.emit(Events.CORE_RESTARTED);
   return coreResult;
 }

--- a/apps/desktop/src/api.test.js
+++ b/apps/desktop/src/api.test.js
@@ -3,6 +3,8 @@ import {
     ApiError,
     setBaseUrl,
     setSecret,
+    isCoreReachable,
+    setCoreReachable,
     getProxies,
     switchProxy,
     getConfig,
@@ -132,6 +134,50 @@ describe('setSecret', () => {
 
     it('is a function', () => {
         expect(typeof setSecret).toBe('function');
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  isCoreReachable / setCoreReachable
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('isCoreReachable', () => {
+    afterEach(() => {
+        setCoreReachable(true);
+    });
+
+    it('returns true by default', () => {
+        expect(isCoreReachable()).toBe(true);
+    });
+
+    it('returns false after setCoreReachable(false)', () => {
+        setCoreReachable(false);
+        expect(isCoreReachable()).toBe(false);
+    });
+
+    it('returns true after setCoreReachable(true)', () => {
+        setCoreReachable(false);
+        setCoreReachable(true);
+        expect(isCoreReachable()).toBe(true);
+    });
+
+    it('is a function', () => {
+        expect(typeof isCoreReachable).toBe('function');
+    });
+});
+
+describe('setCoreReachable', () => {
+    afterEach(() => {
+        setCoreReachable(true);
+    });
+
+    it('does not throw', () => {
+        expect(() => setCoreReachable(true)).not.toThrow();
+        expect(() => setCoreReachable(false)).not.toThrow();
+    });
+
+    it('is a function', () => {
+        expect(typeof setCoreReachable).toBe('function');
     });
 });
 

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -10,6 +10,7 @@ import {
   invoke,
   setBaseUrl,
   setSecret,
+  setCoreReachable,
 } from './api.js';
 import {
   setBaseUrl as setWsBaseUrl,
@@ -171,6 +172,7 @@ async function initApp() {
     setWsBaseUrl(`ws://127.0.0.1:${port}`);
     setSecret(secret || '');
     setWsSecret(secret || '');
+    setCoreReachable(true);
 
     // 5b. Initialize Prism engine — compile patches and populate rule annotations.
     // mihomo already started with run_config.yaml (previous compile output), so rules
@@ -350,12 +352,22 @@ async function initApp() {
     updateTrafficData(data);
   });
 
+  // 9b. Reconnect traffic stream when core restarts
+  const _unsubCoreRestarted = Bus.on(Events.CORE_RESTARTED, () => {
+    if (_trafficWsHandle) {
+      _trafficWsHandle.reconnect();
+    }
+  });
+
   // 11. Cleanup handlers
   registerCleanup(() => {
     if (_configParseErrorListener) {
       _configParseErrorListener();
       _configParseErrorListener = null;
     }
+  });
+  registerCleanup(() => {
+    _unsubCoreRestarted();
   });
   registerCleanup(() => {
     if (_trafficWsHandle) {

--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -18,7 +18,7 @@
  *   - destroyConnectionsPage()
  */
 
-import { getConnections, closeConnection, closeAllConnections } from '../api.js';
+import { getConnections, closeConnection, closeAllConnections, isCoreReachable } from '../api.js';
 import { showNotification } from '../ui/notifications.js';
 import { translations, currentLang, applyTranslations } from '../i18n.js';
 import { escapeHtml } from '../utils/sanitize.js';
@@ -190,13 +190,24 @@ const _onThemeChanged = () => updateSortIndicators();
 _unsubI18n = Bus.on(Events.I18N_APPLIED, _onI18nApplied);
 _unsubTheme = Bus.on(Events.THEME_MODE_CHANGED, _onThemeChanged);
 
-    // Auto-refresh every 2 seconds (only when page is visible)
+    // Auto-refresh every 2 seconds when core is reachable, every 15 seconds when unreachable
     connectionsPollTimer = setInterval(() => {
         const pageEl = document.querySelector('[data-page="connections"]');
         if (pageEl && !pageEl.classList.contains('hidden')) {
             fetchAndRenderConnections();
         }
-    }, 2000);
+    }, isCoreReachable() ? 2000 : 15000);
+
+    // Adjust interval when core reachability changes
+    const _unsubReachable = Bus.on(Events.CORE_RESTARTED, () => {
+        if (connectionsPollTimer != null) clearInterval(connectionsPollTimer);
+        connectionsPollTimer = setInterval(() => {
+            const pageEl = document.querySelector('[data-page="connections"]');
+            if (pageEl && !pageEl.classList.contains('hidden')) {
+                fetchAndRenderConnections();
+            }
+        }, 2000);
+    });
 }
 
 /**

--- a/apps/desktop/src/ui/observed-group.js
+++ b/apps/desktop/src/ui/observed-group.js
@@ -10,7 +10,7 @@
  * @module ui/observed-group
  */
 
-import { getConnections } from '../api.js';
+import { getConnections, isCoreReachable } from '../api.js';
 import { getProxiesCached } from './cache.js';
 import { isWritableGroupType } from './proxy-groups.js';
 import { appStore } from './state.js';
@@ -152,12 +152,13 @@ export function resetObservedGroup() {
 
 function _scheduleNext() {
     if (!_active || _timer) return;
+    const interval = isCoreReachable() ? POLL_INTERVAL : 15000;
     _timer = setTimeout(() => {
         _timer = null;
         _poll().finally(() => {
             _scheduleNext();
         });
-    }, POLL_INTERVAL);
+    }, interval);
 }
 
 async function _poll() {

--- a/apps/desktop/src/websocket.js
+++ b/apps/desktop/src/websocket.js
@@ -15,6 +15,7 @@
  */
 
 import { wsLogger as log } from './utils/logger.js';
+import { setCoreReachable, isConnectionRefusedError } from './api.js';
 
 /* ------------------------------------------------------------------ */
 /*  Connection state enum                                             */
@@ -195,8 +196,12 @@ export function connectTraffic(callback) {
   /** @type {boolean} Guard against double connection during force-reconnect */
   let isForceReconnecting = false;
 
+  /** @type {boolean} Whether the last error was a connection-refused (core not running) */
+  let isConnectionRefused = false;
+
   /* ---- constants ---- */
   const MAX_RETRIES = 15;
+  const MAX_RETRIES_REFUSED = 3; // 内核未运行时最多重试 3 次
   const BASE_DELAY = 1000;
   const MAX_DELAY = 30000;
   const HEARTBEAT_TIMEOUT = 30_000; // 30 s
@@ -267,6 +272,7 @@ export function connectTraffic(callback) {
       // --- stream established ---
       retryCount = 0;
       maxRetriesReached = false;
+      isConnectionRefused = false;
       setState(ConnectionState.CONNECTED);
       touchHeartbeat();
 
@@ -338,7 +344,21 @@ export function connectTraffic(callback) {
         return;
       }
       if (error.name === 'AbortError') return;
-      log.error('stream error:', error.message || error);
+
+      // 检测连接被拒绝（内核未运行）
+      isConnectionRefused = isConnectionRefusedError(error);
+
+      if (isConnectionRefused) {
+        setCoreReachable(false);
+        // 连接被拒绝时降级日志：首次 warn，后续 debug
+        if (retryCount === 0) {
+          log.warn('stream error: core unreachable');
+        } else {
+          log.debug(`stream error: core unreachable (retry #${retryCount})`);
+        }
+      } else {
+        log.error('stream error:', error.message || error);
+      }
       handleClose();
     }
   };
@@ -352,23 +372,37 @@ export function connectTraffic(callback) {
 
     if (isForceReconnecting || isClosed) return;
 
-    if (retryCount < MAX_RETRIES) {
+    // 内核未运行时使用更少的重试次数
+    const effectiveMaxRetries = isConnectionRefused ? MAX_RETRIES_REFUSED : MAX_RETRIES;
+
+    if (retryCount < effectiveMaxRetries) {
       retryCount++;
       const delay = Math.min(
         MAX_DELAY,
         BASE_DELAY * Math.pow(2, retryCount - 1),
       );
-      log.warn(`reconnect #${retryCount} in ${delay} ms`);
+      // 连接被拒绝时降级重连日志
+      if (isConnectionRefused) {
+        log.debug(`reconnect #${retryCount} in ${delay} ms (core unreachable)`);
+      } else {
+        log.warn(`reconnect #${retryCount} in ${delay} ms`);
+      }
       setState(ConnectionState.RECONNECTING);
       retryTimer = setTimeout(connect, delay);
     } else {
-      log.error('max reconnection attempts reached — giving up');
+      if (isConnectionRefused) {
+        log.warn('core unreachable — traffic stream stopped, restart core to reconnect');
+      } else {
+        log.error('max reconnection attempts reached — giving up');
+      }
       maxRetriesReached = true;
       setState(ConnectionState.DISCONNECTED);
 
       // User-facing notification
       /** @type {any} */ (window).showNotification?.(
-        'Lost connection to core traffic monitor. Click to reconnect.',
+        isConnectionRefused
+          ? 'Core is not running. Restart core to reconnect.'
+          : 'Lost connection to core traffic monitor. Click to reconnect.',
         'warning',
       );
 
@@ -406,6 +440,7 @@ export function connectTraffic(callback) {
       stopHeartbeat();
       maxRetriesReached = false;
       retryCount = 0;
+      isConnectionRefused = false;
       isForceReconnecting = true;
       abortController.abort();
       abortController = new AbortController();


### PR DESCRIPTION
## Problem

When mihomo core is not running (wrong kernel or not restarted after config change), the frontend produces excessive console errors from repeated API failures and WebSocket reconnection attempts:

- `Failed to load resource: Could not connect to 127.0.0.1: Connection refused` (proxies, traffic)
- `[WebSocket] stream error: Load failed`
- 15 reconnection attempts with error-level logs each time
- Connections page polling every 2 seconds while core is down

## Changes

### Frontend (JS)

- **api.js**: Add global `coreReachable` state to track core availability. Extract `isConnectionRefusedError()` shared utility with null-safe error checking. Connection-refused errors downgrade logs: first occurrence warns, subsequent ones use debug level. Successful requests auto-restore the state.
- **websocket.js**: Reduce traffic stream retries from 15 to 3 when core is unreachable. Downgrade reconnection logs to debug level. Friendlier notification message. Reset `isConnectionRefused` flag on successful connection. Use shared `isConnectionRefusedError()` from api.js.
- **connections.js**: Reduce polling interval to 15 seconds when core is unreachable (instead of 2 seconds), restore to 2 seconds on CORE_RESTARTED.
- **observed-group.js**: Reduce polling interval to 15 seconds when core is unreachable (instead of 2 seconds), auto-restores when core comes back.
- **main.js**: Set `coreReachable(true)` after core starts. Listen for `CORE_RESTARTED` event to auto-reconnect traffic stream. Register cleanup handler for the event listener.

### Backend (Rust)

- **core_process.rs**: Fix `start_core` returning stale info when mihomo process crashed but the `Child` handle still exists. Now checks process liveness via `matches!(try_wait(), Ok(None))` before short-circuiting on same-config path. Skip drain when process is dead to avoid useless HTTP timeout.

## Testing

- 362 tests pass (including new `isCoreReachable`/`setCoreReachable` unit tests)
- ESLint, typecheck, cargo fmt, cargo clippy all pass