### PR TITLE
perf: replace Arc<Mutex<HashMap>> with DashMap in RateLimiter

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ uuid      = { version = "1", features = ["v4"] }
 tokio     = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 url       = "2"
 regex     = "1"
+dashmap   = "6"
 clash-prism-core  = "0.1.5"
 clash-prism-smart = "0.1.1"
 

--- a/crates/core/src/rate_limiter.rs
+++ b/crates/core/src/rate_limiter.rs
@@ -2,8 +2,9 @@
 //!
 //! Entire file is pure logic with no platform dependencies.
 
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
 
 /// Per-key rate limit configuration.
 struct Bucket {
@@ -49,13 +50,14 @@ impl Bucket {
     }
 }
 
-/// Multi-key rate limiter.
+/// Multi-key rate limiter backed by a sharded lock-free map.
+///
+/// Each key's `Bucket` is protected by its own shard lock, so concurrent
+/// calls to different keys do not contend.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct RateLimiter {
-    buckets: Arc<std::sync::Mutex<HashMap<String, Bucket>>>,
+    buckets: DashMap<String, Bucket>,
 }
-
-use std::sync::Arc;
 
 impl Default for RateLimiter {
     fn default() -> Self {
@@ -69,14 +71,13 @@ impl RateLimiter {
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn new() -> Self {
         Self {
-            buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            buckets: DashMap::new(),
         }
     }
 
     /// Register a rate limit rule for a command key.
     pub fn register(&self, key: String, max_calls: u32, window_ms: u64) {
-        let mut buckets = self.buckets.lock().unwrap();
-        buckets.insert(
+        self.buckets.insert(
             key,
             Bucket::new(max_calls, Duration::from_millis(window_ms)),
         );
@@ -85,8 +86,7 @@ impl RateLimiter {
     /// Check if a call to `key` is allowed. Returns true if allowed, false if rate-limited.
     /// If no rule is registered for `key`, always allows.
     pub fn check(&self, key: &str) -> bool {
-        let mut buckets = self.buckets.lock().unwrap();
-        if let Some(bucket) = buckets.get_mut(key) {
+        if let Some(mut bucket) = self.buckets.get_mut(key) {
             bucket.check().is_ok()
         } else {
             true


### PR DESCRIPTION
## Summary

Replaced the global `Arc<Mutex<HashMap>>` in `RateLimiter` (core crate) with `DashMap`, eliminating lock contention across different rate-limit keys on every IPC call. Also removed redundant outer `Arc` wrapper since `DashMap` is already `Send + Sync`.

### Changes
- **crates/core/Cargo.toml**: added `dashmap = \"6\"` dependency
- **crates/core/src/rate_limiter.rs**: internal storage changed from `Arc<Mutex<HashMap<String, Bucket>>>` to bare `DashMap<String, Bucket>`; removed unnecessary `std::sync::Arc` import; `register()` and `check()` each save one `lock().unwrap()` call; per-key shard locking means concurrent calls to different keys never contend.

### Validation
- cargo fmt --check passed
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::indexing_slicing passed
- cargo test -p zephyr-core rate_limiter (4/4) passed
- cargo test rate_limiter (8/8) passed