### PR TITLE
refactor: consolidate TUN toggle cleanup into finally block

### DIFF
--- a/apps/desktop/src/ui/tun.js
+++ b/apps/desktop/src/ui/tun.js
@@ -76,12 +76,10 @@ export function initTunToggle() {
                             showNotification(t.tunAuthFailed || 'Authorization failed', 'error');
                         }
                         toggle.checked = false;
-                        if (spinner) spinner.classList.add('hidden');
                         if (statusText) {
                             statusText.textContent = t.virtualAdapter;
                             statusText.classList.remove('text-accent');
                         }
-                        appStore.set('isNetworkUpdating', false);
                         return;
                     }
                 } else {
@@ -125,9 +123,6 @@ export function initTunToggle() {
                 statusText.textContent = enable ? t.proxyActive : t.virtualAdapter;
                 if (!enable) statusText.classList.remove('text-accent');
             }
-            if (spinner) spinner.classList.add('hidden');
-            appStore.set('isNetworkUpdating', false);
-            try { await invoke(COMMANDS.RELEASE_TUN_TOGGLE); } catch (_) {}
         } catch (_err) {
             toggle.checked = !enable;
             appStore.set('isTunEnabled', !enable);
@@ -135,7 +130,6 @@ export function initTunToggle() {
                 statusText.textContent = t.virtualAdapter;
                 statusText.classList.remove('text-accent');
             }
-            if (spinner) spinner.classList.add('hidden');
 
             const isLinux = navigator.userAgent.toLowerCase().includes('linux');
             if (isLinux && enable) {
@@ -180,8 +174,6 @@ export function initTunToggle() {
                                 statusText.classList.add('text-accent');
                             }
                             showNotification(t.configSuccess, 'success');
-                            appStore.set('isNetworkUpdating', false);
-                            try { await invoke(COMMANDS.RELEASE_TUN_TOGGLE); } catch (_) {}
                             return;
                         } catch (retryErr) {
                             tunLogger.error('TUN retry failed after permission grant', retryErr);
@@ -203,6 +195,8 @@ export function initTunToggle() {
                 showNotification(isMac ? t.tunFailedMac : t.tunFailed, 'error');
             }
 
+        } finally {
+            if (spinner) spinner.classList.add('hidden');
             appStore.set('isNetworkUpdating', false);
             try { await invoke(COMMANDS.RELEASE_TUN_TOGGLE); } catch (_) {}
         }


### PR DESCRIPTION
## Summary

The TUN toggle handler in `tun.js` had 4 separate locations duplicating the same cleanup logic (spinner hide, `isNetworkUpdating` reset, `RELEASE_TUN_TOGGLE` call). This replaces them with a single `finally` block, ensuring cleanup runs on every exit path without manual duplication.

## Changes

- Moved `spinner.classList.add('hidden')`, `appStore.set('isNetworkUpdating', false)`, and `RELEASE_TUN_TOGGLE` into a single `finally` block
- Removed 4 duplicate cleanup sites from: macOS auth-cancel path, success path, Linux permission success path, and error path
- Side effect: macOS auth-cancel path now also calls `RELEASE_TUN_TOGGLE`, which was previously missed

## Test plan

- [ ] Verify TUN enable/disable works on macOS (including auth cancel)
- [ ] Verify TUN enable/disable works on Linux (including permission grant flow)
- [ ] Verify TUN enable/disable works on non-macOS/non-Linux (config patch path)
- [ ] Verify `isNetworkUpdating` is correctly reset on all exit paths
- [ ] Verify spinner is hidden on all exit paths