### PR TITLE
fix(core): force restart on subscription update and harden last_config lifecycle

### DIFF
--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -1,8 +1,9 @@
 use crate::core_manager::MihomoState;
+use crate::{persist_settings, SettingsState};
 use std::fs::{self, File};
 use std::path::PathBuf;
 use std::process::Command;
-use tauri::{AppHandle, Manager as _};
+use tauri::{AppHandle, Manager as _, State};
 use tauri_plugin_dialog::DialogExt as _;
 
 use super::core_process::ensure_app_storage;
@@ -243,8 +244,55 @@ pub async fn update_subscription_ua(
     Ok(())
 }
 
+/// 删除配置后检查 `last_config` 是否悬空（指向已删除的文件）。
+/// 如果是，重置为第一个可用配置；如果没有任何配置，置为 `None`。
+fn cleanup_dangling_last_config(
+    app: &AppHandle,
+    state: &State<'_, SettingsState>,
+    paths: &super::AppPaths,
+    deleted_name: &str,
+) {
+    let mut settings_guard = state
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let needs_cleanup = settings_guard
+        .last_config
+        .as_deref()
+        .is_some_and(|lc| lc == deleted_name);
+
+    if !needs_cleanup {
+        return;
+    }
+
+    // 找到第一个可用的配置文件作为替代
+    let new_config = super::core_process::first_available_profile(paths).and_then(|p| {
+        p.file_name()
+            .and_then(|name| name.to_str())
+            .map(std::borrow::ToOwned::to_owned)
+    });
+    settings_guard.last_config = new_config;
+    let settings_clone = settings_guard.clone();
+    drop(settings_guard);
+
+    if let Err(e) = persist_settings(app, &settings_clone) {
+        eprintln!("[delete_config] failed to persist settings after last_config cleanup: {e}");
+    }
+    if let Some(name) = &settings_clone.last_config {
+        eprintln!("[delete_config] last_config was dangling (pointed to deleted '{deleted_name}'), reset to '{name}'");
+    } else {
+        eprintln!("[delete_config] last_config was dangling (pointed to deleted '{deleted_name}'), reset to None (no profiles left)");
+    }
+}
+
 #[tauri::command]
-pub async fn delete_config(app: AppHandle, name: String) -> Result<String, String> {
+#[allow(private_interfaces)]
+pub async fn delete_config(
+    app: AppHandle,
+    state: State<'_, SettingsState>,
+    name: String,
+) -> Result<String, String> {
     let paths = ensure_app_storage(&app)?;
 
     // Ensure the name has a .yaml extension
@@ -274,6 +322,7 @@ pub async fn delete_config(app: AppHandle, name: String) -> Result<String, Strin
             let mut metadata = load_metadata(&paths);
             metadata.configs.remove(&yml_name);
             save_metadata(&paths, &metadata)?;
+            cleanup_dangling_last_config(&app, &state, &paths, &yml_name);
             return Ok(format!("Config {yml_name} deleted"));
         }
         return Err("File does not exist".to_owned());
@@ -302,6 +351,10 @@ pub async fn delete_config(app: AppHandle, name: String) -> Result<String, Strin
         metadata.configs.remove(&name);
     }
     save_metadata(&paths, &metadata)?;
+
+    // 如果被删除的配置恰好是 last_config 指向的配置，重置为第一个可用配置，
+    // 避免悬空指针导致下次冷启动加载到错误的配置。
+    cleanup_dangling_last_config(&app, &state, &paths, &clean_name);
 
     Ok(format!("Config {name} deleted"))
 }

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -657,7 +657,7 @@ rules:
     Ok(())
 }
 
