### PR TITLE
feat(sys-proxy): add ownership guard to prevent external proxy tampering

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -30,7 +30,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use sys_proxy::{clear_sys_proxy, disable_sysproxy, enable_sysproxy, get_sys_proxy};
+use sys_proxy::{
+    clear_sys_proxy, disable_sysproxy, enable_sysproxy, get_sys_proxy, has_sysproxy_ownership,
+    restore_sys_proxy,
+};
 use tauri::Manager as _;
 #[cfg(desktop)]
 use tauri_plugin_autostart::Builder as AutostartBuilder;
@@ -937,8 +940,8 @@ pub fn run() {
                         // User explicitly wants to quit
                         explicit_exit.store(true, std::sync::atomic::Ordering::SeqCst);
                         kill_mihomo();
-                        let _ = clear_sys_proxy();
                         let app = window.app_handle();
+                        let _ = clear_sys_proxy(app);
                         app.cleanup_before_exit();
                         app.exit(0);
                     }
@@ -1011,6 +1014,8 @@ pub fn run() {
             enable_sysproxy,
             disable_sysproxy,
             get_sys_proxy,
+            has_sysproxy_ownership,
+            restore_sys_proxy,
             get_settings,
             save_settings,
             patch_settings,

--- a/apps/desktop/src-tauri/src/sys_proxy.rs
+++ b/apps/desktop/src-tauri/src/sys_proxy.rs
@@ -1,7 +1,9 @@
 use std::net::IpAddr;
+use std::path::PathBuf;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::process::Command;
 use tauri::command;
+use tauri::AppHandle;
 
 #[cfg(target_os = "windows")]
 use std::ptr;
@@ -15,7 +17,77 @@ use winreg::enums::HKEY_CURRENT_USER;
 #[cfg(target_os = "windows")]
 use winreg::RegKey;
 
-/// Validates that the proxy server address is a valid local address.
+// ── System Proxy Ownership Guard ─────────────────────────────────────────
+//
+// When Zephyr enables the system proxy, it writes an ownership marker file
+// (`.sys-proxy-ownership`) to the app data directory containing the server
+// address. On every periodic sync (10 s), if the marker exists but the system
+// proxy has been disabled by an external program, Zephyr automatically
+// re-enables it. On normal exit the marker is deleted together with the proxy.
+// If the app crashes, the marker persists and the proxy is restored on next
+// launch.
+
+/// Name of the ownership marker file (stored in app data dir).
+const OWNERSHIP_FILE: &str = ".sys-proxy-ownership";
+
+/// Return the path to the ownership marker file.
+fn ownership_path(app: &AppHandle) -> Option<PathBuf> {
+    crate::core_manager::resolve_app_paths(app)
+        .ok()
+        .map(|p| p.app_data_dir.join(OWNERSHIP_FILE))
+}
+
+/// Write the ownership marker with the given server address.
+fn write_ownership(app: &AppHandle, server: &str) {
+    if let Some(path) = ownership_path(app) {
+        if let Err(e) = std::fs::write(&path, server) {
+            emit_warn!(
+                System,
+                SYS_PROXY_FAILED,
+                "Failed to write proxy ownership marker: {e}"
+            );
+        }
+    }
+}
+
+/// Delete the ownership marker file.
+fn remove_ownership(app: &AppHandle) {
+    if let Some(path) = ownership_path(app) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Read the server address from the ownership marker, if it exists.
+#[must_use]
+pub fn read_ownership(app: &AppHandle) -> Option<String> {
+    let path = ownership_path(app)?;
+    std::fs::read_to_string(path)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+/// Check whether Zephyr currently owns the system proxy (marker exists).
+#[must_use]
+pub fn has_ownership(app: &AppHandle) -> bool {
+    read_ownership(app).is_some()
+}
+
+/// Restore the system proxy from the ownership marker.
+/// Called during startup (crash recovery) and during periodic guard checks.
+#[command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn restore_sys_proxy(app: AppHandle) -> Result<(), String> {
+    let server = read_ownership(&app).ok_or("No proxy ownership marker found")?;
+    enable_sysproxy(app, server, None)?;
+    Ok(())
+}
+
+/// Clean up the ownership marker on normal exit.
+pub fn cleanup_ownership(app: &AppHandle) {
+    remove_ownership(app);
+}
+
+// ── Proxy validation ────────────────────────────────────────────────────
 /// This prevents proxy hijacking by ensuring only loopback addresses are allowed.
 fn validate_proxy_server(server: &str) -> Result<(), String> {
     if server.is_empty() {
@@ -423,7 +495,11 @@ fn enable_xfce_proxy(host: &str, port: &str) -> bool {
 
 #[command]
 #[allow(clippy::needless_pass_by_value)]
-pub fn enable_sysproxy(server: String, bypass: Option<String>) -> Result<String, String> {
+pub fn enable_sysproxy(
+    app: AppHandle,
+    server: String,
+    bypass: Option<String>,
+) -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
         validate_proxy_server(&server)?;
@@ -472,6 +548,7 @@ pub fn enable_sysproxy(server: String, bypass: Option<String>) -> Result<String,
             }
         }
 
+        write_ownership(&app, &server);
         Ok("System proxy enabled".to_owned())
     }
 
@@ -496,6 +573,7 @@ pub fn enable_sysproxy(server: String, bypass: Option<String>) -> Result<String,
             }
             Ok(())
         })?;
