### PR TITLE
fix: reapply overrides after core restart

### DIFF
--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -160,13 +160,19 @@ fn resolve_url_from_metadata(
     super::config_manager::get_config_url(app, name)
 }
 
+#[derive(serde::Serialize)]
+pub struct DownloadSubResult {
+    pub name: String,
+    pub message: String,
+}
+
 pub(crate) async fn download_sub_inner(
     app: &AppHandle,
     url: String,
     name: String,
     user_agent: Option<String>,
     overwrite: bool,
-) -> Result<String, String> {
+) -> Result<DownloadSubResult, String> {
     download_sub_inner_raw(app, url, name, user_agent, overwrite)
         .await
         .map_err(redact_url_in_string)
@@ -179,7 +185,7 @@ async fn download_sub_inner_raw(
     name: String,
     user_agent: Option<String>,
     overwrite: bool,
-) -> Result<String, String> {
+) -> Result<DownloadSubResult, String> {
     let safe_name = validate_subscription_name(&name).map_err(|e| e.to_string())?;
 
     let (host, resolved_addr, user_entered_private) = validate_subscription_url_with_ip(&url)?;
@@ -519,7 +525,10 @@ async fn download_sub_inner_raw(
         let _ = std::fs::remove_file(bp);
     }
 
-    Ok(format!("Config saved as {clean_name}"))
+    Ok(DownloadSubResult {
+        message: format!("Config saved as {clean_name}"),
+        name: clean_name,
+    })
 }
 
 fn log_sub_update_failure(name: &str, err: &str) {
@@ -542,7 +551,7 @@ pub async fn download_sub(
     user_agent: Option<String>,
     overwrite: Option<bool>,
     rate_limiter: State<'_, crate::RateLimiter>,
-) -> Result<String, String> {
+) -> Result<DownloadSubResult, String> {
     crate::rate_limit!(rate_limiter, "download_sub", 5000);
     let resolved_url = match resolve_url_from_metadata(&app, &name, url) {
         Ok(u) => u,

--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -2,7 +2,7 @@
 /**
  * 核心生命周期管理模块
  *
- * 负责订阅切换等高层 orchestration 逻辑。
+ * 负责订阅切换、重启后恢复等高层 orchestration 逻辑。
  * 此模块可以导入 api.js 和 UI 模块，避免 api.js 出现分层违规。
  */
 
@@ -96,49 +96,9 @@ export async function switchToConfig(configName, customArgs = []) {
   const configToPersist = actualConfig || configName;
   await invoke(COMMANDS.UPDATE_LAST_CONFIG, { configName: configToPersist });
   invalidateSettingsCache();
-  invalidateRunConfigCache();
 
-  // 重建 prism patches（__when__.profile 条件需要重新评估）
-  try {
-    const { rebuild } = await import('./prism.js');
-    await rebuild();
-  } catch (e) {
-    apiLogger.warn('[switchToConfig] prism.rebuild failed:', e);
-  }
-
-  // 重新应用所有启用的覆写脚本（JS 覆写可能修改 proxy-groups 等，
-  // 切换订阅后必须重新执行，否则规则引用的代理组可能不存在）
-  try {
-    const { overrideApplyAll } = await import('./prism.js');
-    const logs = await overrideApplyAll();
-    const successCount = logs?.filter(l => l.success).length ?? 0;
-    const failCount = logs?.filter(l => !l.success).length ?? 0;
-    if (logs && logs.length > 0) {
-      apiLogger.info(`[switchToConfig] override_apply_all: ${successCount} succeeded, ${failCount} failed`);
-    }
-  } catch (e) {
-    apiLogger.warn('[switchToConfig] override_apply_all failed:', e);
-  }
-
-  // 恢复代理选择（使用实际加载的配置）
-  try {
-    const { restoreProxySelection } = await import('./proxy-memory.js');
-    await restoreProxySelection(configToPersist);
-  } catch (e) {
-    apiLogger.warn('[switchToConfig] restoreProxySelection failed:', e);
-  }
-
-  // 刷新前端代理组数据（复用「保存并执行」的逻辑）
-  // 覆写脚本可能修改 proxy-groups，必须清缓存并重新渲染
-  invalidateProxiesCache();
-  invalidateConfigCache();
-  (async () => {
-    const { renderProxies, startSmartAutoTest } = await import('./proxies.js');
-    const { waitForMihomoReady } = await import('./proxy-memory.js');
-    await waitForMihomoReady();
-    await renderProxies();
-    startSmartAutoTest();
-  })().catch(e => apiLogger.warn('[switchToConfig] renderProxies failed:', e));
+  // Post-restart recovery: rebuild prism, reapply overrides, restore proxy, refresh UI
+  await postRestartRecovery(configToPersist);
 
   return {
     ...coreResult,
@@ -147,4 +107,68 @@ export async function switchToConfig(configName, customArgs = []) {
     /** @type {string|null} The actual config that was loaded */
     actualConfig: actualConfig,
   };
+}
+
+/**
+ * Post-restart recovery: rebuild prism patches, reapply all override scripts,
+ * restore the last proxy selection, and refresh the proxy UI.
+ *
+ * Must be called after every `restartCore()` invocation — `restartCore`
+ * rewrites `run_config.yaml` from the raw profile, so all previously-applied
+ * overrides (JS proxy-groups, Prism YAML patches, etc.) are lost.
+ *
+ * @param {string} configName - The active profile name (used for restoreProxySelection).
+ */
+export async function postRestartRecovery(configName) {
+  invalidateRunConfigCache();
+
+  // 1. Rebuild prism patches (__when__.profile conditions need re-evaluation)
+  try {
+    const { rebuild } = await import('./prism.js');
+    await rebuild();
+  } catch (e) {
+    apiLogger.warn('[postRestartRecovery] prism.rebuild failed:', e);
+  }
+
+  // 2. Re-apply all enabled override scripts
+  //    JS overrides may modify proxy-groups; without re-execution, rules
+  //    referencing those groups will fail.
+  try {
+    const { overrideApplyAll } = await import('./prism.js');
+    const logs = await overrideApplyAll();
+    const overrideLogs = Array.isArray(logs) ? logs : [];
+    const successCount = overrideLogs.filter(l => l?.success).length;
+    const failCount = overrideLogs.filter(l => !l?.success).length;
+    if (overrideLogs.length > 0) {
+      apiLogger.info(`[postRestartRecovery] override_apply_all: ${successCount} succeeded, ${failCount} failed`);
+    }
+  } catch (e) {
+    apiLogger.warn('[postRestartRecovery] override_apply_all failed:', e);
+  }
+
+  // 3. Restore last proxy selection for this profile
+  try {
+    const { restoreProxySelection } = await import('./proxy-memory.js');
+    await restoreProxySelection(configName);
+  } catch (e) {
+    apiLogger.warn('[postRestartRecovery] restoreProxySelection failed:', e);
+  }
+
+  // 4. Refresh frontend proxy display (overrides may have modified proxy-groups)
+  invalidateProxiesCache();
+  invalidateConfigCache();
+  try {
+    const { Bus, Events } = await import('./events.js');
+    Bus.emit(Events.CONFIG_UPDATED);
+  } catch (e) {
+    apiLogger.warn('[postRestartRecovery] CONFIG_UPDATED emit failed:', e);
+  }
+  (async () => {
+    const { renderProxies, startSmartAutoTest, syncCoreConfig } = await import('./proxies.js');
+    const { waitForMihomoReady } = await import('./proxy-memory.js');
+    await waitForMihomoReady();
+    await syncCoreConfig();
+    await renderProxies();
+    startSmartAutoTest();
+  })().catch(e => apiLogger.warn('[postRestartRecovery] renderProxies failed:', e));
 }

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -25,6 +25,7 @@ import { fetchProxyGroups as fetchProxyGroupsShared, isWritableGroupType } from 
 import { Bus, Events } from './events.js';
 import { saveProxySelection, savePrimaryGroupPreference } from './proxy-memory.js';
 import { invalidateRunConfigCache } from './run-config-cache.js';
+import { postRestartRecovery } from './lifecycle.js';
 import { startObservedGroupWatcher, stopObservedGroupWatcher, resetObservedGroup } from './observed-group.js';
 
 // Re-export switchPage for external consumers that import from this module
@@ -1236,17 +1237,8 @@ async function handleCoreRestart(btn, tObj, context) {
         const configPath = settings?.last_config || 'config.yaml';
         const customArgs = settings?.custom_args || [];
         await restartCore(configPath, customArgs);
+        await postRestartRecovery(configPath);
         showNotification(tObj.coreRestarted || 'Core restarted', 'success');
-        (async () => {
-            try {
-                const { invalidateProxiesCache, invalidateConfigCache } = await import('./cache.js');
-                invalidateProxiesCache();
-                invalidateConfigCache();
-                await renderProxies();
-            } catch (error) {
-                proxyLogger.error('Failed to re-render proxies after restart', error);
-            }
-        })();
     } catch (err) {
         proxyLogger.error(`Failed to restart core from ${context}`, err);
         showNotification(String(err), 'error');

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -34,6 +34,7 @@ import { applyTheme } from './theme.js';
 import { appStore } from './state.js';
 import { Bus, Events } from './events.js';
 import { invalidateSettingsCache } from './cache.js';
+import { postRestartRecovery } from './lifecycle.js';
 import { saveSetting, saveSettings } from './settings-helpers.js';
 import { initNetworkOptim } from './network-optim.js';
 import {
@@ -803,8 +804,8 @@ export async function initSettings() {
                 await save();
                 abortLatencyTests();
                 await restartCore(configPath, customArgs);
+                await postRestartRecovery(configPath);
                 showNotification(t.notifRestartSuccess || "Core restarted successfully", 'success');
-                syncCoreConfig();
             } catch (err) {
                 const error = toError(err);
                 showNotification(error.toString(), 'error');
@@ -1467,6 +1468,7 @@ export async function initSettings() {
             const customArgs = geoSettings.custom_args || [];
             abortLatencyTests();
             await restartCore(configPath, customArgs);
+            await postRestartRecovery(configPath);
         } catch (err) {
             const error = toError(err);
             showNotification(error.toString(), 'error');

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -11,22 +11,19 @@
 import {
     invoke,
     restartCore,
-    reloadConfig,
     abortLatencyTests,
 } from '../../api.js';
-import { switchToConfig } from '../lifecycle.js';
+import { switchToConfig, postRestartRecovery } from '../lifecycle.js';
 import { COMMANDS } from '@zephyr/shared';
 import { translations } from '../../i18n.js';
 import { rulesLogger } from '../../utils/logger.js';
 import { showNotification, showModal, showConfirmModal } from '../notifications.js';
 import { appStore } from '../state.js';
-import { Bus, Events } from '../events.js';
 import { getSettingsCached, getConfigsCached, invalidateSettingsCache, invalidateConfigsCache } from '../cache.js';
 import { formatFileSize } from '../../utils/format.js';
 import { escapeHtml, escapeAttr } from '../../utils/sanitize.js';
 import { removeContextMenu, createContextMenuContainer, attachContextMenuCloseHandlers } from '../../utils/context-menu.js';
 import { SVG_ICONS } from '../icons.js';
-import { syncCoreConfig } from '../proxies.js';
 import { initCustomDropdown } from '../dropdown.js';
 import * as prism from '../prism.js';
 
@@ -337,15 +334,21 @@ export function initSubscriptionSettings({
                 if (userAgent) {
                     invokeArgs.userAgent = userAgent;
                 }
-                await invoke(COMMANDS.DOWNLOAD_SUB, invokeArgs);
+                /** @type {{name: string, message?: string}} */
+                const savedConfig = await invoke(COMMANDS.DOWNLOAD_SUB, invokeArgs);
+                const savedConfigName = savedConfig.name;
 
                 invalidateConfigsCache();
 
                 /** @type {any} */
                 const subSettings = await invoke(COMMANDS.GET_SETTINGS);
                 const currentConfig = subSettings.last_config || 'config.yaml';
-                if (name === currentConfig || name === `${currentConfig}.yaml`) {
-                    await reloadConfig();
+                const normalizeConfigName = (/** @type {string | null | undefined} */ configName) => typeof configName === 'string' ? configName.replace(/\.(ya?ml)$/i, '') : '';
+                if (normalizeConfigName(savedConfigName) === normalizeConfigName(currentConfig)) {
+                    abortLatencyTests();
+                    const customArgs = subSettings.custom_args || [];
+                    await restartCore(savedConfigName, customArgs);
+                    await postRestartRecovery(savedConfigName);
                 }
 
                 /** @type {any} */
@@ -414,6 +417,7 @@ export function initSubscriptionSettings({
             if (wasCurrentUpdated && successCount > 0) {
                 abortLatencyTests();
                 await restartCore(currentConfig, customArgs);
+                await postRestartRecovery(currentConfig);
             }
 
             if (icon) icon.classList.remove('animate-spin');
@@ -1170,6 +1174,7 @@ export function initSubscriptionSettings({
                             abortLatencyTests();
                             const cfgCustomArgs = cfgSettings.custom_args || [];
                             await restartCore(configInfo.name, cfgCustomArgs);
+                            await postRestartRecovery(configInfo.name);
                         }
                         showNotification(t.notifSubUpdateSuccess || t.notifSubSuccess, 'success');
                         renderConfigs();
@@ -1198,8 +1203,6 @@ export function initSubscriptionSettings({
                         showNotification(t.configSuccess, 'success');
                     }
                     await renderConfigs();
-                    Bus.emit(Events.CONFIG_UPDATED);
-                    await syncCoreConfig();
                 } catch (err) {
                     const error = /** @type {Error} */ (err instanceof Error ? err : new Error(String(err)));
                     showNotification(error.toString(), 'error');

--- a/apps/desktop/src/ui/tun.js
+++ b/apps/desktop/src/ui/tun.js
@@ -12,6 +12,7 @@ import { translations, currentLang } from '../i18n.js';
 import { saveSetting } from './settings-helpers.js';
 import { appStore } from './state.js';
 import { COMMANDS } from '@zephyr/shared';
+import { postRestartRecovery } from './lifecycle.js';
 
 export function initTunToggle() {
     const toggle = /** @type {HTMLInputElement|null} */ (document.getElementById('tun-proxy-toggle'));
@@ -28,6 +29,7 @@ export function initTunToggle() {
             const currentConfig = settings.last_config || 'config.yaml';
             const customArgs = settings.custom_args || [];
             await restartCore(currentConfig, customArgs);
+            await postRestartRecovery(currentConfig);
         } catch (recoverErr) {
             tunLogger.error('recovery failed', recoverErr);
         }
@@ -94,6 +96,7 @@ export function initTunToggle() {
                         const customArgs = settings.custom_args || [];
                         await new Promise(r => setTimeout(r, 1000));
                         await restartCore(currentConfig, customArgs);
+                        await postRestartRecovery(currentConfig);
                     } catch (restartErr) {
                         tunLogger.error('failed to disable TUN', restartErr);
                     }
@@ -163,6 +166,7 @@ export function initTunToggle() {
                             const currentConfig = settings.last_config || 'config.yaml';
                             const customArgs = settings.custom_args || [];
                             const coreResult = await restartCore(currentConfig, customArgs);
+                            await postRestartRecovery(currentConfig);
                             if (coreResult?.secret) {
                                 setSecret(coreResult.secret);
                                 setWsSecret(coreResult.secret);
@@ -187,6 +191,7 @@ export function initTunToggle() {
                                 const currentConfig = settings.last_config || 'config.yaml';
                                 const customArgs = settings.custom_args || [];
                                 await restartCore(currentConfig, customArgs);
+                                await postRestartRecovery(currentConfig);
                             } catch (restartErr) {
                                 tunLogger.error('Core restart without TUN also failed', restartErr);
                             }


### PR DESCRIPTION
## Summary
- add a shared post-restart recovery flow that rebuilds Prism patches, reapplies enabled overrides, restores proxy selection, and refreshes proxy UI state
- invoke recovery after core restart paths for config switches, subscription updates, settings restarts, proxy restart, Geo update, and TUN recovery
- return structured subscription download results so the frontend can identify the actual saved config without parsing a display string

## Validation
- pnpm --filter @zephyr/desktop lint
- pnpm --filter @zephyr/desktop typecheck
- cargo fmt --check
- cargo clippy