### PR TITLE
perf: optimize rust hot paths

### DIFF
--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -127,7 +127,12 @@ async fn read_response_body(resp: reqwest::Response) -> Result<Vec<u8>, String> 
     }
 
     use futures_util::StreamExt as _;
-    let mut bytes = Vec::new();
+    let capacity = resp
+        .content_length()
+        .and_then(|len| usize::try_from(len).ok())
+        .unwrap_or(0)
+        .min(MAX_RESPONSE_SIZE);
+    let mut bytes = Vec::with_capacity(capacity);
     let mut stream = resp.bytes_stream();
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result.map_err(|e| format!("Failed to read chunk: {e}"))?;
@@ -330,7 +335,8 @@ async fn download_sub_inner_raw(
         }
     })?;
 
-    let mut content = String::from_utf8_lossy(&bytes).into_owned();
+    let mut content = String::from_utf8(bytes)
+        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
 
     // Reject empty responses — typically caused by expired subscriptions,
     // server-side errors, or CDN edge returning an empty 200.

--- a/apps/desktop/src-tauri/src/prism/rate_limiter.rs
+++ b/apps/desktop/src-tauri/src/prism/rate_limiter.rs
@@ -30,8 +30,10 @@ impl Bucket {
         let now = Instant::now();
         let cutoff = now - self.window;
 
-        // Prune expired timestamps
-        self.timestamps.retain(|&t| t > cutoff);
+        let first_valid = self.timestamps.partition_point(|&t| t <= cutoff);
+        if first_valid > 0 {
+            self.timestamps.drain(..first_valid);
+        }
 
         if self.timestamps.len() >= self.max_calls as usize {
             // Calculate when the oldest entry expires

--- a/crates/core/src/config/sanitizer.rs
+++ b/crates/core/src/config/sanitizer.rs
@@ -7,6 +7,16 @@ use std::path::Path;
 /// Maximum recursion depth for YAML processing to prevent stack overflow attacks.
 const MAX_YAML_DEPTH: usize = 100;
 
+#[inline]
+fn decode_hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// Internal implementation with depth tracking.
 #[allow(clippy::wildcard_enum_match_arm)]
 fn remove_dangerous_keys_internal(
@@ -93,45 +103,46 @@ pub fn remove_dangerous_keys_internal_pub(
 /// Complete URL decoding for path traversal detection
 /// Handles standard percent-encoding, double encoding, and mixed case
 pub fn url_decode_complete(input: &str) -> String {
-    let mut result = input.to_owned();
+    if !input.contains('%') {
+        return input.to_owned();
+    }
 
-    // Decode iteratively until no more changes (handles nested encoding)
-    let mut changed = true;
-    let max_iterations = 5; // Prevent infinite loops
-    let mut iterations = 0;
+    let mut current = input.as_bytes().to_vec();
+    let mut decoded = Vec::with_capacity(current.len());
 
-    while changed && iterations < max_iterations {
-        changed = false;
-        iterations += 1;
-
-        // Handle standard percent-encoded characters
-        let mut decoded = String::new();
-        let chars: Vec<char> = result.chars().collect();
+    for _ in 0..5 {
+        let mut changed = false;
+        decoded.clear();
         let mut i = 0;
 
-        while i < chars.len() {
-            if chars.get(i) == Some(&'%') && i + 2 < chars.len() {
-                // Try to decode %XX
-                if let Some(hex_chars) = chars.get(i + 1..i + 3) {
-                    let hex: String = hex_chars.iter().collect();
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        decoded.push(byte as char);
-                        i += 3;
-                        changed = true;
-                        continue;
-                    }
+        while let Some(&byte) = current.get(i) {
+            if byte == b'%' {
+                if let (Some(hi), Some(lo)) = (
+                    current.get(i + 1).and_then(|&byte| decode_hex_digit(byte)),
+                    current.get(i + 2).and_then(|&byte| decode_hex_digit(byte)),
+                ) {
+                    decoded.push((hi << 4) | lo);
+                    i += 3;
+                    changed = true;
+                    continue;
                 }
             }
-            if let Some(c) = chars.get(i) {
-                decoded.push(*c);
-            }
+
+            decoded.push(byte);
             i += 1;
         }
 
-        result = decoded;
+        std::mem::swap(&mut current, &mut decoded);
+        if !changed {
+            break;
+        }
+        if !current.contains(&b'%') {
+            break;
+        }
     }
 
-    result
+    String::from_utf8(current)
+        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// Common base filename sanitization shared by config and prism file handlers.

--- a/crates/core/src/config/subscription.rs
+++ b/crates/core/src/config/subscription.rs
@@ -9,6 +9,16 @@ use std::net::IpAddr;
 /// Maximum response size for subscription downloads (10 MB).
 pub const MAX_RESPONSE_SIZE: usize = 10 * 1024 * 1024;
 
+#[inline]
+fn decode_hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 // ── Pure functions for subscription content sanitization ─────────────────
 
 /// Quote `short-id` values in YAML content before parsing.
@@ -116,31 +126,33 @@ pub fn percent_decode(input: &str) -> String {
     let mut result = Vec::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
-    while i < bytes.len() {
-        if bytes.get(i) == Some(&b'%') && i + 2 < bytes.len() {
-            if let Some(hex) = bytes.get(i + 1..i + 3) {
-                if let Ok(s) = std::str::from_utf8(hex) {
-                    if let Ok(byte) = u8::from_str_radix(s, 16) {
-                        result.push(byte);
-                        i += 3;
-                        continue;
-                    }
-                }
+    while let Some(&byte) = bytes.get(i) {
+        if byte == b'%' {
+            if let (Some(hi), Some(lo)) = (
+                bytes.get(i + 1).and_then(|&byte| decode_hex_digit(byte)),
+                bytes.get(i + 2).and_then(|&byte| decode_hex_digit(byte)),
+            ) {
+                result.push((hi << 4) | lo);
+                i += 3;
+                continue;
             }
         }
-        if let Some(&b) = bytes.get(i) {
-            result.push(b);
-        }
+        result.push(byte);
         i += 1;
     }
-    String::from_utf8(result).unwrap_or_else(|_| input.to_owned())
+    String::from_utf8(result).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// Attempt to base64-decode content that does not already contain Clash markers.
 /// Returns `Some(decoded)` only if the decoded bytes are valid UTF-8, valid YAML,
 /// and contain a `proxies:` key (required for a valid Clash config).
 pub fn try_decode_base64_content(content: &str) -> Option<String> {
-    let trimmed = content.replace(&['\r', '\n', ' ', '\t'][..], "");
+    let mut trimmed = Vec::with_capacity(content.len());
+    trimmed.extend(
+        content
+            .bytes()
+            .filter(|&byte| !matches!(byte, b'\r' | b'\n' | b' ' | b'\t')),
+    );
     let decoded_bytes = base64::engine::general_purpose::STANDARD
         .decode(&trimmed)
         .ok()?;
@@ -325,25 +337,31 @@ pub fn classify_sub_error(e: String) -> u16 {
 /// Migrated from `src-tauri/src/core/subscription.rs`.
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn redact_url_in_string(s: String) -> String {
-    let mut result = s;
+    if !s.contains("http://") && !s.contains("https://") {
+        return s;
+    }
+
+    let mut result = String::with_capacity(s.len());
     let mut start_idx = 0;
-    while start_idx < result.len() {
-        let remaining = &result[start_idx..];
+    while start_idx < s.len() {
+        let remaining = &s[start_idx..];
         let found_http = remaining.find("http://");
         let found_https = remaining.find("https://");
         let found_offset = found_http.into_iter().chain(found_https).min();
         let Some(offset) = found_offset else {
+            result.push_str(remaining);
             break;
         };
         let start = start_idx + offset;
+        result.push_str(&s[start_idx..start]);
         // Find end of URL (whitespace or end of string)
-        let mut url_end = result[start..]
+        let mut url_end = s[start..]
             .find(|c: char| c.is_whitespace())
             .map(|pos| start + pos)
-            .unwrap_or(result.len());
+            .unwrap_or(s.len());
         // Trim trailing punctuation/delimiters that are likely not part of the URL
         while url_end > start {
-            let last_char = result[..url_end].chars().next_back();
+            let last_char = s[..url_end].chars().next_back();
             if let Some(c) = last_char {
                 if matches!(
                     c,
@@ -357,13 +375,14 @@ pub fn redact_url_in_string(s: String) -> String {
                 break;
             }
         }
-        let url_str = &result[start..url_end];
+        let url_str = &s[start..url_end];
         if url::Url::parse(url_str).is_ok() {
             let redacted = crate::config::merge::mask_url(url_str.to_owned());
-            result.replace_range(start..url_end, &redacted);
-            start_idx = start + redacted.len();
+            result.push_str(&redacted);
+            start_idx = url_end;
         } else {
-            start_idx = start + 4; // Skip past "http" to avoid infinite loop
+            result.push_str(&s[start..start + 4]);
+            start_idx = start + 4;
         }
     }
     result

--- a/crates/core/src/rate_limiter.rs
+++ b/crates/core/src/rate_limiter.rs
@@ -29,8 +29,10 @@ impl Bucket {
         let now = Instant::now();
         let cutoff = now - self.window;
 
-        // Prune expired timestamps
-        self.timestamps.retain(|&t| t > cutoff);
+        let first_valid = self.timestamps.partition_point(|&t| t <= cutoff);
+        if first_valid > 0 {
+            self.timestamps.drain(..first_valid);
+        }
 
         if self.timestamps.len() >= self.max_calls as usize {
             // Calculate when the oldest entry expires


### PR DESCRIPTION
## Summary
- optimize percent/url decoding with byte-level scanning and fixed hex decoding
- redact URLs in a single pass instead of repeated string replacement
- reduce subscription decode/read allocations and prune rate limiter buckets with partition_point + drain

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::indexing_slicing
- cargo test -p zephyr-core subscription
- cargo test -p zephyr-core sanitizer
- cargo test -p zephyr-core rate_limiter
- cargo test rate_limiter