### PR TITLE
fix: preserve YAML key order in JS override pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,6 +4516,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 reqwest = { version = "0.13", features = ["json", "stream", "gzip", "brotli", "deflate", "blocking"] }
 zip = "2.2"
 flate2 = "1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["rlib"]
 uniffi    = { version = "0.28", optional = true }
 thiserror = "1"
 serde     = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 base64    = "0.22"
 aes-gcm   = "0.10"


### PR DESCRIPTION
## Problem

When JS overrides are applied, the `run_config.yaml` is read via `serde_yaml::from_str` into `serde_json::Value`, then written back via `serde_yaml::to_string`. Since `serde_json::Map` defaults to `BTreeMap`, all YAML mapping keys are reordered alphabetically, altering the original key order of the configuration.

This causes proxy group keys (name, type, proxies, etc.) and top-level config keys to be rearranged, which can change the display order in the UI's proxy group dropdown.

## Fix

Enable `serde_json`'s `preserve_order` feature in both `apps/desktop/src-tauri/Cargo.toml` and `crates/core/Cargo.toml`. This makes `serde_json::Map` use `IndexMap` instead of `BTreeMap`, preserving the original insertion order of keys through the YAML → JSON → YAML round-trip.