### PR TITLE
feat: WebView2 crash auto-recovery with three-layer defense

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "url",
  "uuid",
+ "webview2-com",
  "windows-sys 0.59.0",
  "winreg 0.52.0",
  "zephyr-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -83,6 +83,10 @@ windows-sys = { version = "0.59", features = [
     "Win32_UI_Shell"
 ] }
 winreg = "0.52"
+# webview2-com: direct dependency for ProcessFailed crash recovery.
+# MUST match the version in Cargo.lock (transitive via tauri → wry → webview2-com).
+# Re-check this version whenever Tauri is upgraded.
+webview2-com = "=0.38.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS specific dependencies will be added as needed

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ pub mod prism;
 pub mod sys_proxy;
 pub mod tray;
 pub mod updater;
+#[cfg(target_os = "windows")]
+pub mod webview_recovery;
 pub mod uwp_loopback;
 
 use config_manager::{read_config, update_config};
@@ -28,8 +30,9 @@ use global_shortcut::ShortcutRegistry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sys_proxy::{
     clear_sys_proxy, disable_sysproxy, enable_sysproxy, get_sys_proxy, has_sysproxy_ownership,
     restore_sys_proxy,
@@ -260,6 +263,175 @@ pub(crate) struct SettingsState(pub(crate) Arc<Mutex<Settings>>);
 /// close button with `close_to_tray` disabled). Prevents `ExitRequested`
 /// from blocking the shutdown.
 pub(crate) struct ExplicitExitFlag(pub(crate) Arc<std::sync::atomic::AtomicBool>);
+
+/// Tracks webview liveness via a heartbeat from the frontend (Layer 2).
+///
+/// Uses a lock-free `AtomicI64` storing Unix-millis of the last heartbeat.
+/// If the heartbeat goes stale (> `HEARTBEAT_TIMEOUT_SECS`), the webview is
+/// considered dead (e.g. `WebView2` crash on a non-Windows platform, or
+/// Layer 1 missed an event) and the window will be recreated on the next
+/// show attempt.
+///
+/// This is a pure fallback — Layer 1 (`ProcessFailed`) handles the 95% case
+/// with millisecond latency. The heartbeat only fires when Layer 1 is absent
+/// (non-Windows) or silently fails.
+pub(crate) struct WebviewHealth {
+    /// Unix-millis timestamp of the last heartbeat from the frontend.
+    /// Updated atomically — no mutex, no allocation, nanosecond-level cost.
+    ///
+    /// Sentinel: `0` means "explicitly invalidated" (written only by
+    /// `invalidate_heartbeat()` after window destroy). The initial value is
+    /// `now_unix_ms()` (app startup time), **never** `0`, so the cold-start
+    /// window before the first frontend heartbeat arrives is not mistaken for
+    /// a dead webview.
+    pub last_heartbeat_ms: AtomicI64,
+    /// Idempotent reconstruction gate. When `true`, a reconstruction is
+    /// already in progress and concurrent callers should skip.
+    /// Toggled via `compare_exchange` for lock-free mutual exclusion.
+    pub reconstructing: std::sync::atomic::AtomicBool,
+}
+
+impl Default for WebviewHealth {
+    fn default() -> Self {
+        Self {
+            // Initialise to app-startup time so the cold-start window
+            // (before the first heartbeat arrives) is not falsely judged dead.
+            last_heartbeat_ms: AtomicI64::new(now_unix_ms()),
+            reconstructing: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+/// Heartbeat send interval (frontend side): 15 seconds.
+///
+/// Deliberately lazy — Layer 1 handles instant recovery, so the heartbeat
+/// only needs to catch the rare case where Layer 1 is absent or fails.
+/// At 15 s, that's ~5 760 IPC calls/day — negligible.
+pub(crate) const HEARTBEAT_INTERVAL_SECS: u64 = 15;
+
+/// Consecutive missed heartbeats before declaring the webview dead.
+///
+/// 3 × 15 s = 45 s worst-case detection latency. Tolerates one or two
+/// transient IPC hiccups without false-positive recreation.
+pub(crate) const HEARTBEAT_MISSED_THRESHOLD: u64 = 3;
+
+/// Effective timeout: `HEARTBEAT_INTERVAL_SECS * HEARTBEAT_MISSED_THRESHOLD`.
+pub(crate) const HEARTBEAT_TIMEOUT_SECS: u64 = HEARTBEAT_INTERVAL_SECS * HEARTBEAT_MISSED_THRESHOLD;
+
+/// Current time as Unix milliseconds.
+#[allow(clippy::cast_possible_truncation)]
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Atomically update the heartbeat timestamp.
+pub(crate) fn touch_heartbeat(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health
+            .last_heartbeat_ms
+            .store(now_unix_ms(), Ordering::Relaxed);
+    }
+}
+
+/// Mark the heartbeat as stale (e.g. after window destroy).
+///
+/// This is the **only** place that writes `0` — the sentinel for
+/// "explicitly invalidated". `is_webview_alive` checks `last == 0` first
+/// and returns `false` immediately, so the window is guaranteed to be
+/// recreated on the next show attempt.
+pub(crate) fn invalidate_heartbeat(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health.last_heartbeat_ms.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Try to acquire the reconstruction gate.
+///
+/// Returns `true` if this caller "wins" and should proceed with
+/// reconstruction. Returns `false` if another caller is already
+/// reconstructing — the caller should silently skip.
+///
+/// The gate is released by [`release_reconstruct_gate`].
+pub(crate) fn try_acquire_reconstruct_gate(app: &tauri::AppHandle) -> bool {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health
+            .reconstructing
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+    } else {
+        true
+    }
+}
+
+/// Release the reconstruction gate after reconstruction finishes.
+pub(crate) fn release_reconstruct_gate(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health
+            .reconstructing
+            .store(false, Ordering::Release);
+    }
+}
+
+/// Check whether the webview is alive based on the last heartbeat timestamp.
+///
+/// Returns `true` if the heartbeat is recent (< `HEARTBEAT_TIMEOUT_SECS`)
+/// or if the health state is not yet registered.
+pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        let last = health.last_heartbeat_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            return false;
+        }
+        let elapsed_ms = now_unix_ms() - last;
+        let timeout_ms = i64::try_from(HEARTBEAT_TIMEOUT_SECS).unwrap_or(i64::MAX) * 1000;
+        elapsed_ms < timeout_ms
+    } else {
+        true
+    }
+}
+
+/// Show or recreate the main window, detecting dead webviews.
+///
+/// This is the unified entry point for all "show window" paths:
+/// - `show_main_window` command (called from frontend)
+/// - Tray icon click
+/// - Single-instance plugin (second launch)
+///
+/// If the window exists but the webview heartbeat is stale (`WebView2` crash
+/// not caught by Layer 1, or non-Windows platform), the zombie window is
+/// destroyed and a fresh one is created.
+pub(crate) fn show_or_recreate_main_window(app: &tauri::AppHandle) {
+    // Fast path: window exists and webview is alive — just show it.
+    if let Some(window) = app.get_webview_window("main") {
+        if is_webview_alive(app) {
+            let _ = window.show();
+            let _ = window.set_focus();
+            return;
+        }
+        // Webview is dead (heartbeat stale) — destroy zombie first.
+        eprintln!("[lib] Webview heartbeat stale — recreating window");
+        let _ = window.destroy();
+    }
+
+    // Slow path: reconstruct the window (either it didn't exist, or we just
+    // destroyed the zombie). Guard against concurrent reconstruction.
+    if !try_acquire_reconstruct_gate(app) {
+        eprintln!("[lib] Reconstruction already in progress — skipping");
+        return;
+    }
+    if let Err(e) = recreate_main_window(app) {
+        eprintln!("[lib] Failed to recreate main window: {e}");
+        emit_error!(
+            System,
+            SYS_WINDOW_RECREATE_FAILED,
+            "Failed to recreate main window: {e}"
+        );
+    }
+    release_reconstruct_gate(app);
+}
 
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
@@ -543,44 +715,58 @@ pub(crate) fn persist_settings(app: &tauri::AppHandle, settings: &Settings) -> R
     Ok(())
 }
 
