### PR TITLE
fix: apply Prism YAML overrides in override_apply_all on config switch

### DIFF
--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -470,6 +470,96 @@ fn execute_override_write(
     })
 }
 
+/// Execute a batch of Prism YAML overrides efficiently.
+///
+/// Writes all patch files first, then performs a single `ext.apply()` compilation,
+/// a single write to `run_config.yaml`, and a single hot-reload.
+/// If `trigger_reload` is false (JS overrides will follow), hot-reload is deferred
+/// to avoid redundant core reloads.
+fn execute_prism_yaml_batch(
+    state: &PrismState,
+    patches: &[(String, String, String)], // (id, name, content)
+    trigger_reload: bool,
+) -> Result<Vec<OverrideLog>, String> {
+    use crate::prism::pipeline::RUN_CONFIG_LOCK;
+
+    let _guard = RUN_CONFIG_LOCK
+        .lock()
+        .map_err(|e| format!("Run config lock poisoned: {e}"))?;
+
+    let start = std::time::Instant::now();
+
+    // Load meta once to resolve patch filenames
+    let meta = overrides_store::load_meta(state)?;
+
+    // Step 1: Write all patch files to the Prism workspace
+    let prism_dir = crate::prism::prism_data_dir(&state.app)?;
+
+    for (id, name, content) in patches {
+        let item = meta
+            .items
+            .iter()
+            .find(|i| i.id == *id)
+            .ok_or_else(|| format!("Override item '{name}' not found in meta"))?;
+
+        let patch_filename = item.patch_filename();
+        let patch_path = prism_dir.join(&patch_filename);
+        write_file_secure(&patch_path, content)
+            .map_err(|e| format!("Failed to write Prism patch for '{name}': {e}"))?;
+    }
+
+    // Step 2: Single compilation via ext.apply()
+    let lock = state
+        .inner
+        .lock()
+        .map_err(|e| format!("Prism lock failed: {e}"))?;
+    let ext = lock
+        .extension
+        .as_ref()
+        .ok_or_else(|| "Prism extension not initialized".to_owned())?;
+    let result = ext.apply(ApplyOptions::default())?;
+    drop(lock);
+
+    let duration_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+
+    // Step 3: Write the output config back to run_config.yaml
+    let paths = crate::core_manager::ensure_app_storage(&state.app)?;
+    let run_config_path = paths.core_dir.join("run_config.yaml");
+    crate::core_manager::write_file_secure(&run_config_path, &result.output_config)
+        .map_err(|e| format!("Failed to write run_config.yaml: {e}"))?;
+
+    // Step 4: Trigger hot-reload only if no JS overrides will follow
+    if trigger_reload {
+        crate::prism::pipeline::trigger_hot_reload(state)?;
+    }
+
+    // Build logs for each patch (all share the same compilation result)
+    let trace_logs: Vec<LogEntry> = result
+        .trace
+        .iter()
+        .map(|t| LogEntry {
+            level: "info".to_owned(),
+            message: format!("{t:?}"),
+        })
+        .collect();
+
+    let logs: Vec<OverrideLog> = patches
+        .iter()
+        .map(|(id, name, _)| OverrideLog {
+            script_id: id.clone(),
+            script_name: name.clone(),
+            executed_at: chrono::Utc::now().timestamp_millis(),
+            duration_us,
+            success: true,
+            config_modified: true,
+            error: None,
+            logs: trace_logs.clone(),
+        })
+        .collect();
+
+    Ok(logs)
+}
+
 /// Execute a Prism YAML override by writing it to the Prism workspace and applying.
 ///
 /// This writes the Prism YAML content as a patch file in the Prism workspace,
@@ -666,17 +756,13 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
 
     let meta = overrides_store::load_meta(&state)?;
 
-    // Collect all enabled JS overrides with their content.
+    // Collect enabled overrides by type with scope filtering.
     // Pre-execution errors (empty file, read failure) are included in the returned logs
     // so the UI can display them alongside execution results.
