### PR TITLE
perf: replace Arc<Mutex<HashMap>> with DashMap in RateLimiter and fix critical bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,6 +7242,7 @@ dependencies = [
  "base64 0.22.1",
  "clash-prism-core",
  "clash-prism-smart",
+ "dashmap",
  "rand 0.9.4",
  "regex",
  "serde",

--- a/apps/desktop/src-tauri/src/prism/rate_limiter.rs
+++ b/apps/desktop/src-tauri/src/prism/rate_limiter.rs
@@ -28,7 +28,12 @@ impl Bucket {
     /// Returns `Ok(())` if the call is allowed, `Err(retry_after)` if rate-limited.
     fn check(&mut self) -> Result<(), Duration> {
         let now = Instant::now();
-        let cutoff = now - self.window;
+        let cutoff = now.checked_sub(self.window).unwrap_or_else(|| {
+            self.timestamps
+                .first()
+                .and_then(|t| t.checked_sub(Duration::from_nanos(1)))
+                .unwrap_or(now)
+        });
 
         let first_valid = self.timestamps.partition_point(|&t| t <= cutoff);
         if first_valid > 0 {
@@ -40,7 +45,12 @@ impl Bucket {
             let retry_after = self
                 .timestamps
                 .first()
-                .map(|&t| t.duration_since(now) + Duration::from_nanos(1))
+                .map(|&t| {
+                    t.checked_add(self.window)
+                        .and_then(|t_limit| t_limit.checked_duration_since(now))
+                        .unwrap_or(self.window)
+                        .saturating_add(Duration::from_nanos(1))
+                })
                 .unwrap_or(Duration::from_secs(1));
             Err(retry_after)
         } else {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ uuid      = { version = "1", features = ["v4"] }
 tokio     = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 url       = "2"
 regex     = "1"
+dashmap   = "6"
 clash-prism-core  = "0.1.5"
 clash-prism-smart = "0.1.1"
 

--- a/crates/core/src/rate_limiter.rs
+++ b/crates/core/src/rate_limiter.rs
@@ -2,8 +2,10 @@
 //!
 //! Entire file is pure logic with no platform dependencies.
 
-use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
 
 /// Per-key rate limit configuration.
 struct Bucket {
@@ -27,7 +29,12 @@ impl Bucket {
     /// Returns `Ok(())` if the call is allowed, `Err(retry_after)` if rate-limited.
     fn check(&mut self) -> Result<(), Duration> {
         let now = Instant::now();
-        let cutoff = now - self.window;
+        let cutoff = now.checked_sub(self.window).unwrap_or_else(|| {
+            self.timestamps
+                .first()
+                .and_then(|t| t.checked_sub(Duration::from_nanos(1)))
+                .unwrap_or(now)
+        });
 
         let first_valid = self.timestamps.partition_point(|&t| t <= cutoff);
         if first_valid > 0 {
@@ -39,7 +46,12 @@ impl Bucket {
             let retry_after = self
                 .timestamps
                 .first()
-                .map(|&t| t.duration_since(now) + Duration::from_nanos(1))
+                .map(|&t| {
+                    t.checked_add(self.window)
+                        .and_then(|t_limit| t_limit.checked_duration_since(now))
+                        .unwrap_or(self.window)
+                        .saturating_add(Duration::from_nanos(1))
+                })
                 .unwrap_or(Duration::from_secs(1));
             Err(retry_after)
         } else {
@@ -49,13 +61,16 @@ impl Bucket {
     }
 }
 
-/// Multi-key rate limiter.
+/// Multi-key rate limiter backed by a sharded concurrent map.
+///
+/// Each key's `Bucket` is wrapped in `Arc<Mutex<>>` so that `check()` can
+/// clone the Arc, release the DashMap shard read lock immediately, then lock
+/// only the individual bucket. Concurrent calls to different keys never
+/// contend, even when they hash to the same shard.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct RateLimiter {
-    buckets: Arc<std::sync::Mutex<HashMap<String, Bucket>>>,
+    buckets: DashMap<String, Arc<Mutex<Bucket>>>,
 }
-
-use std::sync::Arc;
 
 impl Default for RateLimiter {
     fn default() -> Self {
@@ -69,25 +84,32 @@ impl RateLimiter {
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn new() -> Self {
         Self {
-            buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            buckets: DashMap::new(),
         }
     }
 
     /// Register a rate limit rule for a command key.
     pub fn register(&self, key: String, max_calls: u32, window_ms: u64) {
-        let mut buckets = self.buckets.lock().unwrap();
-        buckets.insert(
+        self.buckets.insert(
             key,
-            Bucket::new(max_calls, Duration::from_millis(window_ms)),
+            Arc::new(Mutex::new(Bucket::new(
+                max_calls,
+                Duration::from_millis(window_ms),
+            ))),
         );
     }
 
     /// Check if a call to `key` is allowed. Returns true if allowed, false if rate-limited.
     /// If no rule is registered for `key`, always allows.
     pub fn check(&self, key: &str) -> bool {
-        let mut buckets = self.buckets.lock().unwrap();
-        if let Some(bucket) = buckets.get_mut(key) {
-            bucket.check().is_ok()
+        // Clone the Arc to release the DashMap shard read lock immediately,
+        // then lock only the per-bucket mutex.
+        if let Some(bucket) = self.buckets.get(key).map(|r| Arc::clone(r.value())) {
+            bucket
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .check()
+                .is_ok()
         } else {
             true
         }


### PR DESCRIPTION
## Summary

Migrate `RateLimiter` from `Arc<Mutex<HashMap>>` to `DashMap<String, Arc<Mutex<Bucket>>>` for fine-grained locking, and fix a critical panic bug in `Bucket::check`.

## Changes

### Lock contention optimization
- Replace `Arc<Mutex<HashMap<String, Bucket>>>` with `DashMap<String, Arc<Mutex<Bucket>>>`
- Clone `Arc` to release DashMap shard read lock immediately, then lock only the per-bucket mutex
- Concurrent calls to different keys never contend, even when they hash to the same shard

### Critical bug fixes
- Fix panic in `Bucket::check`: use `t.checked_add(self.window).and_then(|t_limit| t_limit.checked_duration_since(now))` instead of `t.duration_since(now)` which panics when `t < now`
- `checked_add` prevents Instant overflow with very large window durations
- `checked_duration_since` provides additional safety against edge cases
- `unwrap_or(self.window)` as fallback: overflow means large window, retry should reflect that
- `saturating_add` for the +1ns to prevent Duration overflow
- Fix `now - self.window` panic with `checked_sub`: when underflow, set cutoff to `first_timestamp - 1ns` so no timestamps are pruned (preserving rate limit integrity)
- Sync same fixes to desktop `prism/rate_limiter.rs`

### Robustness
- Handle Mutex poisoning with `unwrap_or_else(|e| e.into_inner())` instead of `unwrap()`

## Test plan
- [x] All 447 existing tests pass (323 desktop + 124 core)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Rate limiter unit tests cover within-limit, over-limit, unregistered keys, and key independence