+/// Frontend heartbeat — called periodically by `main.js` to signal that
+/// the webview is alive (Layer 2). If this stops arriving (3 consecutive
+/// missed = 45 s), `is_webview_alive` returns `false` and the next
+/// `show_main_window` / tray click will recreate the window.
+///
+/// Implementation: a single `AtomicI64` store — no lock, no allocation,
+/// nanosecond-level cost.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn heartbeat(state: tauri::State<WebviewHealth>) {
+    state
+        .last_heartbeat_ms
+        .store(now_unix_ms(), Ordering::Relaxed);
+}
+
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
 fn show_main_window(app: tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.set_focus();
-    } else {
-        // Window was destroyed by lightweight mode — recreate it
-        match recreate_main_window(&app) {
-            Ok(window) => {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
-            Err(e) => {
-                eprintln!("Failed to recreate main window: {e}");
-                emit_error!(
-                    System,
-                    SYS_WINDOW_RECREATE_FAILED,
-                    "Failed to recreate main window: {e}"
-                );
-            }
-        }
-    }
+    show_or_recreate_main_window(&app);
 }
 
-/// Recreate the main window with the same configuration as the initial window.
-/// Uses conditional compilation for `.transparent()` which requires
-/// `macos-private-api` feature on macOS.
+/// Recreate the main window with the same configuration as `tauri.conf.json`.
+/// Dimensions and properties mirror the config-defined window so that the
+/// recreated window is visually identical to the original.
+///
+/// The `on_page_load` callback re-arms the `WebView2` crash recovery handler
+/// (Layer 1) once the new webview finishes loading — this covers both the
+/// initial creation and every subsequent recreation.
 pub(crate) fn recreate_main_window(
     app: &tauri::AppHandle,
 ) -> Result<tauri::WebviewWindow, tauri::Error> {
     let window_builder =
         tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
             .title("Zephyr")
-            .inner_size(960.0, 680.0)
-            .min_inner_size(640.0, 420.0)
+            .inner_size(860.0, 620.0)
+            .min_inner_size(720.0, 540.0)
+            .center()
             .decorations(false)
-            .visible(true);
+            .visible(true)
+            .on_page_load(move |webview_window, payload| {
+                if payload.event() == tauri::webview::PageLoadEvent::Finished {
+                    #[cfg(target_os = "windows")]
+                    {
+                        if let Err(e) = webview_recovery::arm_crash_recovery(&webview_window) {
+                            eprintln!("[lib] Failed to arm crash recovery: {e}");
+                        }
+                    }
+                    // Reset heartbeat timestamp so Layer 2 doesn't falsely
+                    // detect the fresh webview as dead during initialisation.
+                    touch_heartbeat(webview_window.app_handle());
+                }
+            });
 
     #[cfg(not(target_os = "macos"))]
     #[allow(clippy::shadow_reuse)]
@@ -782,17 +968,8 @@ pub fn run() {
     #[cfg(all(desktop, not(debug_assertions)))]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // Focus the existing window when a second instance is started.
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
-            } else {
-                // Window was destroyed by lightweight mode — recreate it
-                if let Ok(window) = recreate_main_window(app) {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
-            }
+            // Focus the existing window, or recreate it if the webview is dead.
+            show_or_recreate_main_window(app);
             // Forward deep link arguments from the second instance to the first.
             for arg in args {
                 if arg.starts_with("clash://") {
@@ -807,6 +984,7 @@ pub fn run() {
         .manage(TrayState::default())
         .manage(RateLimiter::new())
         .manage(ShortcutRegistry::default())
+        .manage(WebviewHealth::default())
         .setup(|app| {
             backend_event::init_app_handle(app.handle());
             core_event_bridge::install_core_event_bridge();
@@ -960,6 +1138,11 @@ pub fn run() {
                         app.exit(0);
                     }
                 }
+                tauri::WindowEvent::Destroyed => {
+                    // Mark the heartbeat as stale so the next show attempt
+                    // recreates the window instead of finding a zombie.
+                    invalidate_heartbeat(window.app_handle());
+                }
                 tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) => {
                     let app = window.app_handle();
                     if let Ok(storage_paths) = core_manager::ensure_app_storage(app) {
@@ -1080,6 +1263,7 @@ pub fn run() {
             // OS notification command (rate-limited wrapper)
             rate_limited_send_notification,
             get_app_version,
+            heartbeat,
             // Prism Engine commands
             prism::prism_apply,
             prism::prism_status,

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -242,23 +242,10 @@ pub fn init_tray(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Show the main window, or recreate it if it was destroyed (lightweight mode).
+/// Show the main window, or recreate it if it was destroyed (lightweight mode)
+/// or if the webview is dead (detected via stale heartbeat).
 fn show_or_recreate_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.set_focus();
-    } else {
-        // Window was destroyed by lightweight mode — recreate it
-        match crate::recreate_main_window(app) {
-            Ok(window) => {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
-            Err(e) => {
-                eprintln!("Failed to recreate main window: {e}");
-            }
-        }
-    }
+    crate::show_or_recreate_main_window(app);
 }
 
 /// Handle tray menu events

--- a/apps/desktop/src-tauri/src/webview_recovery.rs
+++ b/apps/desktop/src-tauri/src/webview_recovery.rs
@@ -1,0 +1,180 @@
+//! `WebView2` crash detection and auto-recovery.
+//!
+//! ## Architecture
+//!
+//! This module implements **Layer 1** of the crash recovery strategy:
+//! event-driven detection via `WebView2`'s native `ProcessFailed` callback.
+//!
+//! When the `WebView2` browser process or render process crashes, the Win32
+//! window (HWND) stays alive but has no content to render. Combined with
+//! `transparent: true`, this creates an invisible "zombie window" that the
+//! user cannot see or interact with.
+//!
+//! ## How it works
+//!
+//! 1. After the webview is created (or recreated), `arm_crash_recovery` is
+//!    called via `on_page_load` to register a `ProcessFailed` event handler.
+//! 2. When a crash occurs, the handler inspects `ProcessFailedKind`:
+//!    - `RenderProcessExited` → `reload()` (`WebView2` auto-spawns a new render
+//!      process; this is near-instant and invisible to the user).
+//!    - `RenderProcessUnresponsive` → count occurrences; after 3 consecutive
+//!      unresponsive events, force a `reload()` to avoid spinning.
+//!    - `BrowserProcessExited` → the controller is dead; destroy the window
+//!      and recreate it from scratch via `recreate_main_window`.
+//! 3. After recreation, `on_page_load` fires again and re-arms the handler.
+//!
+//! ## Platform scope
+//!
+//! This module is Windows-only (`#[cfg(target_os = "windows")]`).
+//! On macOS/Linux, the heartbeat mechanism in `lib.rs` (Layer 2) provides
+//! the equivalent fallback.
+//!
+//! ## Version pinning
+//!
+//! `webview2-com` and `webview2-com-sys` are transitive dependencies via
+//! `tauri → wry → webview2-com`. They MUST be declared as direct dependencies
+//! with the **exact same version** found in `Cargo.lock` to avoid COM type
+//! incompatibility. When upgrading Tauri, re-check `Cargo.lock` for the new
+//! `webview2-com` version and update the direct dependency accordingly.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use tauri::{AppHandle, Manager as _, WebviewWindow};
+use webview2_com::Microsoft::Web::WebView2::Win32::{
+    COREWEBVIEW2_PROCESS_FAILED_KIND, COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED,
+    COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
+    COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE,
+};
+use webview2_com::ProcessFailedEventHandler;
+
+/// Consecutive `RenderProcessUnresponsive` count.
+/// Reset to 0 on any other event (exit or reload).
+static UNRESPONSIVE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Threshold: after this many consecutive unresponsive events, force reload.
+const UNRESPONSIVE_THRESHOLD: u32 = 3;
+
+/// Register the `ProcessFailed` callback on the webview's `CoreWebView2`.
+///
+/// Must be called after the webview controller is ready (i.e. inside
+/// `on_page_load` with `PageLoadEvent::Finished`). Both initial creation
+/// and `recreate_main_window` paths flow through `on_page_load`, so the
+/// handler is always re-armed after a recreation.
+///
+/// # Errors
+/// Returns an error if the controller or `CoreWebView2` cannot be obtained.
+pub fn arm_crash_recovery(window: &WebviewWindow) -> tauri::Result<()> {
+    let app = window.app_handle().clone();
+
+    window.with_webview(move |wv| {
+        let controller = wv.controller();
+        // SAFETY: `CoreWebView2()` is a COM getter that returns a
+        // reference-counted interface. The controller is valid for the
+        // lifetime of the webview. No raw pointers are stored.
+        let core = match unsafe { controller.CoreWebView2() } {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[webview_recovery] Failed to get CoreWebView2: {e}");
+                return;
+            }
+        };
+
+        let handler = ProcessFailedEventHandler::create(Box::new(move |_, args| {
+            handle_process_failed(&app, args.as_ref());
+            Ok(())
+        }));
+
+        let mut token: i64 = 0;
+        // SAFETY: `add_ProcessFailed` is a standard COM method that stores
+        // the handler and returns an event token. The handler (a COM object
+        // created by `ProcessFailedEventHandler::create`) is reference-counted
+        // by the COM runtime and kept alive as long as it is registered.
+        if let Err(e) = unsafe { core.add_ProcessFailed(&handler, &mut token) } {
+            eprintln!("[webview_recovery] add_ProcessFailed failed: {e}");
+        }
+    })?;
+    Ok(())
+}
+
+/// Dispatch recovery action based on the process failure kind.
+fn handle_process_failed(
+    app: &AppHandle,
+    event_args: Option<&webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2ProcessFailedEventArgs>,
+) {
+    let Some(a) = event_args else {
+        eprintln!("[webview_recovery] ProcessFailed but no event args");
+        return;
+    };
+
+    let mut raw_kind = COREWEBVIEW2_PROCESS_FAILED_KIND::default();
+    // SAFETY: `ProcessFailedKind` is a simple getter that writes an i32
+    // enum value into the output pointer. No lifetime concerns.
+    if let Err(e) = unsafe { a.ProcessFailedKind(&mut raw_kind) } {
+        eprintln!("[webview_recovery] ProcessFailed but could not read kind: {e}");
+        return;
+    }
+
+    if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED {
+        eprintln!("[webview_recovery] Browser process exited — recreating window");
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+        recreate_window(app);
+    } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED {
+        eprintln!("[webview_recovery] Render process exited — reloading");
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+        reload_webview(app);
+    } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE {
+        let count = UNRESPONSIVE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+        eprintln!(
+            "[webview_recovery] Render process unresponsive ({count}/{UNRESPONSIVE_THRESHOLD})"
+        );
+        if count >= UNRESPONSIVE_THRESHOLD {
+            eprintln!("[webview_recovery] Unresponsive threshold reached — force reloading");
+            UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+            reload_webview(app);
+        }
+    } else {
+        eprintln!(
+            "[webview_recovery] ProcessFailed kind: {raw_kind:?} — no action needed (auto-recovered)"
+        );
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Reload the webview content. `WebView2` will spawn a new render process.
+fn reload_webview(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        // `eval` with `location.reload()` forces a full page reload.
+        // The `WebView2` controller stays alive; only the render process is replaced.
+        if let Err(e) = window.eval("location.reload()") {
+            eprintln!("[webview_recovery] reload eval failed: {e}");
+        }
+    }
+}
+
+/// Destroy the zombie window and recreate it from scratch.
+/// Uses the same reconstruction gate as `show_or_recreate_main_window`
+/// to prevent double-recreation when both Layer 1 and Layer 2 fire
+/// simultaneously.
+fn recreate_window(app: &AppHandle) {
+    if !crate::try_acquire_reconstruct_gate(app) {
+        eprintln!("[webview_recovery] Reconstruction already in progress — skipping");
+        return;
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        // Destroy the old window (and its dead controller).
+        let _ = window.destroy();
+    }
+    // Recreate. The `on_page_load` callback in `lib.rs` will re-arm
+    // crash recovery once the new webview finishes loading.
+    if let Err(e) = crate::recreate_main_window(app) {
+        eprintln!("[webview_recovery] recreate_main_window failed: {e}");
+        crate::emit_error!(
+            System,
+            SYS_WINDOW_RECREATE_FAILED,
+            "WebView2 crash recovery: failed to recreate window: {e}"
+        );
+    }
+    crate::release_reconstruct_gate(app);
+}

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -8,6 +8,7 @@
 
 import {
   invoke,
+  listen,
   setBaseUrl,
   setSecret,
   setCoreReachable,
@@ -390,6 +391,53 @@ async function initApp() {
   registerCleanup(() => { cleanupTrayEventListeners(); });
 
   window.addEventListener('beforeunload', () => runCleanup());
+
+  // 10. Heartbeat — let the backend know the webview is alive (Layer 2).
+  // If this stops arriving (e.g. `WebView2` crash not caught by Layer 1),
+  // the backend will recreate the window on the next show attempt.
+  //
+  // Interval is deliberately lazy (15 s) — Layer 1 handles instant recovery;
+  // this is pure fallback. The timer is paused when the window is hidden
+  // (close-to-tray / lightweight mode) to eliminate background overhead.
+  const HEARTBEAT_INTERVAL_MS = 15_000;
+  let _heartbeatTimer = null;
+
+  function startHeartbeat() {
+    // Defensive: always clear first so rapid hide/show cycles
+    // never accumulate duplicate intervals.
+    stopHeartbeat();
+    // Fire one immediately on resume — don't wait for the next 15 s cycle.
+    // Without this, the backend sees a stale timestamp from before the
+    // window was hidden and might falsely trigger reconstruction.
+    invoke(COMMANDS.HEARTBEAT).catch(() => {});
+    _heartbeatTimer = setInterval(() => {
+      invoke(COMMANDS.HEARTBEAT).catch(() => {});
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  function stopHeartbeat() {
+    if (_heartbeatTimer !== null) {
+      clearInterval(_heartbeatTimer);
+      _heartbeatTimer = null;
+    }
+  }
+
+  // Start initially (window is visible on load).
+  startHeartbeat();
+
+  // Pause when hidden, resume when shown — zero overhead while in tray.
+  listen('tauri://window-hidden', () => stopHeartbeat());
+  listen('tauri://window-shown', () => startHeartbeat());
+  // Also respect native visibilitychange (covers system sleep / tab switch).
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopHeartbeat();
+    } else {
+      startHeartbeat();
+    }
+  });
+
+  registerCleanup(() => stopHeartbeat());
 
   apiLogger.info(`[Zephyr] ✅ App ready! Total: ${(performance.now() - t0).toFixed(0)}ms`);
 }

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -141,6 +141,7 @@ export const MISC = Object.freeze({
     SHOW_MAIN_WINDOW: "show_main_window",
     SEND_NOTIFICATION: "rate_limited_send_notification",
     EXEMPT_UWP_APPS: "exempt_uwp_apps",
+    HEARTBEAT: "heartbeat",
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`WebView2` browser/render process crashes leave the Win32 HWND alive but empty. Combined with `transparent: true`, this creates an invisible **zombie window** — the taskbar shows the app as active, but no window is visible. Users had to kill the process manually.

## Solution — Three layers of defense

### Layer 1: Windows event-driven instant recovery (`webview_recovery.rs`)
- Registers `ProcessFailed` callback via `webview2-com` COM interop
- `BrowserProcessExited` → destroy + recreate window (millisecond latency)
- `RenderProcessExited` → `eval(location.reload())` (instant, user-invisible)
- `RenderProcessUnresponsive` → count to 3 then reload (anti-spin)
- Re-armed automatically via `on_page_load(Finished)` after every recreation
- `webview2-com` version pinned to `=0.38.2` (matches Cargo.lock transitive dep)

### Layer 2: Cross-platform lazy heartbeat fallback
- Frontend sends heartbeat every **15s** (paused when window hidden)
- Backend stores timestamp in **lock-free `AtomicI64`** (no mutex, no allocation)
- 3 consecutive misses (**45s**) → window considered dead → recreate on next show
- Sentinel value `0` reserved exclusively for `invalidate_heartbeat()`
- Cold-start initializes to `now_unix_ms()` to avoid false positive

### Layer 3: Unified entry + idempotent reconstruction gate
- All show-window paths converge to `show_or_recreate_main_window()`
- `AtomicBool` reconstruction gate (`compare_exchange`) prevents double-recreate when Layer 1 and Layer 2 fire simultaneously
- Fast-path: window alive → show + focus
- Slow-path: destroy zombie → acquire gate → recreate → release gate

## Files changed

| File | Change |
|---|---|
| `webview_recovery.rs` (new) | Layer 1 — ProcessFailed event handler |
| `lib.rs` | Layer 2 heartbeat + Layer 3 unified entry + reconstruction gate |
| `tray.rs` | Delegate to unified entry |
| `main.js` | 15s heartbeat with hide/show pause/resume + immediate fire on resume |
| `Cargo.toml` | `webview2-com = "=0.38.2"` direct dependency |
| `shared/index.js` | `HEARTBEAT` command constant |
| `Cargo.lock` | Updated for new direct dependency |