-    // Scope filtering: global=true OR profile_ids contains current profile.
-    let mut scripts: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
+    let mut js_scripts: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
+    let mut prism_patches: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
     let mut pre_logs: Vec<OverrideLog> = Vec::new();
     for item in meta.items.iter().filter(|i| i.enabled) {
-        if item.ext != OverrideExt::Js {
-            continue; // Only JS overrides in Phase 1
-        }
-
         // Scope filtering: skip if not global and not matching current profile
         let in_scope = item.global
             || current_profile_id
@@ -689,7 +775,11 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
         let now = chrono::Utc::now().timestamp_millis();
         match overrides_store::read_content(&state, &item.id) {
             Ok(c) if !c.is_empty() => {
-                scripts.push((item.id.clone(), item.name.clone(), c));
+                if item.ext == OverrideExt::PrismYaml {
+                    prism_patches.push((item.id.clone(), item.name.clone(), c));
+                } else {
+                    js_scripts.push((item.id.clone(), item.name.clone(), c));
+                }
             }
             Ok(_) => {
                 let log = OverrideLog {
@@ -742,55 +832,77 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
         };
     }
 
-    if scripts.is_empty() {
+    if js_scripts.is_empty() && prism_patches.is_empty() {
         return Ok(pre_logs);
     }
 
-    // Use batch pipeline: single load → all scripts in memory → single write → single reload
-    let script_refs: Vec<(&str, &str)> = scripts
-        .iter()
-        .map(|(_, name, content)| (content.as_str(), name.as_str()))
-        .collect();
+    let mut all_logs = pre_logs;
 
-    let results = execute_batch_pipeline(&state, &script_refs, true)?;
-
-    // Convert pipeline results to override logs
-    let exec_logs: Vec<OverrideLog> = scripts
-        .iter()
-        .zip(results.iter())
-        .map(|((id, name, _), result)| {
-            let log = OverrideLog {
-                script_id: id.clone(),
-                script_name: name.clone(),
-                executed_at: chrono::Utc::now().timestamp_millis(),
-                duration_us: result.duration_us,
-                success: result.success,
-                config_modified: result.config_modified,
-                error: result.error.clone(),
-                logs: result
-                    .logs
-                    .iter()
-                    .map(|l| LogEntry {
-                        level: l.level.clone(),
-                        message: l.message.clone(),
-                    })
-                    .collect(),
-            };
-            // Persist individual logs (ignore errors)
-            if let Err(e) = overrides_store::save_log(&state, id, &log) {
+    // Phase 1: Apply Prism YAML overrides (batch: write all patches → single compile → single write)
+    // Prism DSL runs first so JS overrides can read and modify Prism's output.
+    if !prism_patches.is_empty() {
+        let prism_logs = execute_prism_yaml_batch(&state, &prism_patches, js_scripts.is_empty())?;
+        for log in &prism_logs {
+            if let Err(e) = overrides_store::save_log(&state, &log.script_id, log) {
                 emit_warn!(
                     Override,
                     OVERRIDE_APPLY_FAILED,
-                    "Failed to save log for '{id}': {e}"
+                    "Failed to save log for '{}': {e}",
+                    log.script_name
                 );
             }
-            log
-        })
-        .collect();
+        }
+        all_logs.extend(prism_logs);
+    }
 
-    // Merge pre-execution errors with execution results
-    let mut all_logs = pre_logs;
-    all_logs.extend(exec_logs);
+    // Phase 2: Execute JS overrides via batch pipeline
+    // JS overrides run after Prism so they can modify Prism's output.
+    if !js_scripts.is_empty() {
+        // Use batch pipeline: single load → all scripts in memory → single write → single reload
+        let script_refs: Vec<(&str, &str)> = js_scripts
+            .iter()
+            .map(|(_, name, content)| (content.as_str(), name.as_str()))
+            .collect();
+
+        let results = execute_batch_pipeline(&state, &script_refs, true)?;
+
+        // Convert pipeline results to override logs
+        let exec_logs: Vec<OverrideLog> = js_scripts
+            .iter()
+            .zip(results.iter())
+            .map(|((id, name, _), result)| {
+                let log = OverrideLog {
+                    script_id: id.clone(),
+                    script_name: name.clone(),
+                    executed_at: chrono::Utc::now().timestamp_millis(),
+                    duration_us: result.duration_us,
+                    success: result.success,
+                    config_modified: result.config_modified,
+                    error: result.error.clone(),
+                    logs: result
+                        .logs
+                        .iter()
+                        .map(|l| LogEntry {
+                            level: l.level.clone(),
+                            message: l.message.clone(),
+                        })
+                        .collect(),
+                };
+                // Persist individual logs (ignore errors)
+                if let Err(e) = overrides_store::save_log(&state, id, &log) {
+                    emit_warn!(
+                        Override,
+                        OVERRIDE_APPLY_FAILED,
+                        "Failed to save log for '{id}': {e}"
+                    );
+                }
+                log
+            })
+            .collect();
+
+        all_logs.extend(exec_logs);
+    }
+
     Ok(all_logs)
 }
 

--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -478,7 +478,7 @@ fn execute_override_write(
 /// to avoid redundant core reloads.
 fn execute_prism_yaml_batch(
     state: &PrismState,
-    patches: &[(String, String, String)], // (id, name, content)
+    patches: &[(String, String, String, String)], // (id, name, patch_filename, content)
     trigger_reload: bool,
 ) -> Result<Vec<OverrideLog>, String> {
     use crate::prism::pipeline::RUN_CONFIG_LOCK;
@@ -489,21 +489,11 @@ fn execute_prism_yaml_batch(
 
     let start = std::time::Instant::now();
 
-    // Load meta once to resolve patch filenames
-    let meta = overrides_store::load_meta(state)?;
-
     // Step 1: Write all patch files to the Prism workspace
     let prism_dir = crate::prism::prism_data_dir(&state.app)?;
 
-    for (id, name, content) in patches {
-        let item = meta
-            .items
-            .iter()
-            .find(|i| i.id == *id)
-            .ok_or_else(|| format!("Override item '{name}' not found in meta"))?;
-
-        let patch_filename = item.patch_filename();
-        let patch_path = prism_dir.join(&patch_filename);
+    for (_id, name, patch_filename, content) in patches {
+        let patch_path = prism_dir.join(patch_filename);
         write_file_secure(&patch_path, content)
             .map_err(|e| format!("Failed to write Prism patch for '{name}': {e}"))?;
     }
@@ -545,7 +535,7 @@ fn execute_prism_yaml_batch(
 
     let logs: Vec<OverrideLog> = patches
         .iter()
-        .map(|(id, name, _)| OverrideLog {
+        .map(|(id, name, _, _)| OverrideLog {
             script_id: id.clone(),
             script_name: name.clone(),
             executed_at: chrono::Utc::now().timestamp_millis(),
@@ -760,7 +750,7 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
     // Pre-execution errors (empty file, read failure) are included in the returned logs
     // so the UI can display them alongside execution results.
     let mut js_scripts: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
-    let mut prism_patches: Vec<(String, String, String)> = Vec::new(); // (id, name, content)
+    let mut prism_patches: Vec<(String, String, String, String)> = Vec::new(); // (id, name, patch_filename, content)
     let mut pre_logs: Vec<OverrideLog> = Vec::new();
     for item in meta.items.iter().filter(|i| i.enabled) {
         // Scope filtering: skip if not global and not matching current profile
@@ -776,7 +766,12 @@ pub async fn override_apply_all(state: State<'_, PrismState>) -> Result<Vec<Over
         match overrides_store::read_content(&state, &item.id) {
             Ok(c) if !c.is_empty() => {
                 if item.ext == OverrideExt::PrismYaml {
-                    prism_patches.push((item.id.clone(), item.name.clone(), c));
+                    prism_patches.push((
+                        item.id.clone(),
+                        item.name.clone(),
+                        item.patch_filename(),
+                        c,
+                    ));
                 } else {
                     js_scripts.push((item.id.clone(), item.name.clone(), c));
                 }


### PR DESCRIPTION
## Problem

`override_apply_all` only processed JS overrides, causing Prism YAML overrides to be lost after switching subscriptions (which restarts the core and regenerates `run_config.yaml` from the raw profile).

Additionally, the early-return check `scripts.is_empty()` would skip Prism YAML processing entirely when no JS overrides existed.

## Root Cause

1. `override_apply_all` (since initial implementation in `e82a0d1`) only handled JS overrides — Prism YAML overrides were never included
2. `scripts.is_empty()` early-return prevented Prism YAML from ever executing when there were no JS overrides
3. Execution order was reversed: JS ran first, but the documented pipeline order is Prism YAML → JS

## Fix

- Added Phase 1 (Prism YAML) and Phase 2 (JS) to `override_apply_all`, following the documented pipeline order
- **Batch Prism YAML processing**: all patch files written first, then a single `ext.apply()` compilation, a single `run_config.yaml` write, and a single hot-reload (deferred if JS overrides will follow)
- Fixed the early-return to check for both JS and Prism YAML overrides

## Performance

N Prism YAML overrides: **1 compilation + 1 disk write + 1 hot-reload** (instead of N×3)

## Testing

- [x] Switch subscription config → Prism YAML override is preserved
- [x] App startup → overrides applied correctly
- [x] All 323 Rust tests pass
- [x] All 362 JS tests pass
- [x] cargo clippy clean
- [x] cargo fmt clean