### PR TITLE
feat: WebView2 crash auto-recovery with three-layer defense

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "url",
  "uuid",
+ "webview2-com",
  "windows-sys 0.59.0",
  "winreg 0.52.0",
  "zephyr-core",
@@ -2890,14 +2891,16 @@ dependencies = [
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -3123,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.17.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -3166,7 +3169,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3580,13 +3583,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3779,27 +3782,18 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3817,15 +3811,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3947,6 +3942,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -5358,11 +5362,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows",
  "windows-version",
@@ -6403,7 +6406,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -83,6 +83,10 @@ windows-sys = { version = "0.59", features = [
     "Win32_UI_Shell"
 ] }
 winreg = "0.52"
+# webview2-com: direct dependency for ProcessFailed crash recovery.
+# MUST match the version in Cargo.lock (transitive via tauri → wry → webview2-com).
+# Re-check this version whenever Tauri is upgraded.
+webview2-com = "=0.38.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS specific dependencies will be added as needed

--- a/apps/desktop/src-tauri/audit.toml
+++ b/apps/desktop/src-tauri/audit.toml
@@ -1,0 +1,15 @@
+# cargo-audit configuration
+# https://github.com/rustsec/rustsec/tree/main/cargo-audit
+
+[advisories]
+ignore = [
+  # rand 0.8 unsound with custom logger using rand::rng()
+  # Indirect dep via clash-prism-script v0.1.3 (latest, still uses rand 0.8)
+  # Our code pins rand = "0.10.1" directly; fix requires clash-prism-script to upgrade rand
+  "RUSTSEC-2026-0097",
+  # rustls-webpki name constraints issues
+  # Indirect dep via reqwest -> hyper-rustls -> tokio-rustls -> rustls -> rustls-webpki
+  # Fixed by rustls 0.23.40 + webpki 0.103.13; kept in ignore for compatibility
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
+]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ pub mod sys_proxy;
 pub mod tray;
 pub mod updater;
 pub mod uwp_loopback;
+#[cfg(target_os = "windows")]
+pub mod webview_recovery;
 
 use config_manager::{read_config, update_config};
 use core_manager::core::subscription_scheduler::start_scheduler;
@@ -28,6 +30,7 @@ use global_shortcut::ShortcutRegistry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use sys_proxy::{
@@ -260,6 +263,218 @@ pub(crate) struct SettingsState(pub(crate) Arc<Mutex<Settings>>);
 /// close button with `close_to_tray` disabled). Prevents `ExitRequested`
 /// from blocking the shutdown.
 pub(crate) struct ExplicitExitFlag(pub(crate) Arc<std::sync::atomic::AtomicBool>);
+
+/// Tracks webview liveness via a heartbeat from the frontend (Layer 2).
+///
+/// Uses a lock-free `AtomicI64` storing Unix-millis of the last heartbeat.
+/// If the heartbeat goes stale (> `HEARTBEAT_TIMEOUT_SECS`), the webview is
+/// considered dead (e.g. `WebView2` crash on a non-Windows platform, or
+/// Layer 1 missed an event) and the window will be recreated on the next
+/// show attempt.
+///
+/// This is a pure fallback — Layer 1 (`ProcessFailed`) handles the 95% case
+/// with millisecond latency. The heartbeat only fires when Layer 1 is absent
+/// (non-Windows) or silently fails.
+pub(crate) struct WebviewHealth {
+    /// Unix-millis timestamp of the last heartbeat from the frontend.
+    /// Updated atomically — no mutex, no allocation, nanosecond-level cost.
+    ///
+    /// Sentinel: `0` means "explicitly invalidated" (written only by
+    /// `invalidate_heartbeat()` after window destroy). The initial value is
+    /// `monotonic_ms()` (app startup time), **never** `0`, so the cold-start
+    /// window before the first frontend heartbeat arrives is not mistaken for
+    /// a dead webview.
+    pub last_heartbeat_ms: AtomicI64,
+    /// Idempotent reconstruction gate. When `true`, a reconstruction is
+    /// already in progress and concurrent callers should skip.
+    /// Toggled via `compare_exchange` for lock-free mutual exclusion.
+    pub reconstructing: std::sync::atomic::AtomicBool,
+}
+
+impl Default for WebviewHealth {
+    fn default() -> Self {
+        Self {
+            // Initialise to app-startup time so the cold-start window
+            // (before the first heartbeat arrives) is not falsely judged dead.
+            last_heartbeat_ms: AtomicI64::new(monotonic_ms()),
+            reconstructing: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+/// Heartbeat send interval (frontend side): 15 seconds.
+///
+/// Deliberately lazy — Layer 1 handles instant recovery, so the heartbeat
+/// only needs to catch the rare case where Layer 1 is absent or fails.
+/// At 15 s, that's ~5 760 IPC calls/day — negligible.
+pub(crate) const HEARTBEAT_INTERVAL_SECS: u64 = 15;
+
+/// Consecutive missed heartbeats before declaring the webview dead.
+///
+/// 3 × 15 s = 45 s worst-case detection latency. Tolerates one or two
+/// transient IPC hiccups without false-positive recreation.
+pub(crate) const HEARTBEAT_MISSED_THRESHOLD: u64 = 3;
+
+/// Effective timeout: `HEARTBEAT_INTERVAL_SECS * HEARTBEAT_MISSED_THRESHOLD`.
+pub(crate) const HEARTBEAT_TIMEOUT_SECS: u64 = HEARTBEAT_INTERVAL_SECS * HEARTBEAT_MISSED_THRESHOLD;
+
+/// Monotonic milliseconds since application startup.
+///
+/// Uses `Instant` (monotonic clock) instead of `SystemTime` to be immune
+/// to system clock adjustments (NTP sync, timezone changes, manual resets,
+/// CMOS battery failure). This is critical because `SystemTime` jumping
+/// backward could make `monotonic_ms()` return `0` — the sentinel for
+/// "invalidated heartbeat" — triggering an infinite window recreation loop.
+///
+/// The returned value is always ≥ 1 (never `0`, the sentinel).
+fn monotonic_ms() -> i64 {
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    let startup = *START.get_or_init(Instant::now);
+    let millis = Instant::now()
+        .saturating_duration_since(startup)
+        .as_millis();
+    i64::try_from(millis).unwrap_or(i64::MAX).max(1)
+}
+
+/// Atomically update the heartbeat timestamp.
+pub(crate) fn touch_heartbeat(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health
+            .last_heartbeat_ms
+            .store(monotonic_ms(), Ordering::Relaxed);
+    }
+}
+
+/// Mark the heartbeat as stale (e.g. after window destroy).
+///
+/// This is the **only** place that writes `0` — the sentinel for
+/// "explicitly invalidated". `is_webview_alive` checks `last == 0` first
+/// and returns `false` immediately, so the window is guaranteed to be
+/// recreated on the next show attempt.
+pub(crate) fn invalidate_heartbeat(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health.last_heartbeat_ms.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Try to acquire the reconstruction gate.
+///
+/// Returns `true` if this caller "wins" and should proceed with
+/// reconstruction. Returns `false` if another caller is already
+/// reconstructing — the caller should silently skip.
+///
+/// The gate is released by [`release_reconstruct_gate`].
+pub(crate) fn try_acquire_reconstruct_gate(app: &tauri::AppHandle) -> bool {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health
+            .reconstructing
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+    } else {
+        true
+    }
+}
+
+/// Release the reconstruction gate after reconstruction finishes.
+pub(crate) fn release_reconstruct_gate(app: &tauri::AppHandle) {
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        health.reconstructing.store(false, Ordering::Release);
+    }
+}
+
+/// Check whether the webview is alive based on the last heartbeat timestamp.
+///
+/// Returns `true` if the heartbeat is recent (< `HEARTBEAT_TIMEOUT_SECS`),
+/// if the window is currently hidden (browser engine throttles JS timers
+/// when hidden, so the heartbeat naturally stops), or if the health state
+/// is not yet registered.
+pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
+    // If the window is hidden, the browser engine throttles JS timers,
+    // so the heartbeat will naturally stop. Treat the webview as alive
+    // to avoid false-positive recreation when showing.
+    if let Some(window) = app.get_webview_window("main") {
+        if !window.is_visible().unwrap_or(true) {
+            return true;
+        }
+    }
+    if let Some(health) = app.try_state::<WebviewHealth>() {
+        let last = health.last_heartbeat_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            return false;
+        }
+        let elapsed_ms = monotonic_ms() - last;
+        let timeout_ms = i64::try_from(HEARTBEAT_TIMEOUT_SECS)
+            .ok()
+            .and_then(|t| t.checked_mul(1000))
+            .unwrap_or(i64::MAX);
+        elapsed_ms < timeout_ms
+    } else {
+        true
+    }
+}
+
+/// Show or recreate the main window, detecting dead webviews.
+///
+/// This is the unified entry point for all "show window" paths:
+/// - `show_main_window` command (called from frontend)
+/// - Tray icon click
+/// - Single-instance plugin (second launch)
+///
+/// If the window exists but the webview heartbeat is stale (`WebView2` crash
+/// not caught by Layer 1, or non-Windows platform), the zombie window is
+/// destroyed and a fresh one is created.
+pub(crate) fn show_or_recreate_main_window(app: &tauri::AppHandle) {
+    // Fast path: window exists and webview is alive — just show it.
+    if let Some(window) = app.get_webview_window("main") {
+        if is_webview_alive(app) {
+            let _ = window.show();
+            let _ = window.set_focus();
+            return;
+        }
+    }
+
+    // Slow path: window missing or webview dead.
+    // Acquire the reconstruction gate BEFORE destroying the zombie window.
+    // If another caller already holds the gate, we must not destroy the
+    // existing window — otherwise the app is left in a windowless state.
+    if !try_acquire_reconstruct_gate(app) {
+        eprintln!("[lib] Reconstruction already in progress — skipping");
+        return;
+    }
+
+    // Double-check: another caller may have already recreated the window
+    // while we were waiting for the gate.
+    if let Some(window) = app.get_webview_window("main") {
+        if is_webview_alive(app) {
+            let _ = window.show();
+            let _ = window.set_focus();
+            release_reconstruct_gate(app);
+            return;
+        }
+    }
+
+    // Destroy zombie if it exists (now safe — we hold the gate).
+    if let Some(window) = app.get_webview_window("main") {
+        eprintln!("[lib] Webview heartbeat stale — recreating window");
+        let _ = window.destroy();
+    }
+
+    match recreate_main_window(app) {
+        Ok(window) => {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        Err(e) => {
+            eprintln!("[lib] Failed to recreate main window: {e}");
+            emit_error!(
+                System,
+                SYS_WINDOW_RECREATE_FAILED,
+                "Failed to recreate main window: {e}"
+            );
+        }
+    }
+    release_reconstruct_gate(app);
+}
 
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
@@ -543,44 +758,64 @@ pub(crate) fn persist_settings(app: &tauri::AppHandle, settings: &Settings) -> R
     Ok(())
 }
 
+/// Frontend heartbeat — called periodically by `main.js` to signal that
+/// the webview is alive (Layer 2). If this stops arriving (3 consecutive
+/// missed = 45 s), `is_webview_alive` returns `false` and the next
+/// `show_main_window` / tray click will recreate the window.
+///
+/// Implementation: a single `AtomicI64` store — no lock, no allocation,
+/// nanosecond-level cost.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn heartbeat(state: tauri::State<WebviewHealth>) {
+    state
+        .last_heartbeat_ms
+        .store(monotonic_ms(), Ordering::Relaxed);
+}
+
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
 fn show_main_window(app: tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.set_focus();
-    } else {
-        // Window was destroyed by lightweight mode — recreate it
-        match recreate_main_window(&app) {
-            Ok(window) => {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
-            Err(e) => {
-                eprintln!("Failed to recreate main window: {e}");
-                emit_error!(
-                    System,
-                    SYS_WINDOW_RECREATE_FAILED,
-                    "Failed to recreate main window: {e}"
-                );
-            }
-        }
-    }
+    show_or_recreate_main_window(&app);
 }
 
