### PR TITLE
perf: replace Arc<Mutex<HashMap>> with DashMap in RateLimiter

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ uuid      = { version = "1", features = ["v4"] }
 tokio     = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 url       = "2"
 regex     = "1"
+dashmap   = "6"
 clash-prism-core  = "0.1.5"
 clash-prism-smart = "0.1.1"
 

--- a/crates/core/src/rate_limiter.rs
+++ b/crates/core/src/rate_limiter.rs
@@ -2,8 +2,10 @@
 //!
 //! Entire file is pure logic with no platform dependencies.
 
-use std::collections::HashMap;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
 
 /// Per-key rate limit configuration.
 struct Bucket {
@@ -49,13 +51,16 @@ impl Bucket {
     }
 }
 
-/// Multi-key rate limiter.
+/// Multi-key rate limiter backed by a sharded concurrent map.
+///
+/// Each key's `Bucket` is wrapped in its own `Mutex` so that `check()` only
+/// acquires a read lock on the DashMap shard (via `get`), then locks only the
+/// individual bucket. Concurrent calls to different keys never contend, even
+/// when they hash to the same shard.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct RateLimiter {
-    buckets: Arc<std::sync::Mutex<HashMap<String, Bucket>>>,
+    buckets: DashMap<String, Mutex<Bucket>>,
 }
-
-use std::sync::Arc;
 
 impl Default for RateLimiter {
     fn default() -> Self {
@@ -69,25 +74,27 @@ impl RateLimiter {
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn new() -> Self {
         Self {
-            buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            buckets: DashMap::new(),
         }
     }
 
     /// Register a rate limit rule for a command key.
     pub fn register(&self, key: String, max_calls: u32, window_ms: u64) {
-        let mut buckets = self.buckets.lock().unwrap();
-        buckets.insert(
+        self.buckets.insert(
             key,
-            Bucket::new(max_calls, Duration::from_millis(window_ms)),
+            Mutex::new(Bucket::new(max_calls, Duration::from_millis(window_ms))),
         );
     }
 
     /// Check if a call to `key` is allowed. Returns true if allowed, false if rate-limited.
     /// If no rule is registered for `key`, always allows.
     pub fn check(&self, key: &str) -> bool {
-        let mut buckets = self.buckets.lock().unwrap();
-        if let Some(bucket) = buckets.get_mut(key) {
-            bucket.check().is_ok()
+        if let Some(bucket) = self.buckets.get(key) {
+            bucket
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .check()
+                .is_ok()
         } else {
             true
         }


### PR DESCRIPTION
## Summary

Replaced the global `Arc<Mutex<HashMap>>` in `RateLimiter` (core crate) with `DashMap<String, Mutex<Bucket>>`. This eliminates both the global mutex contention and the per-shard write-lock contention ([now uses `get` + per-key mutex]).

### Changes
- **crates/core/Cargo.toml**: added `dashmap = \"6\"` dependency
- **crates/core/src/rate_limiter.rs**:
  - Storage: `Arc<Mutex<HashMap>>` → `DashMap<String, Mutex<Bucket>>`
  - `check()` uses `DashMap::get` (shard read-lock) + per-key mutex so different keys never contend even when hashing to the same shard
  - Removed redundant outer `Arc`
  - Poisoned-mutex safety via `unwrap_or_else(|e| e.into_inner())`

### Validation
- cargo fmt --check passed
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::indexing_slicing passed
- cargo test -p zephyr-core rate_limiter (4/4) passed
- cargo test rate_limiter (8/8) passed