### PR TITLE
feat(settings): add copy proxy environment variables for terminal use

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -217,6 +217,10 @@ struct Settings {
     /// Max single log file size in MB.
     #[serde(default = "default_log_max_file_mb")]
     log_max_file_mb: u32,
+    /// Shell format for copying proxy environment variables.
+    /// Values: "bash", "fish", "cmd", "powershell", "nushell".
+    #[serde(default = "default_copy_env_format")]
+    copy_env_format: String,
 }
 
 const fn default_log_retention_days() -> u32 {
@@ -224,6 +228,14 @@ const fn default_log_retention_days() -> u32 {
 }
 const fn default_log_max_file_mb() -> u32 {
     50
+}
+
+fn default_copy_env_format() -> String {
+    if cfg!(target_os = "windows") {
+        "powershell".to_owned()
+    } else {
+        "bash".to_owned()
+    }
 }
 
 impl Settings {
@@ -342,6 +354,7 @@ fn patch_settings(
             patch_field!(log_core_enabled);
             patch_field!(log_retention_days);
             patch_field!(log_max_file_mb);
+            patch_field!(copy_env_format);
         }
         if !modified {
             return Ok(());
@@ -870,6 +883,7 @@ pub fn run() {
                     log_core_enabled: false,
                     log_retention_days: default_log_retention_days(),
                     log_max_file_mb: default_log_max_file_mb(),
+                    copy_env_format: default_copy_env_format(),
                 }
             };
             app.manage(SettingsState(Arc::new(Mutex::new(settings))));

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -42,6 +42,7 @@ pub struct TrayLabels {
     pub rule: String,
     pub global: String,
     pub direct: String,
+    pub copy_env: String,
 }
 
 impl Default for TrayLabels {
@@ -54,6 +55,7 @@ impl Default for TrayLabels {
             rule: "Rule".to_owned(),
             global: "Global".to_owned(),
             direct: "Direct".to_owned(),
+            copy_env: "Copy Proxy Env".to_owned(),
         }
     }
 }
@@ -292,6 +294,9 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
             let mode = id.strip_prefix("mode_").unwrap_or("rule");
             crate::backend_event::emit_to_main(app, "tray-mode-changed", mode);
         }