-fn first_available_profile(paths: &AppPaths) -> Option<PathBuf> {
+pub(crate) fn first_available_profile(paths: &AppPaths) -> Option<PathBuf> {
     let mut configs = Vec::new();
     let entries = match fs::read_dir(&paths.profiles_dir) {
         Ok(entries) => entries,
@@ -1338,6 +1338,7 @@ pub async fn start_core(
     test: bool,
     custom_args: Vec<String>,
     secret: Option<String>,
+    force: Option<bool>,
 ) -> Result<CoreStartResult, String> {
     // Wait for any previous core start operation to complete (max 10s)
     let mut wait_ms = 0;
@@ -1392,7 +1393,7 @@ pub async fn start_core(
                 let same_config = lock
                     .last_config_path()
                     .is_some_and(|current| current == config_path);
-                if same_config {
+                if same_config && !force.unwrap_or(false) {
                     if let Some(port) = lock.last_port() {
                         let active = lock.last_config_path().map(std::borrow::ToOwned::to_owned);
                         return Ok(CoreStartResult {
@@ -1403,7 +1404,7 @@ pub async fn start_core(
                     }
                     None
                 } else {
-                    // Core is running with a different config — prepare drain info
+                    // Core is running with a different config (or force restart) — prepare drain info
                     lock.last_port()
                         .map(|port| (port, lock.last_secret().to_owned()))
                 }

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -63,8 +63,8 @@ fn build_http_client_with_proxy(
     });
 
     let mut client_builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .connect_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
         .redirect(redirect_policy)
         .no_proxy();
 
@@ -163,6 +163,59 @@ fn resolve_url_from_metadata(
 
     // Reuse the existing, sanitized logic from config_manager
     super::config_manager::get_config_url(app, name)
+}
+
+/// 获取 mihomo API 的客户端、URL 和 secret。
+/// 失败时返回 None（核心未运行或端口未就绪）。
+fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
+    let (api_port, secret) = {
+        let state = app.state::<MihomoState>();
+        let guard = state
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.process()?;
+        (guard.last_port()?, guard.last_secret().to_owned())
+    };
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .ok()?;
+    let url = format!("http://127.0.0.1:{api_port}/configs");
+    Some((client, url, secret))
+}
+
+/// 获取 mihomo 当前的代理模式（rule / global / direct）。
+/// 失败时返回 None，调用方可据此跳过 global 回退。
+async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
+    let (client, url, secret) = mihomo_api_client(app)?;
+    let mut req = client.get(&url);
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    body.get("mode")?
+        .as_str()
+        .map(std::borrow::ToOwned::to_owned)
+}
+
+/// 通过 mihomo API 切换代理模式。失败时返回 None。
+async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
+    let (client, url, secret) = mihomo_api_client(app)?;
+    let mut req = client
+        .patch(&url)
+        .json(&serde_json::json!({ "mode": mode }));
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    resp.status().is_success().then_some(())
 }
 
 #[derive(serde::Serialize)]
@@ -285,7 +338,7 @@ async fn download_sub_inner_raw(
             guard.and_then(|g| {
                 g.process()
                     .is_some()
-                    .then(|| format!("http://127.0.0.1:{}", g.last_port().unwrap_or(7890)))
+                    .then(|| format!("http://127.0.0.1:{}", g.last_proxy_port().unwrap_or(7890)))
             })
         };
 
@@ -299,11 +352,16 @@ async fn download_sub_inner_raw(
             // - ⚠️  Proxy-side SSRF (proxy resolving to internal IPs) is NOT
             //     preventable client-side — this is inherent to any proxy architecture.
             //     Mitigate by only configuring trusted proxies.
-            let client_mihomo =
-                build_http_client_with_proxy(user_agent.as_deref(), None, Some(proxy_url_val));
+            let client_mihomo = build_http_client_with_proxy(
+                user_agent.as_deref(),
+                None,
+                Some(proxy_url_val.clone()),
+            );
             match client_mihomo {
                 Ok(client) => match do_download(client, url.clone()).await {
-                    Ok(data) => result = Some(data),
+                    Ok(data) => {
+                        result = Some(data);
+                    }
                     Err(e) => {
                         last_error = match direct_error.as_deref() {
                             Some(de) => format!("{de} | Proxy: {e}"),
@@ -315,6 +373,56 @@ async fn download_sub_inner_raw(
                     last_error = match direct_error.as_deref() {
                         Some(de) => format!("{de} | Proxy client build: {e}"),
                         None => format!("Proxy client build: {e}"),
+                    }
+                }
+            }
+
+            // ── Tier 3: 临时切换 global 模式重试 ──────────────────────────────
+            // 直连和普通代理都失败后，尝试临时把 mihomo 切到 global 模式，
+            // 让所有流量走当前选中的代理节点（绕过分流规则可能导致的不可达），
+            // 下载完成后切回原模式。
+            if result.is_none() {
+                // 只有成功获取到当前模式且不是 global 时才切换，
+                // 否则切到 global 后无法切回（original_mode 为 None 时跳过恢复）。
+                if let Some(orig) = get_mihomo_mode(app).await {
+                    if orig != "global" && set_mihomo_mode(app, "global").await.is_some() {
+                        // 切换后短暂等待 mihomo 生效
+                        tokio::time::sleep(Duration::from_millis(300)).await;
+
+                        let client_global = build_http_client_with_proxy(
+                            user_agent.as_deref(),
+                            None,
+                            Some(proxy_url_val),
+                        );
+                        match client_global {
+                            Ok(client) => match do_download(client, url).await {
+                                Ok(data) => {
+                                    result = Some(data);
+                                }
+                                Err(e) => {
+                                    last_error = if last_error.is_empty() {
+                                        format!("Global-mode: {e}")
+                                    } else {
+                                        format!("{last_error} | Global-mode: {e}")
+                                    };
+                                }
+                            },
+                            Err(e) => {
+                                last_error = if last_error.is_empty() {
+                                    format!("Global-mode client build: {e}")
+                                } else {
+                                    format!("{last_error} | Global-mode client build: {e}")
+                                };
+                            }
+                        }
+
+                        // 无论成功失败都切回原模式；失败时记录日志便于诊断
+                        // （若不恢复，core 会停留在 global 模式，可能导致意外的流量/路由问题）
+                        if set_mihomo_mode(app, &orig).await.is_none() {
+                            eprintln!(
+                                "[subscription] failed to restore original mihomo mode '{orig}'"
+                            );
+                        }
                     }
                 }
             }

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -789,6 +789,7 @@ pub async fn update_core(
         false,
         last_args,
         last_secret,
+        Some(true),
     )
     .await;
     match result {

--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -597,6 +597,7 @@ export async function restartCore(configPath, customArgs = []) {
     configPath,
     test: false,
     customArgs,
+    force: true,
   });
   setBaseUrl(`http://127.0.0.1:${coreResult.port}`);
   setSecret(coreResult.secret);

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -165,6 +165,17 @@ async function initApp() {
     });
     apiLogger.info(`[Zephyr] start_core: +${(performance.now() - tStartCore).toFixed(0)}ms`);
 
+    // 如果 start_core 发生了静默回退（请求的配置文件不存在），
+    // 用实际加载的配置名纠正 last_config，避免下次冷启动仍然指向已不存在的文件。
+    if (coreResult.active_config && coreResult.active_config !== configPath) {
+      apiLogger.info(`[Zephyr] config fallback detected: requested "${configPath}" but loaded "${coreResult.active_config}", updating last_config`);
+      try {
+        await invoke(COMMANDS.UPDATE_LAST_CONFIG, { configName: coreResult.active_config });
+      } catch (e) {
+        apiLogger.warn(`[Zephyr] failed to update last_config after fallback: ${e}`);
+      }
+    }
+
     secret = coreResult.secret;
     const port = coreResult.port;
 


### PR DESCRIPTION
## Summary

Three fixes for subscription/proxy refresh issues:

### 1. Force restart on subscription update (`start_core` `force` parameter)

**Root cause**: `start_core` had a "same-config optimization" — when the requested `config_path` matched the currently running config name, it returned early without restarting mihomo. After updating a subscription, `restartCore()` would hit this check (same config name), and mihomo never actually restarted. The API kept serving stale proxy nodes.

**Fix**: Added `force: Option<bool>` parameter to `start_core`. `restartCore()` now always passes `force: true`. Initial startup leaves `force` unset (default `false`).

### 2. Tier-3 global mode fallback for subscription download

When direct connection and proxy (rule mode) both fail, temporarily switch mihomo to global mode to bypass rule-based routing. Safety: only attempt if `get_mihomo_mode` returns `Some`, ensuring we can always restore the original mode.

Also fixed: use `last_proxy_port()` (not `last_port()`) for proxy URL construction. Local API clients have 2s timeouts. Download timeout 10s total / 5s connect. Avoid unnecessary clones in the final fallback path. Conditional `last_error` formatting to avoid leading separator. Extracted shared `mihomo_api_client` helper to eliminate duplication. Capture and log client build failures in Tier-3.

### 3. Harden `last_config` lifecycle

- **Cold-start correction** (`main.js`): correct `last_config` after `resolve_profile_path` silently falls back
- **Delete cleanup** (`delete_config`): clean up dangling `last_config`, reuse `first_available_profile` (no code duplication), avoid unnecessary clone
- Use `unwrap_or_else(PoisonError::into_inner)` for mutex poisoning throughout

## Testing

- 323 Rust tests + 124 core tests + 362 JS tests all pass
- clippy clean (0 warnings), eslint clean, typecheck clean