### PR TITLE
fix: apply Prism YAML overrides in override_apply_all on config switch

### DIFF
--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -666,15 +666,14 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
 
     let meta = overrides_store::load_meta(&state)?;
 
-    // Collect all enabled JS overrides with their content.
+    // Collect all enabled overrides by type.
     // Pre-execution errors (empty file, read failure) are included in the returned logs
     // so the UI can display them alongside execution results.
-    // Scope filtering: global=true OR profile_ids contains current profile.
     let mut scripts: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
     let mut pre_logs: Vec<OverrideLog> = Vec::new();
     for item in meta.items.iter().filter(|i| i.enabled) {
         if item.ext != OverrideExt::Js {
-            continue; // Only JS overrides in Phase 1
+            continue; // JS overrides collected separately for Phase 2
         }
 
         // Scope filtering: skip if not global and not matching current profile
@@ -742,55 +741,172 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
         };
     }
 
-    if scripts.is_empty() {
+    let has_prism_yaml = meta
+        .items
+        .iter()
+        .any(|i| i.enabled && i.ext == OverrideExt::PrismYaml);
+    if scripts.is_empty() && !has_prism_yaml {
         return Ok(pre_logs);
     }
 
-    // Use batch pipeline: single load → all scripts in memory → single write → single reload
-    let script_refs: Vec<(&str, &str)> = scripts
-        .iter()
-        .map(|(_, name, content)| (content.as_str(), name.as_str()))
-        .collect();
-
-    let results = execute_batch_pipeline(&state, &script_refs, true)?;
-
-    // Convert pipeline results to override logs
-    let exec_logs: Vec<OverrideLog> = scripts
-        .iter()
-        .zip(results.iter())
-        .map(|((id, name, _), result)| {
-            let log = OverrideLog {
-                script_id: id.clone(),
-                script_name: name.clone(),
-                executed_at: chrono::Utc::now().timestamp_millis(),
-                duration_us: result.duration_us,
-                success: result.success,
-                config_modified: result.config_modified,
-                error: result.error.clone(),
-                logs: result
-                    .logs
-                    .iter()
-                    .map(|l| LogEntry {
-                        level: l.level.clone(),
-                        message: l.message.clone(),
-                    })
-                    .collect(),
-            };
-            // Persist individual logs (ignore errors)
-            if let Err(e) = overrides_store::save_log(&state, id, &log) {
-                emit_warn!(
-                    Override,
-                    OVERRIDE_APPLY_FAILED,
-                    "Failed to save log for '{id}': {e}"
-                );
-            }
-            log
-        })
-        .collect();
-
-    // Merge pre-execution errors with execution results
     let mut all_logs = pre_logs;
-    all_logs.extend(exec_logs);
+
+    // Phase 1: Apply Prism YAML overrides
+    // Prism DSL runs first so JS overrides can read and modify Prism's output.
+    // Each Prism YAML override writes a patch file and calls ext.apply() which
+    // compiles all patches together.
+    for item in meta
+        .items
+        .iter()
+        .filter(|i| i.enabled && i.ext == OverrideExt::PrismYaml)
+    {
+        // Scope filtering: skip if not global and not matching current profile
+        let in_scope = item.global
+            || current_profile_id
+                .as_ref()
+                .is_some_and(|pid| item.profile_ids.contains(pid));
+        if !in_scope {
+            continue;
+        }
+
+        let content = match overrides_store::read_content(&state, &item.id) {
+            Ok(c) if !c.is_empty() => c,
+            Ok(_) => {
+                let log = OverrideLog {
+                    script_id: item.id.clone(),
+                    script_name: item.name.clone(),
+                    executed_at: chrono::Utc::now().timestamp_millis(),
+                    duration_us: 0,
+                    success: false,
+                    config_modified: false,
+                    error: Some("Prism YAML override file is empty".to_owned()),
+                    logs: vec![LogEntry {
+                        level: "Error".to_owned(),
+                        message: "Prism YAML override content file is empty".to_owned(),
+                    }],
+                };
+                if let Err(e) = overrides_store::save_log(&state, &item.id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{}': {e}",
+                        item.name
+                    );
+                }
+                all_logs.push(log);
+                continue;
+            }
+            Err(e) => {
+                let log = OverrideLog {
+                    script_id: item.id.clone(),
+                    script_name: item.name.clone(),
+                    executed_at: chrono::Utc::now().timestamp_millis(),
+                    duration_us: 0,
+                    success: false,
+                    config_modified: false,
+                    error: Some(format!("Failed to read Prism YAML override: {e}")),
+                    logs: vec![LogEntry {
+                        level: "Error".to_owned(),
+                        message: format!("Failed to read Prism YAML override content: {e}"),
+                    }],
+                };
+                if let Err(e) = overrides_store::save_log(&state, &item.id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{}': {e}",
+                        item.name
+                    );
+                }
+                all_logs.push(log);
+                continue;
+            }
+        };
+
+        match execute_prism_yaml_write(&state, item, &content) {
+            Ok(log) => {
+                if let Err(e) = overrides_store::save_log(&state, &item.id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{}': {e}",
+                        item.name
+                    );
+                }
+                all_logs.push(log);
+            }
+            Err(e) => {
+                let log = OverrideLog {
+                    script_id: item.id.clone(),
+                    script_name: item.name.clone(),
+                    executed_at: chrono::Utc::now().timestamp_millis(),
+                    duration_us: 0,
+                    success: false,
+                    config_modified: false,
+                    error: Some(e),
+                    logs: vec![],
+                };
+                if let Err(e) = overrides_store::save_log(&state, &item.id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{}': {e}",
+                        item.name
+                    );
+                }
+                all_logs.push(log);
+            }
+        }
+    }
+
+    // Phase 2: Execute JS overrides via batch pipeline
+    // JS overrides run after Prism so they can modify Prism's output.
+    if !scripts.is_empty() {
+        // Use batch pipeline: single load → all scripts in memory → single write → single reload
+        let script_refs: Vec<(&str, &str)> = scripts
+            .iter()
+            .map(|(_, name, content)| (content.as_str(), name.as_str()))
+            .collect();
+
+        let results = execute_batch_pipeline(&state, &script_refs, true)?;
+
+        // Convert pipeline results to override logs
+        let exec_logs: Vec<OverrideLog> = scripts
+            .iter()
+            .zip(results.iter())
+            .map(|((id, name, _), result)| {
+                let log = OverrideLog {
+                    script_id: id.clone(),
+                    script_name: name.clone(),
+                    executed_at: chrono::Utc::now().timestamp_millis(),
+                    duration_us: result.duration_us,
+                    success: result.success,
+                    config_modified: result.config_modified,
+                    error: result.error.clone(),
+                    logs: result
+                        .logs
+                        .iter()
+                        .map(|l| LogEntry {
+                            level: l.level.clone(),
+                            message: l.message.clone(),
+                        })
+                        .collect(),
+                };
+                // Persist individual logs (ignore errors)
+                if let Err(e) = overrides_store::save_log(&state, id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{id}': {e}"
+                    );
+                }
+                log
+            })
+            .collect();
+
+        all_logs.extend(exec_logs);
+    }
+
     Ok(all_logs)
 }
 


### PR DESCRIPTION
## Problem

`override_apply_all` only processed JS overrides, causing Prism YAML overrides to be lost after switching subscriptions (which restarts the core and regenerates `run_config.yaml` from the raw profile).

Additionally, the early-return check `scripts.is_empty()` would skip Prism YAML processing entirely when no JS overrides existed.

## Root Cause

1. `override_apply_all` (since initial implementation in `e82a0d1`) only handled JS overrides — Prism YAML overrides were never included
2. `scripts.is_empty()` early-return prevented Phase 2 (Prism YAML) from ever executing when there were no JS overrides
3. Execution order was reversed: JS ran first, but the documented pipeline order is Prism YAML → JS

## Fix

- Added Phase 1 (Prism YAML) and Phase 2 (JS) to `override_apply_all`, following the documented pipeline order
- Fixed the early-return to check for both JS and Prism YAML overrides
- Prism YAML overrides are applied individually via `execute_prism_yaml_write` (each writes a patch file and calls `ext.apply()`)

## Testing

- [x] Switch subscription config → Prism YAML override is preserved
- [x] App startup → overrides applied correctly
- [x] All 323 Rust tests pass
- [x] All 362 JS tests pass
- [x] cargo clippy clean
- [x] cargo fmt clean