-/// Recreate the main window with the same configuration as the initial window.
-/// Uses conditional compilation for `.transparent()` which requires
-/// `macos-private-api` feature on macOS.
+/// Recreate the main window with the same configuration as `tauri.conf.json`.
+/// Dimensions and properties mirror the config-defined window so that the
+/// recreated window is visually identical to the original.
+///
+/// The `on_page_load` callback re-arms the `WebView2` crash recovery handler
+/// (Layer 1) once the new webview finishes loading — this covers both the
+/// initial creation and every subsequent recreation.
 pub(crate) fn recreate_main_window(
     app: &tauri::AppHandle,
 ) -> Result<tauri::WebviewWindow, tauri::Error> {
+    // Touch heartbeat immediately so that a show request arriving during
+    // page load doesn't mistake the fresh webview for a dead one (which
+    // would cause an infinite destroy→recreate loop). The `on_page_load`
+    // callback will touch again once the page finishes loading.
+    touch_heartbeat(app);
+
     let window_builder =
         tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
             .title("Zephyr")
-            .inner_size(960.0, 680.0)
-            .min_inner_size(640.0, 420.0)
+            .inner_size(860.0, 620.0)
+            .min_inner_size(720.0, 540.0)
+            .center()
             .decorations(false)
-            .visible(true);
+            .visible(true)
+            .on_page_load(move |webview_window, payload| {
+                if payload.event() == tauri::webview::PageLoadEvent::Finished {
+                    #[cfg(target_os = "windows")]
+                    {
+                        if let Err(e) = webview_recovery::arm_crash_recovery(&webview_window) {
+                            eprintln!("[lib] Failed to arm crash recovery: {e}");
+                        }
+                    }
+                    // Reset heartbeat timestamp so Layer 2 doesn't falsely
+                    // detect the fresh webview as dead during initialisation.
+                    touch_heartbeat(webview_window.app_handle());
+                }
+            });
 
     #[cfg(not(target_os = "macos"))]
     #[allow(clippy::shadow_reuse)]
@@ -782,17 +1017,8 @@ pub fn run() {
     #[cfg(all(desktop, not(debug_assertions)))]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // Focus the existing window when a second instance is started.
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
-            } else {
-                // Window was destroyed by lightweight mode — recreate it
-                if let Ok(window) = recreate_main_window(app) {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
-            }
+            // Focus the existing window, or recreate it if the webview is dead.
+            show_or_recreate_main_window(app);
             // Forward deep link arguments from the second instance to the first.
             for arg in args {
                 if arg.starts_with("clash://") {
@@ -807,6 +1033,7 @@ pub fn run() {
         .manage(TrayState::default())
         .manage(RateLimiter::new())
         .manage(ShortcutRegistry::default())
+        .manage(WebviewHealth::default())
         .setup(|app| {
             backend_event::init_app_handle(app.handle());
             core_event_bridge::install_core_event_bridge();
@@ -960,6 +1187,11 @@ pub fn run() {
                         app.exit(0);
                     }
                 }
+                tauri::WindowEvent::Destroyed => {
+                    // Mark the heartbeat as stale so the next show attempt
+                    // recreates the window instead of finding a zombie.
+                    invalidate_heartbeat(window.app_handle());
+                }
                 tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) => {
                     let app = window.app_handle();
                     if let Ok(storage_paths) = core_manager::ensure_app_storage(app) {
@@ -1080,6 +1312,7 @@ pub fn run() {
             // OS notification command (rate-limited wrapper)
             rate_limited_send_notification,
             get_app_version,
+            heartbeat,
             // Prism Engine commands
             prism::prism_apply,
             prism::prism_status,

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -242,23 +242,10 @@ pub fn init_tray(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Show the main window, or recreate it if it was destroyed (lightweight mode).
+/// Show the main window, or recreate it if it was destroyed (lightweight mode)
+/// or if the webview is dead (detected via stale heartbeat).
 fn show_or_recreate_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.set_focus();
-    } else {
-        // Window was destroyed by lightweight mode — recreate it
-        match crate::recreate_main_window(app) {
-            Ok(window) => {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
-            Err(e) => {
-                eprintln!("Failed to recreate main window: {e}");
-            }
-        }
-    }
+    crate::show_or_recreate_main_window(app);
 }
 
 /// Handle tray menu events

--- a/apps/desktop/src-tauri/src/webview_recovery.rs
+++ b/apps/desktop/src-tauri/src/webview_recovery.rs
@@ -1,0 +1,232 @@
+//! `WebView2` crash detection and auto-recovery.
+//!
+//! ## Architecture
+//!
+//! This module implements **Layer 1** of the crash recovery strategy:
+//! event-driven detection via `WebView2`'s native `ProcessFailed` callback.
+//!
+//! When the `WebView2` browser process or render process crashes, the Win32
+//! window (HWND) stays alive but has no content to render. Combined with
+//! `transparent: true`, this creates an invisible "zombie window" that the
+//! user cannot see or interact with.
+//!
+//! ## How it works
+//!
+//! 1. After the webview is created (or recreated), `arm_crash_recovery` is
+//!    called via `on_page_load` to register a `ProcessFailed` event handler.
+//! 2. When a crash occurs, the handler inspects `ProcessFailedKind`:
+//!    - `RenderProcessExited` → `reload()` (`WebView2` auto-spawns a new render
+//!      process; this is near-instant and invisible to the user).
+//!    - `RenderProcessUnresponsive` → count occurrences; after 3 consecutive
+//!      unresponsive events, force a `reload()` to avoid spinning.
+//!    - `BrowserProcessExited` → the controller is dead; destroy the window
+//!      and recreate it from scratch via `recreate_main_window`.
+//! 3. After recreation, `on_page_load` fires again and re-arms the handler.
+//!
+//! ## Platform scope
+//!
+//! This module is Windows-only (`#[cfg(target_os = "windows")]`).
+//! On macOS/Linux, the heartbeat mechanism in `lib.rs` (Layer 2) provides
+//! the equivalent fallback.
+//!
+//! ## Version pinning
+//!
+//! `webview2-com` and `webview2-com-sys` are transitive dependencies via
+//! `tauri → wry → webview2-com`. They MUST be declared as direct dependencies
+//! with the **exact same version** found in `Cargo.lock` to avoid COM type
+//! incompatibility. When upgrading Tauri, re-check `Cargo.lock` for the new
+//! `webview2-com` version and update the direct dependency accordingly.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+
+use tauri::{AppHandle, Manager as _, WebviewWindow};
+use webview2_com::Microsoft::Web::WebView2::Win32::{
+    COREWEBVIEW2_PROCESS_FAILED_KIND, COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED,
+    COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
+    COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE,
+};
+use webview2_com::ProcessFailedEventHandler;
+
+/// Consecutive `RenderProcessUnresponsive` count.
+/// Reset to 0 on any other event (exit or reload).
+static UNRESPONSIVE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Threshold: after this many consecutive unresponsive events, force reload.
+const UNRESPONSIVE_THRESHOLD: u32 = 3;
+
+/// Register the `ProcessFailed` callback on the webview's `CoreWebView2`.
+///
+/// Must be called after the webview controller is ready (i.e. inside
+/// `on_page_load` with `PageLoadEvent::Finished`). Both initial creation
+/// and `recreate_main_window` paths flow through `on_page_load`, so the
+/// handler is always re-armed after a recreation.
+///
+/// # Errors
+/// Returns an error if the controller or `CoreWebView2` cannot be obtained.
+pub fn arm_crash_recovery(window: &WebviewWindow) -> tauri::Result<()> {
+    let app = window.app_handle().clone();
+
+    window.with_webview(move |wv| {
+        let controller = wv.controller();
+        // SAFETY: `CoreWebView2()` is a COM getter that returns a
+        // reference-counted interface. The controller is valid for the
+        // lifetime of the webview. No raw pointers are stored.
+        let core = match unsafe { controller.CoreWebView2() } {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[webview_recovery] Failed to get CoreWebView2: {e}");
+                return;
+            }
+        };
+
+        let handler = ProcessFailedEventHandler::create(Box::new(move |_, args| {
+            handle_process_failed(&app, args.as_ref());
+            Ok(())
+        }));
+
+        let mut token: i64 = 0;
+        // SAFETY: `add_ProcessFailed` is a standard COM method that stores
+        // the handler and returns an event token. The handler (a COM object
+        // created by `ProcessFailedEventHandler::create`) is reference-counted
+        // by the COM runtime and kept alive as long as it is registered.
+        if let Err(e) = unsafe { core.add_ProcessFailed(&handler, &mut token) } {
+            eprintln!("[webview_recovery] add_ProcessFailed failed: {e}");
+        }
+    })?;
+    Ok(())
+}
+
+/// Dispatch recovery action based on the process failure kind.
+fn handle_process_failed(
+    app: &AppHandle,
+    event_args: Option<
+        &webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2ProcessFailedEventArgs,
+    >,
+) {
+    let Some(a) = event_args else {
+        eprintln!("[webview_recovery] ProcessFailed but no event args");
+        return;
+    };
+
+    let mut raw_kind = COREWEBVIEW2_PROCESS_FAILED_KIND::default();
+    // SAFETY: `ProcessFailedKind` is a simple getter that writes an i32
+    // enum value into the output pointer. No lifetime concerns.
+    if let Err(e) = unsafe { a.ProcessFailedKind(&mut raw_kind) } {
+        eprintln!("[webview_recovery] ProcessFailed but could not read kind: {e}");
+        return;
+    }
+
+    if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED {
+        eprintln!("[webview_recovery] Browser process exited — recreating window");
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+        recreate_window(app);
+    } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED {
+        // Rate-limit: if the render process crashes repeatedly within a
+        // short window, escalate to full window recreation to prevent an
+        // infinite crash-reload loop (e.g. fatal JS error on startup).
+        static EXIT_COUNT: AtomicU32 = AtomicU32::new(0);
+        static LAST_EXIT_TIME: AtomicI64 = AtomicI64::new(0);
+        const EXIT_THRESHOLD: u32 = 3;
+        const EXIT_TIME_WINDOW_MS: i64 = 10_000;
+
+        let now = crate::monotonic_ms();
+        let last = LAST_EXIT_TIME.swap(now, Ordering::Relaxed);
+        let count = if now - last < EXIT_TIME_WINDOW_MS {
+            EXIT_COUNT.fetch_add(1, Ordering::Relaxed) + 1
+        } else {
+            EXIT_COUNT.store(1, Ordering::Relaxed);
+            1
+        };
+
+        eprintln!("[webview_recovery] Render process exited ({count}/{EXIT_THRESHOLD})");
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+
+        if count >= EXIT_THRESHOLD {
+            eprintln!(
+                "[webview_recovery] Render process crashing repeatedly — escalating to full window recreation"
+            );
+            EXIT_COUNT.store(0, Ordering::Relaxed);
+            recreate_window(app);
+        } else {
+            reload_webview(app);
+        }
+    } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE {
+        let count = UNRESPONSIVE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+        eprintln!(
+            "[webview_recovery] Render process unresponsive ({count}/{UNRESPONSIVE_THRESHOLD})"
+        );
+        if count >= UNRESPONSIVE_THRESHOLD {
+            eprintln!("[webview_recovery] Unresponsive threshold reached — force reloading");
+            UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+            reload_webview(app);
+        }
+    } else {
+        eprintln!(
+            "[webview_recovery] ProcessFailed kind: {raw_kind:?} — no action needed (auto-recovered)"
+        );
+        UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Reload the webview content. `WebView2` will spawn a new render process.
+///
+/// Uses Tauri's native `reload()` API instead of `eval("location.reload()")`
+/// because `eval` requires a live JS execution context, which may not exist
+/// if the render process has crashed.
+fn reload_webview(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(e) = window.reload() {
+            eprintln!("[webview_recovery] reload failed: {e}");
+        }
+    }
+}
+
+/// Destroy the zombie window and recreate it from scratch.
+///
+/// Deferred to the main event-loop thread via `run_on_main_thread` because
+/// calling `window.destroy()` directly from within the `ProcessFailed` COM
+/// callback would destroy the `WebView2` controller while its own callback
+/// is still on the call stack — a use-after-free that crashes the process.
+///
+/// Uses the same reconstruction gate as `show_or_recreate_main_window`
+/// to prevent double-recreation when both Layer 1 and Layer 2 fire
+/// simultaneously.
+fn recreate_window(app: &AppHandle) {
+    let cloned = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        if !crate::try_acquire_reconstruct_gate(&cloned) {
+            eprintln!("[webview_recovery] Reconstruction already in progress — skipping");
+            return;
+        }
+        // Double-check: another path may have already recreated the window
+        // while we were queued on the main thread.
+        if cloned.get_webview_window("main").is_some() && crate::is_webview_alive(&cloned) {
+            eprintln!("[webview_recovery] Window already recreated and alive — skipping");
+            crate::release_reconstruct_gate(&cloned);
+            return;
+        }
+        if let Some(window) = cloned.get_webview_window("main") {
+            // Destroy the old window (and its dead controller).
+            let _ = window.destroy();
+        }
+        // Recreate. The `on_page_load` callback in `lib.rs` will re-arm
+        // crash recovery once the new webview finishes loading.
+        match crate::recreate_main_window(&cloned) {
+            Ok(window) => {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+            Err(e) => {
+                eprintln!("[webview_recovery] recreate_main_window failed: {e}");
+                crate::emit_error!(
+                    System,
+                    SYS_WINDOW_RECREATE_FAILED,
+                    "WebView2 crash recovery: failed to recreate window: {e}"
+                );
+            }
+        }
+        crate::release_reconstruct_gate(&cloned);
+    });
+}

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -8,6 +8,7 @@
 
 import {
   invoke,
+  listen,
   setBaseUrl,
   setSecret,
   setCoreReachable,
@@ -390,6 +391,21 @@ async function initApp() {
   registerCleanup(() => { cleanupTrayEventListeners(); });
 
   window.addEventListener('beforeunload', () => runCleanup());
+
+  // 10. Heartbeat — let the backend know the webview is alive (Layer 2).
+  // If this stops arriving (e.g. `WebView2` crash not caught by Layer 1),
+  // the backend will recreate the window on the next show attempt.
+  //
+  // The heartbeat runs unconditionally — even when the window is hidden —
+  // because a single `invoke` call every 15 s is negligible overhead,
+  // and keeping it running simplifies the logic (no pause/resume events
+  // needed, which Tauri does not emit natively for hide/show).
+  const HEARTBEAT_INTERVAL_MS = 15_000;
+  invoke(COMMANDS.HEARTBEAT).catch(() => {});
+  const _heartbeatTimer = setInterval(() => {
+    invoke(COMMANDS.HEARTBEAT).catch(() => {});
+  }, HEARTBEAT_INTERVAL_MS);
+  registerCleanup(() => clearInterval(_heartbeatTimer));
 
   apiLogger.info(`[Zephyr] ✅ App ready! Total: ${(performance.now() - t0).toFixed(0)}ms`);
 }

--- a/deny.toml
+++ b/deny.toml
@@ -11,16 +11,21 @@ ignore = [
   "RUSTSEC-2026-0099",
 ]
 # RUSTSEC-2026-0097: rand 0.8 unsound with custom logger using rand::rng()
-#   Indirect dependency via tauri ecosystem (phf_generator -> kuchikiki -> tauri-utils -> tauri v2)
-#   Our code pins rand = "0.10.1" directly; fix requires upstream tauri/kuchikiki to upgrade phf
+#   Indirect dependency via clash-prism-script v0.1.3 (latest, still uses rand 0.8)
+#   Our code pins rand = "0.10.1" directly; fix requires clash-prism-script to upgrade rand
 #   Track: https://rustsec.org/advisories/RUSTSEC-2026-0097.html
 #
-# RUSTSEC-2026-0098 / RUSTSEC-2026-0099: rustls-webpki 0.103.11 name constraints issues
+# RUSTSEC-2026-0098 / RUSTSEC-2026-0099: rustls-webpki name constraints issues
 #   Indirect dependency via reqwest -> hyper-rustls -> tokio-rustls -> rustls -> rustls-webpki
-#   Fix requires rustls >= 0.23.39 (pins webpki >=0.103.12); currently blocked on upstream release
-#   Track:
-#     https://rustsec.org/advisories/RUSTSEC-2026-0098.html
-#     https://rustsec.org/advisories/RUSTSEC-2026-0099.html
+#   Fixed by rustls 0.23.40 + webpki 0.103.13 (>=0.103.12); kept in ignore for older lock files
+#
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml DoS vulnerabilities
+#   Fixed by upgrading plist 1.9.0 → 1.10.0 (quick-xml 0.39.4 → 0.41.0)
+#   and tauri-winrt-notification 0.7.2 → 0.7.3 (removed quick-xml 0.37.5 entirely)
+#
+# RUSTSEC-2026-0185: quinn-proto remote memory exhaustion
+#   Fixed by upgrading quinn-proto 0.11.14 → 0.11.16 (>=0.11.15)
+#
 # RUSTSEC-2024-0418: gdk-sys / gtk-rs GTK3 bindings unmaintained
 #   Indirect dep via Tauri's webkit2gtk on Linux; fix requires Tauri GTK4 migration
 #   Already handled by unmaintained = "warn" but listed for visibility

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -141,6 +141,7 @@ export const MISC = Object.freeze({
     SHOW_MAIN_WINDOW: "show_main_window",
     SEND_NOTIFICATION: "rate_limited_send_notification",
     EXEMPT_UWP_APPS: "exempt_uwp_apps",
+    HEARTBEAT: "heartbeat",
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`WebView2` browser/render process crashes leave the Win32 HWND alive but empty. Combined with `transparent: true`, this creates an invisible **zombie window** — the taskbar shows the app as active, but no window is visible. Users had to kill the process manually.

## Solution — Three layers of defense

### Layer 1: Windows event-driven instant recovery (`webview_recovery.rs`)
- Registers `ProcessFailed` callback via `webview2-com` COM interop
- `BrowserProcessExited` → destroy + recreate window (deferred to main thread via `run_on_main_thread` to avoid use-after-free in COM callback)
- `RenderProcessExited` → `window.reload()` via Tauri native API; rate-limited to 3 crashes per 10s window before escalating to full recreation (prevents infinite crash-reload loop)
- `RenderProcessUnresponsive` → count to 3 then reload (anti-spin)
- Re-armed automatically via `on_page_load(Finished)` after every recreation
- Explicitly `.show()` + `.set_focus()` on recreated window
- Double-check `is_webview_alive` after acquiring gate (prevents double-recreation race)
- `webview2-com` version pinned to `=0.38.2`

### Layer 2: Cross-platform lazy heartbeat fallback
- Frontend sends heartbeat every **15s** unconditionally (one `invoke` call per 15s is negligible overhead)
- Backend stores timestamp in **lock-free `AtomicI64`** using **monotonic `Instant`** (immune to system clock adjustments)
- 3 consecutive misses (**45s**) → window considered dead → recreate on next show
- **Window-hidden check**: `is_webview_alive` returns `true` when window is hidden (browser engine throttles JS timers when hidden, so heartbeat naturally stops)
- Sentinel value `0` reserved exclusively for `invalidate_heartbeat()`
- `touch_heartbeat()` called at start of `recreate_main_window()` to prevent infinite loop during page load
- Cleanup registered for heartbeat interval via `registerCleanup`

### Layer 3: Unified entry + idempotent reconstruction gate
- All show-window paths converge to `show_or_recreate_main_window()`
- Reconstruction gate acquired **before** destroying zombie window (prevents windowless state on race)
- **Double-check** `is_webview_alive` after acquiring gate (prevents double-recreation when multiple paths race)
- `AtomicBool` reconstruction gate (`compare_exchange`) prevents double-recreate
- Explicitly `.show()` + `.set_focus()` on recreated window
- Fast-path: window alive → show + focus
- Slow-path: acquire gate → double-check → destroy zombie → recreate → show + focus → release gate

## Security: RUSTSEC advisory fixes

Upgraded transitive dependencies to fix 3 RUSTSEC advisories:
- `plist` 1.9.0 → 1.10.0 → `quick-xml` 0.39.4 → **0.41.0** (RUSTSEC-2026-0194, RUSTSEC-2026-0195)
- `tauri-winrt-notification` 0.7.2 → 0.7.3 (removed `quick-xml` 0.37.5 entirely)
- `quinn-proto` 0.11.14 → **0.11.16** (RUSTSEC-2026-0185)
- Added `audit.toml` for `cargo audit` CI

## Files changed

| File | Change |
|---|---|
| `webview_recovery.rs` (new) | Layer 1 — ProcessFailed handler, rate-limited reload, double-check race guard, native `reload()` API |
| `lib.rs` | Layer 2 heartbeat (monotonic `Instant`, hidden-window check) + Layer 3 unified entry (gate + double-check, show+focus) |
| `tray.rs` | Delegate to unified entry |
| `main.js` | 15s unconditional heartbeat with cleanup registration |
| `Cargo.toml` | `webview2-com = "=0.38.2"` direct dependency |
| `Cargo.lock` | Updated: quick-xml 0.41.0, quinn-proto 0.11.16, plist 1.10.0, etc. |
| `shared/index.js` | `HEARTBEAT` command constant |
| `deny.toml` | Updated advisory comments |
| `audit.toml` (new) | `cargo audit` config |
