### PR TITLE
fix: override URL import downloads content and auto-detects JS vs YAML type

### DIFF
--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -29,19 +29,83 @@ pub fn override_list(state: State<PrismState>) -> Result<Vec<OverrideItem>, Stri
 }
 
 /// Create a new override item and allocate a content file.
+///
+/// For remote overrides with a URL, the content is downloaded immediately
+/// and the extension is detected from the URL path (falling back to content analysis).
+/// If the download fails or the content is invalid (e.g. HTML), an error is returned
+/// and the override is NOT created.
 #[tauri::command]
-pub fn override_create(
-    state: State<PrismState>,
+pub async fn override_create(
+    state: State<'_, PrismState>,
     name: String,
     ext: String,
     r#type: String,
     url: Option<String>,
 ) -> Result<OverrideItem, String> {
-    let ext = OverrideExt::from_ext(&ext).ok_or_else(|| format!("Unknown ext: {ext}"))?;
+    let mut ext = OverrideExt::from_ext(&ext).ok_or_else(|| format!("Unknown ext: {ext}"))?;
     let r#type = match r#type.as_str() {
         "local" => OverrideType::Local,
-        "remote" => OverrideType::Remote,
+        "remote" => {
+            if url.as_ref().is_none_or(|u| u.trim().is_empty()) {
+                return Err("URL is required for remote overrides".to_owned());
+            }
+            OverrideType::Remote
+        }
         _ => return Err(format!("Unknown type: {type}")),
+    };
+
+    let download_url = if r#type == OverrideType::Remote {
+        url.clone()
+    } else {
+        None
+    };
+
+    // For remote overrides: detect ext from URL first, then download and validate content.
+    let pre_downloaded = if let Some(download_url) = &download_url {
+        // 1. Try URL extension (most reliable for CDN / raw file URLs)
+        if let Some(url_ext) = detect_ext_from_url(download_url) {
+            ext = url_ext;
+        }
+
+        // 2. Download content
+        let proxy_port = {
+            let settings_state = state.app.state::<crate::SettingsState>();
+            let lock = settings_state
+                .0
+                .lock()
+                .map_err(|e| format!("Lock failed: {e}"))?;
+            lock.mixed_port
+        };
+        match download_remote_content(download_url, proxy_port).await {
+            Ok(content) => {
+                // Validate content is not HTML / binary
+                validate_override_content(&content)?;
+
+                // 3. If URL had no clear extension, fall back to content-based detection
+                if detect_ext_from_url(download_url).is_none() {
+                    let detected = detect_override_ext(&content);
+                    if detected != ext {
+                        emit_warn!(
+                            Override,
+                            OVERRIDE_APPLY_FAILED,
+                            "Content-detected override type {:?} (URL hint was {:?}) for: {}",
+                            detected,
+                            ext,
+                            download_url
+                        );
+                    }
+                    ext = detected;
+                }
+                Some(content)
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to download override from {download_url}: {e}"
+                ));
+            }
+        }
+    } else {
+        None
     };
 
     let mut item = OverrideItem::new(name, ext, r#type);
@@ -52,12 +116,209 @@ pub fn override_create(
         item.url = Some(u);
     }
 
-    // Create content file with default template
+    // Write content: use pre-downloaded content, or fall back to default template
     let dir = overrides_store::overrides_dir(&state)?;
     let content_path = dir.join(item.content_filename());
-    let default_content = match item.ext {
-        OverrideExt::Js => {
-            r"// Zephyr Override Script
+    let content = pre_downloaded.unwrap_or_else(|| default_template_content(item.ext));
+
+    write_file_secure(&content_path, &content)
+        .map_err(|e| format!("Failed to create content file: {e}"))?;
+
+    // create_item atomically assigns order and persists — no race condition
+    overrides_store::create_item(&state, item)
+}
+
+/// Extract override extension from a URL path.
+///
+/// Parses the last path segment, strips query params and fragments,
+/// and checks for `.js`, `.yaml`, `.yml` extensions.
+/// Returns `None` if the URL has no recognizable extension.
+fn detect_ext_from_url(url: &str) -> Option<OverrideExt> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let last_segment = parsed
+        .path_segments()?
+        .rev()
+        .find(|s| !s.is_empty())?
+        .to_lowercase();
+
+    if last_segment.ends_with(".js")
+        || last_segment.ends_with(".mjs")
+        || last_segment.ends_with(".cjs")
+    {
+        Some(OverrideExt::Js)
+    } else if last_segment.ends_with(".yaml") || last_segment.ends_with(".yml") {
+        Some(OverrideExt::PrismYaml)
+    } else {
+        None
+    }
+}
+
+/// Validate that downloaded content is not HTML or binary data.
+fn validate_override_content(content: &str) -> Result<(), String> {
+    let trimmed = content.trim();
+    let lower = trimmed.to_lowercase();
+    if lower.starts_with("<!doctype") || lower.starts_with("<html") || lower.starts_with("<head") {
+        return Err(
+            "Downloaded content appears to be an HTML page, not a valid override script. \
+             The URL may point to a web page instead of a raw script file."
+                .to_owned(),
+        );
+    }
+    if content.contains('\0') {
+        return Err("Downloaded content contains null bytes (binary data)".to_owned());
+    }
+    Ok(())
+}
+
+/// Detect whether content is JS or Prism YAML.
+///
+/// Used as fallback when the URL has no recognizable extension.
+/// Tracks block comments (`/* */`) and recognises minified JS patterns.
+fn detect_override_ext(content: &str) -> OverrideExt {
+    let mut in_block_comment = false;
+    let mut yaml_signals = 0_u32;
+    let mut js_signals = 0_u32;
+    let mut semicolons = 0_u32;
+
+    for line in content.lines().take(1000) {
+        // Skip line comments before block-comment stripping to avoid
+        // false `/*` detection inside `// ...` or `# ...` comments.
+        if !in_block_comment {
+            let pre_trimmed = line.trim();
+            if pre_trimmed.starts_with("//") || pre_trimmed.starts_with('#') {
+                continue;
+            }
+        }
+
+        let stripped = strip_block_comments(line, &mut in_block_comment);
+        let trimmed = stripped.as_ref().trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Count semicolons
+        semicolons = semicolons.saturating_add(
+            u32::try_from(trimmed.chars().filter(|&c| c == ';').count()).unwrap_or(u32::MAX),
+        );
+
+        // Minified JS: very long line (> 500 chars) is almost certainly JS.
+        if trimmed.len() > 500 {
+            js_signals += 5;
+            continue;
+        }
+
+        // YAML document start marker
+        if trimmed == "---" || trimmed.starts_with("--- ") {
+            return OverrideExt::PrismYaml;
+        }
+        if trimmed.starts_with("%YAML") || trimmed.starts_with("%TAG") {
+            return OverrideExt::PrismYaml;
+        }
+
+        // Skip single-line comments
+        if trimmed.starts_with('#') || trimmed.starts_with("//") {
+            continue;
+        }
+
+        // YAML key-value: `key: value` (colon + space) or `key:` at EOL
+        if let Some(colon_pos) = trimmed.find(':') {
+            let key_part = &trimmed[..colon_pos];
+            let after_colon = trimmed[colon_pos + 1..].chars().next();
+            if !key_part.is_empty()
+                && !key_part.contains(' ')
+                && !key_part.contains('(')
+                && !key_part.contains('{')
+                && !key_part.contains('.')
+                && key_part
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '$')
+                && (after_colon == Some(' ') || after_colon.is_none())
+                && !trimmed.ends_with(',')
+                && !trimmed.ends_with(';')
+            {
+                yaml_signals += 1;
+            }
+        }
+
+        // YAML list item
+        if trimmed.starts_with("- ") && !trimmed.contains(';') {
+            yaml_signals += 1;
+        }
+
+        // JS keywords
+        if trimmed.starts_with("function ")
+            || trimmed.starts_with("async function ")
+            || trimmed.starts_with("class ")
+            || trimmed.starts_with("export ")
+            || trimmed.starts_with("import ")
+            || trimmed.starts_with("var ")
+            || trimmed.starts_with("let ")
+            || trimmed.starts_with("const ")
+            || trimmed.starts_with("return ")
+            || trimmed == "return"
+        {
+            js_signals += 2;
+        }
+        if trimmed.starts_with("\"use strict\"") || trimmed.starts_with("'use strict'") {
+            js_signals += 3;
+        }
+        if trimmed.contains("=>") || trimmed.contains("console.") {
+            js_signals += 1;
+        }
+    }
+
+    // Semicolons are very common in JS but rare in YAML
+    if semicolons > 20 {
+        js_signals += 5;
+    }
+
+    if yaml_signals >= 2 && yaml_signals > js_signals {
+        OverrideExt::PrismYaml
+    } else {
+        OverrideExt::Js
+    }
+}
+
+/// Strip block comments from a line, tracking multi-line comment state.
+///
+/// Returns a `Cow` to avoid allocation when no block comments are present.
+/// The `in_block_comment` flag persists across calls to handle multi-line comments.
+fn strip_block_comments<'a>(
+    line: &'a str,
+    in_block_comment: &mut bool,
+) -> std::borrow::Cow<'a, str> {
+    // Fast path: no block comment markers and not inside a block comment
+    if !*in_block_comment && !line.contains("/*") {
+        return std::borrow::Cow::Borrowed(line);
+    }
+
+    let mut result = String::new();
+    let mut remaining = line;
+    while !remaining.is_empty() {
+        if *in_block_comment {
+            if let Some(pos) = remaining.find("*/") {
+                *in_block_comment = false;
+                remaining = &remaining[pos + 2..];
+            } else {
+                break;
+            }
+        } else if let Some(pos) = remaining.find("/*") {
+            result.push_str(&remaining[..pos]);
+            *in_block_comment = true;
+            remaining = &remaining[pos + 2..];
+        } else {
+            result.push_str(remaining);
+            break;
+        }
+    }
+    std::borrow::Cow::Owned(result)
+}
+
+/// Return the default template content for a given override extension.
+fn default_template_content(ext: OverrideExt) -> String {
+    match ext {
+        OverrideExt::Js => r"// Zephyr Override Script
 // API: config.get(path), config.set(path, value), log.*, utils.*
 
 function main(config) {
@@ -65,9 +326,8 @@ function main(config) {
     return config;
 }
 "
-        }
-        OverrideExt::PrismYaml => {
-            r#"# Zephyr Prism Override
+        .to_owned(),
+        OverrideExt::PrismYaml => r#"# Zephyr Prism Override
 # Supports: $override, $prepend, $append, $filter, $transform, $remove, $default
 # Conditions: __when__, Variables: __vars__, Dependencies: __after__
 
@@ -76,13 +336,8 @@ function main(config) {
 #   $prepend:
 #     - "DOMAIN-SUFFIX,google.com,DIRECT"
 "#
-        }
-    };
-    write_file_secure(&content_path, default_content)
-        .map_err(|e| format!("Failed to create content file: {e}"))?;
-
-    // create_item atomically assigns order and persists — no race condition
-    overrides_store::create_item(&state, item)
+        .to_owned(),
+    }
 }
 
 /// Update metadata fields of an override item (not content).
