### PR TITLE
feat(core): prevent mihomo orphan process on unexpected exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "glib 0.22.7",
  "hex",
  "hmac",
+ "libc",
  "minisign",
  "mockall",
  "pbkdf2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -65,6 +65,9 @@ minisign = "0.9"
 [target.'cfg(unix)'.dependencies]
 # Force upgrade glib to address known vulnerability (indirect dep via webkit2gtk/gtk on Linux/macOS)
 glib = ">= 0.20, < 1"
+# Already an indirect dep via tauri/gtk; used for prctl(PR_SET_PDEATHSIG) to
+# ensure mihomo exits when the Tauri main process dies (even from SIGKILL).
+libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [
@@ -75,6 +78,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_Threading",
+    "Win32_System_JobObjects",
     "Win32_Foundation",
     "Win32_UI_Shell"
 ] }

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -32,6 +32,74 @@ use super::{AppPaths, CoreStartResult, MihomoState, CORE_STARTING};
 #[cfg(target_os = "windows")]
 use super::CREATE_NO_WINDOW;
 
+// ── Windows Job Object for auto-killing mihomo when Tauri exits ──────────
+#[cfg(target_os = "windows")]
+mod win_job {
+    use std::sync::OnceLock;
+    use windows_sys::Win32::Foundation::*;
+    use windows_sys::Win32::System::JobObjects::*;
+    use windows_sys::Win32::System::Threading::*;
+
+    /// Wrapper to make HANDLE Send+Sync so it can live in a static.
+    /// Safety: Job Object handles are kernel objects; access is serialized by
+    /// the kernel, so sharing the handle across threads is safe.
+    struct SendSyncHandle(HANDLE);
+    unsafe impl Send for SendSyncHandle {}
+    unsafe impl Sync for SendSyncHandle {}
+
+    /// Handle to a Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
+    /// When the Tauri process exits (even from Task Manager), Windows closes
+    /// this handle and automatically terminates all processes in the Job.
+    static JOB: OnceLock<SendSyncHandle> = OnceLock::new();
+
+    /// Create (once) and return the Job Object handle.
+    fn get_or_create_job() -> HANDLE {
+        JOB.get_or_init(|| {
+            // Safety: CreateJobObjectW is a well-defined Windows API.
+            let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+            if job == 0 {
+                return SendSyncHandle(job);
+            }
+
+            let mut info: JOBOBJECT_BASIC_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+            info.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            let mut extended_info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
+                unsafe { std::mem::zeroed() };
+            extended_info.BasicLimitInformation = info;
+
+            // Safety: SetInformationJobObject with these parameters is safe.
+            let result = unsafe {
+                SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    &extended_info as *const _ as *const _,
+                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                )
+            };
+
+            if result == 0 {
+                // Failed to set info — job won't auto-kill, but don't crash.
+                unsafe { CloseHandle(job) };
+                return SendSyncHandle(0);
+            }
+
+            SendSyncHandle(job)
+        })
+        .0
+    }
+
+    /// Assign a process to the auto-kill Job Object.
+    pub fn assign_to_job(process_handle: HANDLE) -> bool {
+        let job = get_or_create_job();
+        if job == 0 {
+            return false;
+        }
+        // Safety: AssignProcessToJobObject is a well-defined Windows API.
+        unsafe { AssignProcessToJobObject(job, process_handle) != 0 }
+    }
+}
+
 // ── ProcessIo trait for testable process operations ────────────────────────
 
 /// Trait for process operations used by `core_process`.
