### PR TITLE
feat: pause rendering and polling when window is hidden

### DIFF
--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -66,6 +66,8 @@ let _unsubI18n = null;
 let _unsubTheme = null;
 /** Generation counter to invalidate stale poll callbacks on re-init */
 let _pollGeneration = 0;
+/** @type {(() => void) | null} Visibility change handler, cleaned up on destroy. */
+let _visibilityHandler = null;
 
 // HTML template for the connections page (injected into DOM on init)
 const PAGE_HTML = `
@@ -202,7 +204,7 @@ _unsubTheme = Bus.on(Events.THEME_MODE_CHANGED, _onThemeChanged);
             // Skip if a new init invalidated this generation
             if (generation !== _pollGeneration) return;
             const pageEl = document.querySelector('[data-page="connections"]');
-            if (pageEl && !pageEl.classList.contains('hidden')) {
+            if (pageEl && !pageEl.classList.contains('hidden') && !document.hidden) {
                 await fetchAndRenderConnections();
             }
             // Only schedule next poll if not destroyed during await
@@ -212,7 +214,23 @@ _unsubTheme = Bus.on(Events.THEME_MODE_CHANGED, _onThemeChanged);
         }, interval);
     }
     schedulePoll();
+
+    // Immediately refresh connections when the window becomes visible again
+    if (_visibilityHandler) {
+        document.removeEventListener('visibilitychange', _visibilityHandler);
+    }
+    _visibilityHandler = () => {
+        const pageEl = document.querySelector('[data-page="connections"]');
+        const isPageActive = pageEl && !pageEl.classList.contains('hidden');
+        if (!document.hidden && isPageActive && connectionsPollTimer != null) {
+            clearTimeout(connectionsPollTimer);
+            fetchAndRenderConnections();
+            schedulePoll();
+        }
+    };
+    document.addEventListener('visibilitychange', _visibilityHandler);
 }
+
 
 /**
  * Clean up resources when navigating away.
@@ -221,6 +239,10 @@ export function destroyConnectionsPage() {
     if (connectionsPollTimer != null) {
         clearTimeout(connectionsPollTimer);
         connectionsPollTimer = null;
+    }
+    if (_visibilityHandler) {
+        document.removeEventListener('visibilitychange', _visibilityHandler);
+        _visibilityHandler = null;
     }
     if (_unsubI18n) { _unsubI18n(); _unsubI18n = null; }
     if (_unsubTheme) { _unsubTheme(); _unsubTheme = null; }

--- a/apps/desktop/src/modules/traffic-chart.js
+++ b/apps/desktop/src/modules/traffic-chart.js
@@ -46,6 +46,43 @@ let _chartFrameId = null;
 /** @type {ReturnType<typeof setTimeout> | null} */
 let _chartResizeDebounce = null;
 
+/* ---- visibility state ---- */
+
+/** @type {boolean} Whether the document is currently visible. */
+let _isVisible = !document.hidden;
+
+/** @type {boolean} Whether data was received while hidden (needs re-render on visible). */
+let _pendingRender = false;
+
+function _onVisibilityChange() {
+  const wasHidden = !_isVisible;
+  _isVisible = !document.hidden;
+  // When becoming visible again, render any data that accumulated while hidden
+  if (wasHidden && _isVisible && _pendingRender) {
+    _pendingRender = false;
+    scheduleRender();
+  }
+}
+
+/**
+ * Start listening for document visibility changes.
+ * Called automatically by initChart().
+ * @private
+ */
+function _initVisibilityListener() {
+  _isVisible = !document.hidden;
+  _pendingRender = false;
+  document.addEventListener('visibilitychange', _onVisibilityChange);
+}
+
+/**
+ * Remove the visibility listener. Called by cleanupChart().
+ * @private
+ */
+function _destroyVisibilityListener() {
+  document.removeEventListener('visibilitychange', _onVisibilityChange);
+}
+
 /* ---- colour state ---- */
 
 /**
@@ -158,6 +195,9 @@ export function initChart() {
   // Immediately adopt the current theme colours
   updateChartTheme();
 
+  // Start listening for visibility changes (pause rendering when hidden)
+  _initVisibilityListener();
+
   // Clean up any pre-existing listeners
   if (_chartResizeHandler) {
     window.removeEventListener('resize', _chartResizeHandler);
@@ -200,6 +240,8 @@ export function initChart() {
  * Release all chart resources — call when unmounting or switching pages.
  */
 export function cleanupChart() {
+  _destroyVisibilityListener();
+
   if (_chartFrameId !== null) {
     cancelAnimationFrame(_chartFrameId);
     _chartFrameId = null;
@@ -246,7 +288,12 @@ export function updateTrafficData(data) {
     trafficHistory.shift();
   }
 
-  scheduleRender();
+  // Skip rendering when the document is hidden; mark for deferred render
+  if (!_isVisible) {
+    _pendingRender = true;
+  } else {
+    scheduleRender();
+  }
 
   // Update the numeric speed display in the DOM
   const upValEl = document.getElementById('speed-up-val');


### PR DESCRIPTION
## Summary

Pause CPU-intensive operations when the application window is not visible (minimized, covered, or on another virtual desktop), and automatically resume when the window becomes visible again.

## Changes

- **traffic-chart.js**: Skip `scheduleRender()` when `document.hidden` is true. Data collection continues to maintain history continuity. A pending render flag triggers a single render when the window becomes visible again. Visibility state is reset on `initChart()` to avoid stale state after chart unmount/remount cycles.
- **connections.js**: Skip `fetchAndRenderConnections()` when `document.hidden` is true, avoiding unnecessary HTTP requests and DOM updates while the user cannot see them. When the window becomes visible again and the connections page is active, immediately trigger a refresh and reset the poll cycle so the user sees up-to-date data without waiting for the next scheduled poll.

## Rationale

- Canvas rendering (`renderChart`) is the most CPU-intensive operation in the app — it runs on every `requestAnimationFrame` tick. Pausing it when hidden saves significant CPU and battery.
- Connections polling makes HTTP requests every 2 seconds — skipping these when hidden saves network and processing overhead.
- WebSocket connections are kept alive (disconnecting/reconnecting is more expensive than idle keepalive).
- The existing `page-visibility.js` utility was not used because it operates at the `data-page` level, whereas this feature needs document-level visibility detection.