+        write_ownership(&app, &server);
         Ok(format!("System proxy enabled on macOS (HTTP+HTTPS+SOCKS)"))
     }
 
@@ -510,6 +588,7 @@ pub fn enable_sysproxy(server: String, bypass: Option<String>) -> Result<String,
         let success = gnome_ok || kde_ok || xfce_ok;
 
         if success {
+            write_ownership(&app, &server);
             Ok("System proxy enabled on Linux".to_owned())
         } else {
             Err(
@@ -521,7 +600,8 @@ pub fn enable_sysproxy(server: String, bypass: Option<String>) -> Result<String,
 }
 
 #[command]
-pub fn disable_sysproxy() -> Result<String, String> {
+#[allow(clippy::needless_pass_by_value)]
+pub fn disable_sysproxy(app: AppHandle) -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
@@ -548,6 +628,7 @@ pub fn disable_sysproxy() -> Result<String, String> {
             }
         }
 
+        remove_ownership(&app);
         Ok("System proxy disabled".to_owned())
     }
 
@@ -559,6 +640,7 @@ pub fn disable_sysproxy() -> Result<String, String> {
             run_networksetup(&["-setsocksfirewallproxystate", service, "off"])?;
             Ok(())
         })?;
+        remove_ownership(&app);
         Ok("System proxy disabled on macOS".to_owned())
     }
 