@@ -1049,6 +1117,47 @@ async fn spawn_with_cache_retry(
             use std::os::windows::process::CommandExt as _;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            // Place mihomo in its own process group so we can kill the entire
+            // group (including any child processes mihomo may spawn) without
+            // affecting the Tauri main process.
+            cmd.process_group(0);
+            #[cfg(target_os = "linux")]
+            {
+                // Ask the kernel to send SIGTERM to mihomo when its parent
+                // (the Tauri main process) dies — even from SIGKILL.
+                // This prevents mihomo from becoming an orphan process.
+                #[allow(clippy::cast_possible_wrap)]
+                let parent_pid = std::process::id() as libc::pid_t;
+                // Safety: pre_exec runs between fork and exec; prctl and getppid
+                // are async-signal-safe syscalls with no memory safety implications.
+                #[allow(clippy::multiple_unsafe_ops_per_block)]
+                unsafe {
+                    cmd.pre_exec(move || {
+                        if libc::prctl(
+                            libc::PR_SET_PDEATHSIG,
+                            libc::SIGTERM as libc::c_ulong,
+                            0,
+                            0,
+                            0,
+                        ) == -1
+                        {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        // Prevent race condition if parent died before prctl was set.
+                        // getppid is async-signal-safe.
+                        // Use from_raw_os_error to avoid heap allocation (not
+                        // async-signal-safe) in the pre_exec closure.
+                        if libc::getppid() != parent_pid {
+                            return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
+                        }
+                        Ok(())
+                    });
+                }
+            }
+        }
         cmd.args(["-d", "."]);
         cmd.args(["-f", "run_config.yaml"]);
         for arg in safe_custom_args {
@@ -1471,6 +1580,22 @@ pub async fn start_core(
     )
     .await?;
 
+    // Windows: assign child to a Job Object with KILL_ON_JOB_CLOSE so that
+    // mihomo is automatically terminated if the Tauri process dies (even from
+    // Task Manager). This is the Windows equivalent of Linux PR_SET_PDEATHSIG.
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::io::AsRawHandle as _;
+        let handle = child.as_raw_handle();
+        if !win_job::assign_to_job(handle as _) {
+            emit_warn!(
+                Core,
+                CORE_START_FAILED,
+                "Failed to assign mihomo to Job Object (auto-kill on exit disabled)"
+            );
+        }
+    }
+
     // Use config port directly, rely on health check to verify
     let port = config_port;
 
@@ -1518,11 +1643,55 @@ pub fn stop_core_inner(app: &AppHandle, state: &MihomoState) -> Result<(), Strin
     };
 
     if let Some(mut child_process) = child {
-        // Force kill the process (cross-platform safe)
-        let _ = child_process.kill();
-        let _ = child_process.wait();
+        #[cfg(unix)]
+        {
+            // Kill the entire process group (mihomo + any child processes it spawned).
+            // Negative PID signals the process group whose ID equals |pid|.
+            #[allow(clippy::cast_possible_wrap)]
+            let pid = child_process.id() as libc::pid_t;
+            let mut killed_group = false;
+            if pid > 1 {
+                let pgid = -pid;
+                // Safety: libc::kill is a well-defined POSIX syscall. Negative pgid
+                // signals the process group, which is standard POSIX behavior.
+                if unsafe { libc::kill(pgid, libc::SIGTERM) } == 0 {
+                    // Wait up to 500ms for the process group to exit gracefully.
+                    // This ensures ports are released before we return, preventing
+                    // port binding conflicts on restart.
+                    for _ in 0..5 {
+                        if let Ok(Some(_)) = child_process.try_wait() {
+                            killed_group = true;
+                            break;
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                    }
+                    if !killed_group {
+                        // Safety: same as above — force-kill the process group.
+                        let _ = unsafe { libc::kill(pgid, libc::SIGKILL) };
+                        let _ = child_process.wait();
+                        killed_group = true;
+                    }
+                }
+            }
+            // Fallback: if process group kill failed or pid <= 1, kill the child directly
+            if !killed_group {
+                let _ = child_process.kill();
+                let _ = child_process.wait();
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            // Force kill the process (cross-platform safe)
+            let _ = child_process.kill();
+            let _ = child_process.wait();
+        }
     }
 
+    cleanup_run_config(app);
+    Ok(())
+}
+
+fn cleanup_run_config(app: &AppHandle) {
     if let Ok(paths) = ensure_app_storage(app) {
         let run_config_path = paths.core_dir.join("run_config.yaml");
         if run_config_path.exists() {
@@ -1535,8 +1704,6 @@ pub fn stop_core_inner(app: &AppHandle, state: &MihomoState) -> Result<(), Strin
             }
         }
     }
-
-    Ok(())
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

Add platform-specific mechanisms to ensure mihomo is automatically terminated when the Tauri main process dies unexpectedly (e.g. SIGKILL, Task Manager).

## Changes

- **Linux**: `PR_SET_PDEATHSIG(SIGTERM)` via `prctl` with `getppid()` race-condition check and async-signal-safe error handling
- **Windows**: Job Object with `KILL_ON_JOB_CLOSE` (thread-safe `SendSyncHandle` wrapper)
- **Unix**: `process_group(0)` + `libc::kill` for process group termination with `pid > 1` guard
- Graceful SIGTERM → 500ms wait → SIGKILL fallback (synchronous, ensures ports released before restart)
- **macOS**: no kernel-level mechanism available; relies on existing `kill_mihomo()` cleanup
- Refactored `stop_core_inner` to extract `cleanup_run_config` helper

## Dependency Notes

- `libc = "0.2"` added as direct dep for Unix — already an indirect dep via tauri/gtk
- `Win32_System_JobObjects` feature added to existing `windows-sys` dep

## Test Plan

- [x] `cargo clippy` passes with zero warnings
- [x] `pnpm -r lint` and `pnpm -r typecheck` pass
- [x] All 447 Rust tests pass
- [x] All 362 frontend tests pass
- [ ] Manual: kill Tauri process with `kill -9` and verify mihomo exits on Linux
- [ ] Manual: close Tauri via Task Manager and verify mihomo exits on Windows