@@ -587,7 +842,17 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
 /// Uses the unified `fetch_url_content` function from `fetch_util` for consistent
 /// security measures (SSRF protection, DNS pinning, redirect validation).
 async fn download_remote_content(url: &str, proxy_port: Option<u16>) -> Result<String, String> {
-    let content = fetch_url_content(url, proxy_port).await?;
+    let mut content = fetch_url_content(url, proxy_port).await?;
+    // Strip UTF-8 BOM in-place to avoid interfering with content detection
+    if content.starts_with('\u{feff}') {
+        content.drain(..'\u{feff}'.len_utf8());
+    }
+    // Reject empty responses — aligned with subscription.rs empty content check
+    if content.trim().is_empty() {
+        return Err(
+            "Remote override returned empty content. The URL may be invalid or the resource unavailable.".to_owned(),
+        );
+    }
     check_input_size(&content, "Remote override content")?;
     Ok(content)
 }


### PR DESCRIPTION
## 问题\n\n覆写脚本通过 URL 导入时，只生成了一个空模板文件，未实际下载内容。\n\n## 修复\n\n- **`override_create` 改为 async**：创建 remote 覆写时立即下载内容并写入文件\n- **URL 后缀优先检测**：`detect_ext_from_url` 使用 `reqwest::Url` 解析路径，检查 `.js/.mjs/.cjs` → JS、`.yaml/.yml` → PrismYaml\n- **内容验证**：`validate_override_content` 拒绝 HTML（`<!doctype`/`<html`/`<head`）和含 null bytes 的二进制内容\n- **内容类型检测 fallback**：URL 无后缀时 `detect_override_ext` 分析内容判断 JS 或 YAML\n  - `strip_block_comments` 辅助函数（`Cow<str>` 避免无注释行的分配）\n  - 行注释预检查（`//`/`#` 开头时跳过块注释处理）\n  - 压缩 JS 检测（行 > 500 字符，分号计数 > 20）\n  - Prism YAML `$` 键支持（`$append`、`$prepend`）\n- **BOM 剥离**：下载后用 `\u{feff}.len_utf8()` 字节数正确去除 UTF-8 BOM\n- **空内容检查**：对齐 `subscription.rs` 的空内容拒绝逻辑\n- **下载失败返回错误**：前端 `catch` 自动显示通知