@@ -646,6 +728,7 @@ pub fn disable_sysproxy() -> Result<String, String> {
         }
 
         if success {
+            remove_ownership(&app);
             Ok("System proxy disabled on Linux".to_owned())
         } else {
             Err(
@@ -657,11 +740,20 @@ pub fn disable_sysproxy() -> Result<String, String> {
 }
 
 // 供内部调用（如退出时清理）
-pub fn clear_sys_proxy() -> Result<(), String> {
-    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-    {
-        disable_sysproxy().map(|_| ())
-    }
+pub fn clear_sys_proxy(app: &AppHandle) -> Result<(), String> {
+    let result = disable_sysproxy(app.clone());
+    // Always clean up ownership marker even if disable failed,
+    // to avoid a stale marker triggering unwanted restore on next launch.
+    cleanup_ownership(app);
+    result.map(|_| ())
+}
+
+/// Check whether Zephyr currently owns the system proxy (for frontend guard).
+#[command]
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+pub fn has_sysproxy_ownership(app: AppHandle) -> bool {
+    has_ownership(&app)
 }
 
 #[must_use]

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -272,7 +272,7 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
             }
             let state = app.state::<MihomoState>();
             let _ = crate::core_manager::stop_core_inner(app, &state);
-            if let Err(e) = sys_proxy::clear_sys_proxy() {
+            if let Err(e) = sys_proxy::clear_sys_proxy(app) {
                 emit_warn!(
                     System,
                     SYS_PROXY_FAILED,
@@ -322,7 +322,7 @@ fn toggle_sys_proxy(app: &AppHandle) {
     let new_state = !current;
 
     let result = if current {
-        sys_proxy::disable_sysproxy()
+        sys_proxy::disable_sysproxy(app.clone())
     } else {
         // Get the current PROXY port from core state (not the API port)
         let state = app.state::<MihomoState>();
@@ -333,7 +333,7 @@ fn toggle_sys_proxy(app: &AppHandle) {
             .last_proxy_port()
             .unwrap_or(DEFAULT_MIXED_PORT);
         let server = format!("127.0.0.1:{port}");
-        sys_proxy::enable_sysproxy(server, None)
+        sys_proxy::enable_sysproxy(app.clone(), server, None)
     };
 
     if let Err(e) = result {

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -304,16 +304,47 @@ export function startUnifiedSync() {
         win._sysProxyPollInterval = null;
     }
 
+    // Crash recovery: if ownership marker exists from a previous crash, restore proxy immediately
+    (async () => {
+        try {
+            const [sysProxyOn, hasOwnership] = await Promise.all([
+                invoke(COMMANDS.GET_SYS_PROXY),
+                invoke(COMMANDS.HAS_SYSPROXY_OWNERSHIP),
+            ]);
+            if (!sysProxyOn && hasOwnership) {
+                await invoke(COMMANDS.RESTORE_SYS_PROXY);
+                appStore.set('isSysProxyEnabled', true);
+                import('./sysproxy.js').then(m => m.updateSysProxyUI());
+            }
+        } catch (_) {
+            // Non-critical: periodic sync will retry
+        }
+    })();
+
     _unifiedSyncInterval = setInterval(async () => {
         try {
-            const [realSysProxyState, actualMode] = await Promise.all([
+            const [realSysProxyState, actualMode, hasOwnership] = await Promise.all([
                 invoke(COMMANDS.GET_SYS_PROXY),
                 invoke(COMMANDS.GET_TRAY_STATUS),
+                invoke(COMMANDS.HAS_SYSPROXY_OWNERSHIP),
             ]);
 
             if (realSysProxyState !== appStore.get('isSysProxyEnabled')) {
                 appStore.set('isSysProxyEnabled', realSysProxyState);
                 import('./sysproxy.js').then(m => m.updateSysProxyUI());
+            }
+
+            // Guard: if we own the proxy but it was disabled externally, restore it
+            if (!realSysProxyState && hasOwnership) {
+                (async () => {
+                    try {
+                        await invoke(COMMANDS.RESTORE_SYS_PROXY);
+                        appStore.set('isSysProxyEnabled', true);
+                        import('./sysproxy.js').then(m => m.updateSysProxyUI());
+                    } catch (restoreErr) {
+                        trayLogger.error('Failed to restore system proxy', restoreErr);
+                    }
+                })();
             }
 
             let expectedMode;

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -50,6 +50,8 @@ export const SYS_PROXY = Object.freeze({
     ENABLE_SYSPROXY: "enable_sysproxy",
     DISABLE_SYSPROXY: "disable_sysproxy",
     GET_SYS_PROXY: "get_sys_proxy",
+    HAS_SYSPROXY_OWNERSHIP: "has_sysproxy_ownership",
+    RESTORE_SYS_PROXY: "restore_sys_proxy",
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a system proxy ownership guard that prevents external programs from silently disabling Zephyr's system proxy setting.

## Changes

- **Ownership marker file** (`.sys-proxy-ownership`): Written to app data dir when enabling system proxy, deleted on disable/exit
- **Automatic tamper recovery**: The existing 10s periodic sync now checks the ownership marker — if the proxy was disabled externally while Zephyr owns it, the proxy is automatically re-enabled via `restore_sys_proxy`
- **Crash recovery**: On startup, `startUnifiedSync()` checks the ownership marker and restores the proxy immediately if the app crashed previously
- **New Tauri commands**: `has_sysproxy_ownership` (query ownership state) and `restore_sys_proxy` (restore from marker file)

## Design decisions

- No settings toggle — the guard is always active when the user enables system proxy
- Built on the existing 10s polling in `startUnifiedSync()` — no new timers or background threads
- `restore_sys_proxy` uses the server address stored in the marker file instead of guessing the port from config
- Guard restore runs in an un-awaited IIFE to avoid blocking the periodic sync loop
- Marker is cleaned up on normal exit (both window close and tray quit) to avoid stale state
- Even if `disable_sysproxy` fails during exit, the marker is still cleaned up to prevent unwanted restore on next launch

## Test plan

- [x] `cargo clippy --all-targets` passes
- [x] `cargo fmt --check` passes
- [x] `pnpm lint` + `pnpm typecheck` pass
- [x] All 447 Rust tests pass
- [x] All 362 JS tests pass