### PR TITLE
fix: resolve proxy node list race condition after subscription switch

### DIFF
--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -155,15 +155,27 @@ export async function postRestartRecovery(configName) {
   }
 
   // 4. Refresh frontend proxy display (overrides may have modified proxy-groups)
-  invalidateProxiesCache();
-  invalidateConfigCache();
-  (async () => {
+  //    Cache invalidations happen AFTER overrides are applied and BEFORE rendering.
+  //    The earlier invalidation at the top of this function may have been
+  //    repopulated by the CORE_RESTARTED → renderProxies() handler, which runs
+  //    concurrently and can re-fill run_config/proxies caches with pre-override
+  //    data (race condition — see GH#603).
+  try {
     const { Bus, Events } = await import('./events.js');
     const { startSmartAutoTest, syncCoreConfig } = await import('./proxies.js');
     const { waitForMihomoReady } = await import('./proxy-memory.js');
     await waitForMihomoReady();
+    // Re-invalidate all caches after overrides applied, before rendering.
+    // This clears any stale data repopulated by the CORE_RESTARTED render cycle.
+    // Rendering is handled by the CONFIG_UPDATED event below — no need for
+    // an explicit renderProxies() call (which would cause a redundant double render).
+    invalidateProxiesCache();
+    invalidateConfigCache();
+    invalidateRunConfigCache();
     await syncCoreConfig();
     Bus.emit(Events.CONFIG_UPDATED);
     startSmartAutoTest();
-  })().catch(e => apiLogger.warn('[postRestartRecovery] refresh proxies failed:', e));
+  } catch (e) {
+    apiLogger.warn('[postRestartRecovery] refresh proxies failed:', e);
+  }
 }


### PR DESCRIPTION
## 问题

订阅切换/添加/更新后，节点列表可能出现空白或显示旧订阅的节点（GH#603）。

## 根因

`postRestartRecovery()` 中存在竞态条件：

1. **缓存竞态**：函数开头的 `invalidateRunConfigCache()` 会被 `CORE_RESTARTED` handler 的 `renderProxies()` 重新填充为覆写前的旧数据（5s TTL），导致后续渲染使用陈旧的 run_config
2. **fire-and-forget IIFE**：step 4 的 async IIFE 没有 await，如果 `waitForMihomoReady()` 超时或 `syncCoreConfig()` 抛异常，错误被静默吞掉，UI 永远不会刷新

## 修复

- 将缓存失效（proxies / config / run_config）移到 async 块内部，在覆写应用完成后、渲染前执行，消除竞态
- 将 fire-and-forget IIFE 改为 `await` + `try/catch`，确保错误正确传播
- 渲染由 `CONFIG_UPDATED` 事件统一驱动，避免重复渲染