### PR TITLE
perf: replace Arc<Mutex<HashMap>> with DashMap in RateLimiter

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ uuid      = { version = "1", features = ["v4"] }
 tokio     = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 url       = "2"
 regex     = "1"
+dashmap   = "6"
 clash-prism-core  = "0.1.5"
 clash-prism-smart = "0.1.1"
 

--- a/crates/core/src/rate_limiter.rs
+++ b/crates/core/src/rate_limiter.rs
@@ -2,8 +2,10 @@
 //!
 //! Entire file is pure logic with no platform dependencies.
 
-use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
 
 /// Per-key rate limit configuration.
 struct Bucket {
@@ -49,13 +51,16 @@ impl Bucket {
     }
 }
 
-/// Multi-key rate limiter.
+/// Multi-key rate limiter backed by a sharded concurrent map.
+///
+/// Each key's `Bucket` is wrapped in `Arc<Mutex<>>` so that `check()` can
+/// clone the Arc, release the DashMap shard read lock immediately, then lock
+/// only the individual bucket. Concurrent calls to different keys never
+/// contend, even when they hash to the same shard.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct RateLimiter {
-    buckets: Arc<std::sync::Mutex<HashMap<String, Bucket>>>,
+    buckets: DashMap<String, Arc<Mutex<Bucket>>>,
 }
-
-use std::sync::Arc;
 
 impl Default for RateLimiter {
     fn default() -> Self {
@@ -69,25 +74,32 @@ impl RateLimiter {
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn new() -> Self {
         Self {
-            buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            buckets: DashMap::new(),
         }
     }
 
     /// Register a rate limit rule for a command key.
     pub fn register(&self, key: String, max_calls: u32, window_ms: u64) {
-        let mut buckets = self.buckets.lock().unwrap();
-        buckets.insert(
+        self.buckets.insert(
             key,
-            Bucket::new(max_calls, Duration::from_millis(window_ms)),
+            Arc::new(Mutex::new(Bucket::new(
+                max_calls,
+                Duration::from_millis(window_ms),
+            ))),
         );
     }
 
     /// Check if a call to `key` is allowed. Returns true if allowed, false if rate-limited.
     /// If no rule is registered for `key`, always allows.
     pub fn check(&self, key: &str) -> bool {
-        let mut buckets = self.buckets.lock().unwrap();
-        if let Some(bucket) = buckets.get_mut(key) {
-            bucket.check().is_ok()
+        // Clone the Arc to release the DashMap shard read lock immediately,
+        // then lock only the per-bucket mutex.
+        if let Some(bucket) = self.buckets.get(key).map(|r| Arc::clone(r.value())) {
+            bucket
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .check()
+                .is_ok()
         } else {
             true
         }


### PR DESCRIPTION
## Summary

Replaced the global `Arc<Mutex<HashMap>>` in `RateLimiter` (core crate) with `DashMap<String, Arc<Mutex<Bucket>>>`. This eliminates the global mutex, uses per-shard read-lock via `get()`, and immediately releases the shard lock by cloning the `Arc` before acquiring the per-bucket mutex.

### Changes
- **crates/core/Cargo.toml**: added `dashmap = \"6\"` dependency
- **crates/core/src/rate_limiter.rs**:
  - Storage: `Arc<Mutex<HashMap>>` → `DashMap<String, Arc<Mutex<Bucket>>>`
  - `check()` clones the `Arc` to release the DashMap shard read lock immediately, then locks only the per-bucket mutex
  - Poisoned-mutex safety via `unwrap_or_else(|e| e.into_inner())`

### Lock behavior comparison
| Scenario | Before | After |
|----------|--------|-------|
| Global mutex | All keys contend | Eliminated |
| Same shard, different keys | N/A | No contention (clone Arc, shard lock released) |
| Same key, concurrent calls | Blocked | Blocked (per-bucket mutex) |
| register() during check() on same shard | N/A | Not blocked (shard lock not held) |

### Validation
- cargo fmt --check passed
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::indexing_slicing passed
- cargo test -p zephyr-core rate_limiter (4/4) passed
- cargo test rate_limiter (8/8) passed