+        "copy_env" => {
+            crate::backend_event::emit_to_main(app, "tray-copy-env", ());
+        }
         _ => {
             // Handle subscription switching (prefix: sub_)
             if let Some(sub_name) = id.strip_prefix("sub_") {
@@ -400,6 +405,7 @@ pub struct TrayMenuParams {
     pub direct_text: String,
     pub subscriptions_text: String,
     pub proxies_text: String,
+    pub copy_env_text: String,
     pub sys_proxy_enabled: bool,
     pub tun_enabled: bool,
     pub configs: Vec<ConfigInfo>,
@@ -433,6 +439,7 @@ pub fn update_tray_full_menu(app: AppHandle, params: TrayMenuParams) -> Result<(
         rule: params.rule_text.clone(),
         global: params.global_text.clone(),
         direct: params.direct_text.clone(),
+        copy_env: params.copy_env_text.clone(),
     };
     drop(guard);
 
@@ -502,6 +509,14 @@ pub fn update_tray_full_menu(app: AppHandle, params: TrayMenuParams) -> Result<(
         .item(&rule_i)
         .item(&global_i)
         .item(&direct_i);
+
+    // Build Copy Proxy Env menu item
+    let env_sep = PredefinedMenuItem::separator(&app)
+        .map_err(|e| format!("Failed to create separator: {e}"))?;
+    let copy_env_i = MenuItem::with_id(&app, "copy_env", &params.copy_env_text, true, None::<&str>)
+        .map_err(|e| format!("Failed to create copy env item: {e}"))?;
+
+    builder = builder.item(&env_sep).item(&copy_env_i);
 
     // Build separate Subscriptions and Proxies submenus
     let has_configs = !params.configs.is_empty();
@@ -685,6 +700,17 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
         Err(_) => return,
     };
 
+    // Copy Proxy Env menu item
+    let env_sep = match PredefinedMenuItem::separator(app) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let copy_env_i = match MenuItem::with_id(app, "copy_env", &labels.copy_env, true, None::<&str>)
+    {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
     let sep2 = match PredefinedMenuItem::separator(app) {
         Ok(s) => s,
         Err(_) => return,
@@ -703,6 +729,8 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
         .item(&rule_i)
         .item(&global_i)
         .item(&direct_i)
+        .item(&env_sep)
+        .item(&copy_env_i)
         .item(&sep2)
         .item(&quit_i)
         .build();

--- a/apps/desktop/src/i18n.js
+++ b/apps/desktop/src/i18n.js
@@ -318,6 +318,13 @@ export const translations = {
         trayProxyMode: "Proxy Mode",
         traySubscriptions: "Subscriptions",
         trayProxies: "Proxies",
+        trayCopyEnv: "Copy Proxy Env",
+        trayCopyEnvSuccess: "Proxy env vars copied",
+        copyProxyEnv: "Copy Proxy Env",
+        copyProxyEnvDesc: "Copy proxy env vars for terminal use",
+        copyEnvFormat: "Shell Format",
+        copyEnvCopied: "Copied",
+        copy: "Copy",
 
         // Rule buttons
         moveToTop: "Move to Top",
@@ -980,6 +987,13 @@ export const translations = {
         trayProxyMode: "代理模式",
         traySubscriptions: "订阅选择",
         trayProxies: "节点选择",
+        trayCopyEnv: "复制代理环境变量",
+        trayCopyEnvSuccess: "代理环境变量已复制",
+        copyProxyEnv: "复制代理环境变量",
+        copyProxyEnvDesc: "复制代理环境变量到剪贴板，方便终端使用",
+        copyEnvFormat: "Shell 格式",
+        copyEnvCopied: "已复制",
+        copy: "复制",
 
         // Rule buttons
         moveToTop: "移至顶部",
@@ -1538,6 +1552,13 @@ export const translations = {
         overrideCoreNotRunning: '⚠ コア未起動、検証不可',
         auto: '自動',
         dismiss: "閉じる",
+        trayCopyEnv: "プロキシ環境変数をコピー",
+        trayCopyEnvSuccess: "プロキシ環境変数をコピーしました",
+        copyProxyEnv: "プロキシ環境変数をコピー",
+        copyProxyEnvDesc: "ターミナル用にプロキシ環境変数をコピー",
+        copyEnvFormat: "シェル形式",
+        copyEnvCopied: "コピー済み",
+        copy: "コピー",
     },
 
     ko: {
@@ -1626,6 +1647,13 @@ export const translations = {
         logLevelFatal: "치명적",
         logPaused: "일시 정지",
         logLines: "줄",
+        trayCopyEnv: "프록시 환경변수 복사",
+        trayCopyEnvSuccess: "프록시 환경변수 복사됨",
+        copyProxyEnv: "프록시 환경변수 복사",
+        copyProxyEnvDesc: "터미널 사용을 위해 프록시 환경변수 복사",
+        copyEnvFormat: "셸 형식",
+        copyEnvCopied: "복사됨",
+        copy: "복사",
     },
 };
 

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -712,6 +712,29 @@
 
                             <div class="h-px bg-[var(--zephyr-bg-muted)]"></div>
 
+                            <!-- Copy Proxy Env -->
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-4">
+                                    <div class="text-[var(--text-secondary)]">
+                                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                                    </div>
+                                    <div>
+                                        <div class="flex items-center gap-3">
+                                            <p class="text-sm font-semibold text-[var(--text-primary)]" data-i18n="copyProxyEnv">Copy Proxy Env</p>
+                                            <button id="copy-env-format-btn" class="text-[var(--text-muted)] hover:text-accent transition-colors" title="Configure shell format">
+                                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                                            </button>
+                                        </div>
+                                        <p class="text-2xs text-[var(--text-muted)]" data-i18n="copyProxyEnvDesc">Copy proxy env vars for terminal use</p>
+                                    </div>
+                                </div>
+                                <button id="copy-env-btn" class="btn-ghost">
+                                    <span data-i18n="copy">Copy</span>
+                                </button>
+                            </div>
+
+                            <div class="h-px bg-[var(--zephyr-bg-muted)]"></div>
+
                             <!-- Encrypt Configs -->
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center gap-4">

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -135,6 +135,153 @@ async function syncUserAgentToBackend() {
 const debouncedSyncUA = debounce(() => syncUserAgentToBackend(), 500);
 
 // ---------------------------------------------------------------------------
+//  Copy Proxy Env Settings
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the "Copy Proxy Env" settings row:
+ * - Copy button: copies env vars in the configured format
+ * - Gear button: opens a modal to select the shell format
+ */
+function initCopyEnvSettings() {
+    const copyBtn = document.getElementById('copy-env-btn');
+    const formatBtn = document.getElementById('copy-env-format-btn');
+
+    /** @type {() => Record<string, any>} */
+    const getT = () => /** @type {any} */ (translations)[appStore.get('currentLang')] ?? {};
+
+    // --- Copy button ---
+    copyBtn?.addEventListener('click', async () => {
+        try {
+            // Clear any pending restore timeout to prevent text getting stuck
+            if (copyBtn.dataset._copyTimeout) {
+                clearTimeout(Number(copyBtn.dataset._copyTimeout));
+                delete copyBtn.dataset._copyTimeout;
+            }
+            const settings = await invoke(COMMANDS.GET_SETTINGS);
+            const { generateProxyEnvVars, copyToClipboard, resolveEnvFormat } = await import('./tray.js');
+            const format = resolveEnvFormat(settings.copy_env_format);
+            const { getConfig } = await import('../api.js');
+            const currentConfig = /** @type {any} */ (await getConfig());
+            const port = currentConfig?.['mixed-port'] || currentConfig?.port || currentConfig?.['socks-port'] || 7890;
+            const text = generateProxyEnvVars(format, port);
+            await copyToClipboard(text);
+            const t = getT();
+            // Visual feedback: briefly change button text (target span to preserve i18n)
+            const textSpan = copyBtn.querySelector('span') || copyBtn;
+            // Store original text only on first click (not during "Copied" state)
+            if (!copyBtn.dataset._originalText) {
+                copyBtn.dataset._originalText = textSpan.textContent || '';
+            }
+            textSpan.textContent = t.copyEnvCopied || 'Copied';
+            copyBtn.style.color = 'var(--accent-primary, #6366f1)';
+            const timeoutId = setTimeout(() => {
+                textSpan.textContent = copyBtn.dataset._originalText || '';
+                copyBtn.style.color = '';
+                delete copyBtn.dataset._originalText;
+                delete copyBtn.dataset._copyTimeout;
+            }, 1500);
+            copyBtn.dataset._copyTimeout = String(timeoutId);
+        } catch (err) {
+            settingsLogger.error('[copy-env] Failed to copy:', err);
+        }
+    });
+
+    // --- Format selection modal (gear icon) ---
+    formatBtn?.addEventListener('click', async () => {
+        document.getElementById('copy-env-format-modal')?.remove();
+
+        const t = getT();
+        const settings = await invoke(COMMANDS.GET_SETTINGS);
+        const { resolveEnvFormat: resolveEnvFormatImported } = await import('./tray.js');
+        const currentFormat = resolveEnvFormatImported(settings.copy_env_format);
+
+        const formats = [
+            { key: 'bash', label: 'Bash / Zsh' },
+            { key: 'fish', label: 'Fish' },
+            { key: 'cmd', label: 'CMD' },
+            { key: 'powershell', label: 'PowerShell' },
+            { key: 'nushell', label: 'Nushell' },
+        ];
+
+        const modal = document.createElement('div');
+        modal.id = 'copy-env-format-modal';
+        modal.className = 'fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-[var(--zephyr-bg-overlay)] backdrop-blur-md';
+        // eslint-disable-next-line no-unsanitized/property -- i18n translation keys
+        modal.innerHTML = `
+            <div class="glass-card w-[360px] p-6 space-y-4">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-sm font-bold text-[var(--text-primary)]">${t.copyEnvFormat || 'Shell Format'}</h3>
+                    <button id="copy-env-modal-close" class="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
+                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="space-y-1">
+                    ${formats.map(f => `
+                        <button class="copy-env-format-option w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-[var(--zephyr-bg-muted)] ${f.key === currentFormat ? 'bg-[var(--zephyr-bg-muted)]' : ''}" data-format="${f.key}">
+                            <span class="text-xs text-[var(--text-primary)]">${f.label}</span>
+                            ${f.key === currentFormat ? '<svg class="w-4 h-4 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>' : ''}
+                        </button>
+                    `).join('')}
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(modal);
+        document.body.style.overflow = 'hidden';
+
+        // Animate in
+        requestAnimationFrame(() => {
+            const panel = modal.querySelector('.glass-card');
+            if (panel instanceof HTMLElement) {
+                panel.style.transform = 'scale(0.96)';
+                panel.style.opacity = '0';
+                requestAnimationFrame(() => {
+                    panel.style.transition = 'all 0.25s cubic-bezier(0.16, 1, 0.3, 1)';
+                    panel.style.transform = 'scale(1)';
+                    panel.style.opacity = '1';
+                });
+            }
+        });
+
+        const closeModal = () => {
+            document.body.style.overflow = '';
+            const panel = modal.querySelector('.glass-card');
+            if (panel instanceof HTMLElement) {
+                panel.style.transition = 'all 0.15s ease-in';
+                panel.style.transform = 'scale(0.96)';
+                panel.style.opacity = '0';
+                setTimeout(() => modal.remove(), 150);
+            } else {
+                modal.remove();
+            }
+        };
+
+        document.getElementById('copy-env-modal-close')?.addEventListener('click', closeModal);
+        modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+
+        // Escape key to close modal
+        /** @param {KeyboardEvent} e */
+        const onEscape = (e) => { if (e.key === 'Escape') { closeModal(); document.removeEventListener('keydown', onEscape); } };
+        document.addEventListener('keydown', onEscape);
+
+        // Format selection
+        modal.querySelectorAll('.copy-env-format-option').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                const selectedFormat = btn.getAttribute('data-format');
+                if (!selectedFormat) return;
+                try {
+                    await invoke(COMMANDS.PATCH_SETTINGS, { patch: { copy_env_format: selectedFormat } });
+                } catch (err) {
+                    settingsLogger.error('[copy-env] Failed to save format:', err);
+                }
+                closeModal();
+            });
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
 //  initUwpExemption
 // ---------------------------------------------------------------------------
 export function initUwpExemption() {
@@ -1957,6 +2104,8 @@ export async function initSettings() {
 
     // Initialize log settings modal
     initLogSettingsModal();
+
+    initCopyEnvSettings();
 
     initFakeClient();
 

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -150,6 +150,7 @@ export async function updateTrayMenu(forceRefresh = false) {
                 directText: t.direct || "Direct",
                 subscriptionsText: t.traySubscriptions || "Subscriptions",
                 proxiesText: t.trayProxies || "Proxies",
+                copyEnvText: t.trayCopyEnv || "Copy Proxy Env",
                 sysProxyEnabled,
                 tunEnabled,
                 configs,
@@ -286,6 +287,24 @@ export async function initTrayEventListeners() {
         }
     });
     _trayEventUnlisteners.push(unlisten5);
+
+    // Listen for copy proxy env from tray
+    const unlisten6 = await listen('tray-copy-env', async () => {
+        try {
+            const settings = await invoke(COMMANDS.GET_SETTINGS);
+            const format = resolveEnvFormat(settings?.copy_env_format);
+            const currentConfig = /** @type {any} */ (await getConfig());
+            const port = currentConfig?.['mixed-port'] || currentConfig?.port || currentConfig?.['socks-port'] || 7890;
+            const text = generateProxyEnvVars(format, port);
+            await copyToClipboard(text);
+            const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
+            const t = /** @type {Record<string, string>} */(translations[langKey]);
+            showNotification(t.trayCopyEnvSuccess || 'Proxy env vars copied', 'info');
+        } catch (err) {
+            trayLogger.error('Failed to copy proxy env vars', err);
+        }
+    });
+    _trayEventUnlisteners.push(unlisten6);
 }
 
 // --- Unified periodic sync ---
@@ -365,5 +384,77 @@ export function stopUnifiedSync() {
     if (_unifiedSyncInterval) {
         clearInterval(_unifiedSyncInterval);
         _unifiedSyncInterval = null;
+    }
+}
+
+// --- Proxy env var generation ---
+
+/**
+ * Detect the default shell format based on the current platform.
+ * @returns {string} Shell format key: bash, cmd, powershell, fish, nushell
+ */
+export function detectDefaultShellFormat() {
+    const ua = navigator.userAgent.toLowerCase();
+    if (ua.includes('windows')) return 'powershell';
+    return 'bash';
+}
+
+/**
+ * Resolve the effective shell format from the user's setting.
+ * Falls back to platform detection if the stored value is empty or invalid.
+ * @param {string} format - Format from settings
+ * @returns {string} Resolved format key
+ */
+export function resolveEnvFormat(format) {
+    const validFormats = ['bash', 'fish', 'cmd', 'powershell', 'nushell'];
+    if (format && validFormats.includes(format)) return format;
+    return detectDefaultShellFormat();
+}
+
+/**
+ * Generate proxy environment variable strings for various shell formats.
+ * @param {string} format - Shell format: bash, fish, cmd, powershell, nushell
+ * @param {number} port - Proxy port number
+ * @returns {string} Formatted env var string ready to copy
+ */
+export function generateProxyEnvVars(format, port = 7890) {
+    const proxy = `http://127.0.0.1:${port}`;
+    switch (format) {
+        case 'bash':
+            return `export https_proxy=${proxy} http_proxy=${proxy} all_proxy=${proxy}`;
+        case 'fish':
+            return `set -x http_proxy ${proxy}; set -x https_proxy ${proxy}; set -x all_proxy ${proxy}`;
+        case 'cmd':
+            return `set http_proxy=${proxy}\r\nset https_proxy=${proxy}\r\nset all_proxy=${proxy}`;
+        case 'powershell':
+            return `$env:HTTP_PROXY="${proxy}"; $env:HTTPS_PROXY="${proxy}"; $env:ALL_PROXY="${proxy}"`;
+        case 'nushell':
+            return `$env.HTTP_PROXY = "${proxy}"; $env.HTTPS_PROXY = "${proxy}"; $env.ALL_PROXY = "${proxy}"`;
+        default:
+            return `export https_proxy=${proxy} http_proxy=${proxy} all_proxy=${proxy}`;
+    }
+}
+
+/**
+ * Copy text to clipboard with fallback for environments without clipboard API.
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+export async function copyToClipboard(text) {
+    try {
+        await navigator.clipboard.writeText(text);
+    } catch (_) {
+        // Fallback for environments without clipboard API
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+        } finally {
+            document.body.removeChild(textarea);
+        }
     }
 }


### PR DESCRIPTION
Add a "Copy Proxy Env" row in Network & Routing settings with a copy button and a gear icon to select shell format (Bash/Fish/CMD/PowerShell/Nushell). Also add a "Copy Proxy Env" item in the tray context menu that copies using the user's configured format. Default format is auto-detected from the platform (PowerShell on Windows, Bash elsewhere).

Changes:
- Settings UI: copy button + format selector modal (with Escape key support)
- Tray menu: single "Copy Proxy Env" item
- Shared helpers: `detectDefaultShellFormat`, `resolveEnvFormat`, `generateProxyEnvVars` exported from tray.js
- Rust backend: `copy_env_format` setting with platform-aware default, `copy_env` as first-class match arm
- i18n: English/Chinese/Japanese/Korean translations
- CMD format uses CRLF line endings for proper Windows pasting
- Copy button targets nested `<span>` to preserve i18n data attributes
- Copy button handles rapid clicks (stores original text in dataset, clears pending timeout)