### PR TITLE
feat: assign granular error codes to all backend error paths

### DIFF
--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -210,6 +210,10 @@ pub mod codes {
     pub const CORE_RELOAD_FAILED: u16 = 1006;
     pub const CORE_LOCK_FAILED: u16 = 1007;
     pub const CORE_LOG_ROTATION_FAILED: u16 = 1008;
+    /// Mihomo mode restore after subscription update failed.
+    pub const CORE_MODE_RESTORE_FAILED: u16 = 1009;
+    /// Mihomo mode restore failed in Drop guard (deferred path).
+    pub const CORE_MODE_RESTORE_DROPPED: u16 = 1010;
 
     // Subscription: 2000-2999
     pub const SUB_UPDATE_FAILED: u16 = 2001;
@@ -226,12 +230,20 @@ pub mod codes {
     pub const SUB_NETWORK_ERROR: u16 = 2012;
     pub const SUB_RESPONSE_TOO_LARGE: u16 = 2013;
     pub const SUB_YAML_INVALID: u16 = 2014;
+    /// Direct download attempt failed; falling back to proxy.
+    pub const SUB_DIRECT_DOWNLOAD_FAILED: u16 = 2015;
+    /// Retrying subscription fetch through local proxy.
+    pub const SUB_PROXY_RETRY: u16 = 2016;
 
     // Prism: 3000-3999
     pub const PRISM_APPLY_FAILED: u16 = 3001;
     pub const PRISM_SCRIPT_ERROR: u16 = 3002;
     pub const PRISM_HOT_RELOAD_FAILED: u16 = 3003;
     pub const PRISM_LOCK_FAILED: u16 = 3004;
+    /// Script pipeline execution returned an error result.
+    pub const PRISM_SCRIPT_EXEC_FAILED: u16 = 3005;
+    /// Script pipeline completed with warnings / informational output.
+    pub const PRISM_SCRIPT_INFO: u16 = 3006;
 
     // Config: 4000-4999
     pub const CONFIG_SAVE_FAILED: u16 = 4001;
@@ -239,6 +251,22 @@ pub mod codes {
     pub const CONFIG_DELETE_FAILED: u16 = 4003;
     pub const CONFIG_CREATED_DEFAULT: u16 = 4004;
     pub const CONFIG_LOCK_FAILED: u16 = 4005;
+    /// Failed to read a profile file during encryption.
+    pub const CONFIG_ENCRYPT_READ_FAILED: u16 = 4006;
+    /// Failed to write an encrypted profile file.
+    pub const CONFIG_ENCRYPT_WRITE_FAILED: u16 = 4007;
+    /// Failed to encrypt profile content.
+    pub const CONFIG_ENCRYPT_FAILED: u16 = 4008;
+    /// Failed to read a profile file during decryption.
+    pub const CONFIG_DECRYPT_READ_FAILED: u16 = 4009;
+    /// Failed to write a decrypted profile file.
+    pub const CONFIG_DECRYPT_WRITE_FAILED: u16 = 4010;
+    /// Failed to decrypt profile content.
+    pub const CONFIG_DECRYPT_FAILED: u16 = 4011;
+    /// Persisting settings to disk failed.
+    pub const CONFIG_PERSIST_FAILED: u16 = 4012;
+    /// A dangling `last_config` reference was cleaned up.
+    pub const CONFIG_DANGLING_REF_CLEANED: u16 = 4013;
 
     // Plugin: 5000-5999
     pub const PLUGIN_LOAD_FAILED: u16 = 5001;
@@ -251,6 +279,32 @@ pub mod codes {
     pub const SYS_DNS_FAILED: u16 = 6003;
     pub const SYS_LOCK_FAILED: u16 = 6004;
     pub const SYS_WINDOW_RECREATE_FAILED: u16 = 6005;
+    /// `CoreWebView2` COM interface could not be obtained.
+    pub const SYS_WEBVIEW2_COM_INIT_FAILED: u16 = 6006;
+    /// `ProcessFailed` event handler registration failed.
+    pub const SYS_WEBVIEW2_HANDLER_FAILED: u16 = 6007;
+    /// Crash recovery arming failed.
+    pub const SYS_CRASH_RECOVERY_ARM_FAILED: u16 = 6008;
+    /// Crash recovery arming failed for the initial window.
+    pub const SYS_CRASH_RECOVERY_ARM_INITIAL: u16 = 6009;
+    /// `WebView` `reload()` call failed.
+    pub const SYS_WEBVIEW_RELOAD_FAILED: u16 = 6010;
+    /// Browser process exited — full window recreation initiated.
+    pub const SYS_WEBVIEW_BROWSER_EXITED: u16 = 6011;
+    /// Render process exited (rate-limited reload).
+    pub const SYS_WEBVIEW_RENDER_EXITED: u16 = 6012;
+    /// Render process crash loop detected — escalating to full recreation.
+    pub const SYS_WEBVIEW_RENDER_CRASH_LOOP: u16 = 6013;
+    /// `WebView` unresponsive threshold reached — force `reload()`.
+    pub const SYS_WEBVIEW_UNRESPONSIVE: u16 = 6014;
+    /// Heartbeat stale — webview considered dead, recreating.
+    pub const SYS_HEARTBEAT_STALE: u16 = 6015;
+    /// Reconstruction already in progress — request skipped.
+    pub const SYS_RECONSTRUCTION_SKIPPED: u16 = 6016;
+    /// System proxy toggle from tray failed.
+    pub const SYS_PROXY_TOGGLE_FAILED: u16 = 6017;
+    /// Other unhandled `ProcessFailedKind` (e.g. GPU, utility process — auto-recovered).
+    pub const SYS_WEBVIEW_PROCESS_FAILED_OTHER: u16 = 6018;
 
     // Updater: 7000-7999
     pub const UPDATE_CHECK_FAILED: u16 = 7001;
@@ -268,6 +322,10 @@ pub mod codes {
     // Smart: 10000-10999
     pub const SMART_SELECT_FAILED: u16 = 10001;
     pub const SMART_LOCK_FAILED: u16 = 10002;
+    /// Smart WAL append operation failed.
+    pub const SMART_WAL_APPEND_FAILED: u16 = 10003;
+    /// Smart WAL remove operation failed.
+    pub const SMART_WAL_REMOVE_FAILED: u16 = 10004;
 }
 
 // ── Global Emitter ──────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -334,12 +334,24 @@ fn cleanup_dangling_last_config(
     }
 
     if let Err(e) = persist_settings(app, &settings_clone) {
-        eprintln!("[delete_config] failed to persist settings after last_config cleanup: {e}");
+        crate::emit_warn!(
+            Config,
+            CONFIG_PERSIST_FAILED,
+            "Failed to persist settings after last_config cleanup: {e}"
+        );
     }
     if let Some(name) = &settings_clone.last_config {
-        eprintln!("[delete_config] last_config was dangling (pointed to deleted '{deleted_name}'), reset to '{name}'");
+        crate::emit_info!(
+            Config,
+            CONFIG_DANGLING_REF_CLEANED,
+            "last_config was dangling (pointed to deleted '{deleted_name}'), reset to '{name}'"
+        );
     } else {
-        eprintln!("[delete_config] last_config was dangling (pointed to deleted '{deleted_name}'), reset to None (no profiles left)");
+        crate::emit_info!(
+            Config,
+            CONFIG_DANGLING_REF_CLEANED,
+            "last_config was dangling (pointed to deleted '{deleted_name}'), reset to None (no profiles left)"
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/core/crypto.rs
+++ b/apps/desktop/src-tauri/src/core/crypto.rs
@@ -395,7 +395,12 @@ pub fn encrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("[encrypt_all_profiles] skip {}: {e}", path.display());
+                crate::emit_warn!(
+                    Config,
+                    CONFIG_ENCRYPT_READ_FAILED,
+                    "encrypt: skip {}: {e}",
+                    path.display()
+                );
                 failures += 1;
                 continue;
             }
@@ -406,12 +411,22 @@ pub fn encrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
         match obfuscate_string(&content) {
             Ok(encrypted) => {
                 if let Err(e) = write_file_secure(&path, &encrypted) {
-                    eprintln!("[encrypt_all_profiles] write {}: {e}", path.display());
+                    crate::emit_warn!(
+                        Config,
+                        CONFIG_ENCRYPT_WRITE_FAILED,
+                        "encrypt: write {}: {e}",
+                        path.display()
+                    );
                     failures += 1;
                 }
             }
             Err(e) => {
-                eprintln!("[encrypt_all_profiles] encrypt {}: {e}", path.display());
+                crate::emit_warn!(
+                    Config,
+                    CONFIG_ENCRYPT_FAILED,
+                    "encrypt: encrypt {}: {e}",
+                    path.display()
+                );
                 failures += 1;
             }
         }
@@ -442,7 +457,12 @@ pub fn decrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("[decrypt_all_profiles] skip {}: {e}", path.display());
+                crate::emit_warn!(
+                    Config,
+                    CONFIG_DECRYPT_READ_FAILED,
+                    "decrypt: skip {}: {e}",
+                    path.display()
+                );
                 failures += 1;
                 continue;
             }
@@ -453,12 +473,22 @@ pub fn decrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
         match deobfuscate_string(&content) {
             Ok(decrypted) => {
                 if let Err(e) = write_file_secure(&path, &decrypted) {
-                    eprintln!("[decrypt_all_profiles] write {}: {e}", path.display());
+                    crate::emit_warn!(
+                        Config,
+                        CONFIG_DECRYPT_WRITE_FAILED,
+                        "decrypt: write {}: {e}",
+                        path.display()
+                    );
                     failures += 1;
                 }
             }
             Err(e) => {
-                eprintln!("[decrypt_all_profiles] decrypt {}: {e}", path.display());
+                crate::emit_warn!(
+                    Config,
+                    CONFIG_DECRYPT_FAILED,
+                    "decrypt: decrypt {}: {e}",
+                    path.display()
+                );
                 failures += 1;
             }
         }

--- a/apps/desktop/src-tauri/src/core/fetch_util.rs
+++ b/apps/desktop/src-tauri/src/core/fetch_util.rs
@@ -167,11 +167,19 @@ pub async fn fetch_url_content(url: &str, proxy_port: Option<u16>) -> Result<Str
     match direct_result {
         Ok(content) => Ok(content),
         Err(direct_err) => {
-            eprintln!("[fetch_url_content] Direct download failed: {direct_err}");
+            crate::emit_warn!(
+                Subscription,
+                SUB_DIRECT_DOWNLOAD_FAILED,
+                "Direct download failed: {direct_err}"
+            );
 
             // Try proxy fallback if available
             if let Some(port) = proxy_port.filter(|&p| p > 0) {
-                eprintln!("[fetch_url_content] Retrying with proxy...");
+                crate::emit_info!(
+                    Subscription,
+                    SUB_PROXY_RETRY,
+                    "Retrying with proxy on port {port}..."
+                );
                 match try_proxy_download(url, port).await {
                     Ok(content) => Ok(content),
                     Err(proxy_err) => Err(format!("Direct: {direct_err}; Proxy: {proxy_err}")),

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -398,8 +398,10 @@ async fn download_sub_inner_raw(
                                     let app = self.app.clone();
                                     tokio::spawn(async move {
                                         if set_mihomo_mode(&app, &orig).await.is_none() {
-                                            eprintln!(
-                                                "[subscription] failed to restore original mihomo mode '{orig}' on drop"
+                                            crate::emit_warn!(
+                                                Core,
+                                                CORE_MODE_RESTORE_DROPPED,
+                                                "Failed to restore original mihomo mode '{orig}' on drop"
                                             );
                                         }
                                     });
@@ -446,8 +448,10 @@ async fn download_sub_inner_raw(
                         // 避免 Drop 时重复执行恢复。
                         if let Some(orig) = restore_guard.orig_mode.take() {
                             if set_mihomo_mode(app, &orig).await.is_none() {
-                                eprintln!(
-                                    "[subscription] failed to restore original mihomo mode '{orig}'"
+                                crate::emit_warn!(
+                                    Core,
+                                    CORE_MODE_RESTORE_FAILED,
+                                    "Failed to restore original mihomo mode '{orig}'"
                                 );
                             }
                         }
@@ -794,7 +798,11 @@ pub struct BatchUpdateItem {
 #[tauri::command]
 pub async fn fetch_text(url: String) -> Result<String, String> {
     fetch_url_content(&url, None).await.map_err(|e| {
-        println!("Fetch failed: {e}");
+        crate::emit_error!(
+            Subscription,
+            SUB_NETWORK_ERROR,
+            "fetch_text failed for '{url}': {e}"
+        );
         "Network error occurred during fetch".to_owned()
     })
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -455,7 +455,11 @@ pub(crate) fn show_or_recreate_main_window(app: &tauri::AppHandle) {
     // If another caller already holds the gate, we must not destroy the
     // existing window — otherwise the app is left in a windowless state.
     if !try_acquire_reconstruct_gate(app) {
-        eprintln!("[lib] Reconstruction already in progress — skipping");
+        emit_info!(
+            System,
+            SYS_RECONSTRUCTION_SKIPPED,
+            "Reconstruction already in progress — skipping"
+        );
         return;
     }
 
@@ -483,7 +487,11 @@ pub(crate) fn show_or_recreate_main_window(app: &tauri::AppHandle) {
 
     // Destroy zombie if it exists (now safe — we hold the gate).
     if let Some(window) = app.get_webview_window("main") {
-        eprintln!("[lib] Webview heartbeat stale — recreating window");
+        emit_info!(
+            System,
+            SYS_HEARTBEAT_STALE,
+            "Webview heartbeat stale — recreating window"
+        );
         let _ = window.destroy();
     }
 
@@ -493,7 +501,6 @@ pub(crate) fn show_or_recreate_main_window(app: &tauri::AppHandle) {
             let _ = window.set_focus();
         }
         Err(e) => {
-            eprintln!("[lib] Failed to recreate main window: {e}");
             emit_error!(
                 System,
                 SYS_WINDOW_RECREATE_FAILED,
@@ -839,7 +846,11 @@ pub(crate) fn recreate_main_window(
                     {
                         if !armed.swap(true, Ordering::Relaxed) {
                             if let Err(e) = webview_recovery::arm_crash_recovery(&webview_window) {
-                                eprintln!("[lib] Failed to arm crash recovery: {e}");
+                                emit_error!(
+                                    System,
+                                    SYS_CRASH_RECOVERY_ARM_FAILED,
+                                    "Failed to arm crash recovery: {e}"
+                                );
                             }
                         }
                     }
@@ -1193,7 +1204,11 @@ pub fn run() {
             {
                 if let Some(window) = app.get_webview_window("main") {
                     if let Err(e) = webview_recovery::arm_crash_recovery(&window) {
-                        eprintln!("[lib] Failed to arm crash recovery for initial window: {e}");
+                        emit_error!(
+                            System,
+                            SYS_CRASH_RECOVERY_ARM_INITIAL,
+                            "Failed to arm crash recovery for initial window: {e}"
+                        );
                     }
                 }
             }

--- a/apps/desktop/src-tauri/src/prism/pipeline.rs
+++ b/apps/desktop/src-tauri/src/prism/pipeline.rs
@@ -21,10 +21,10 @@ pub(crate) static RUN_CONFIG_LOCK: Mutex<()> = Mutex::new(());
 
 // Use eprintln for logging since tracing is not available in this crate
 macro_rules! log_error {
-    ($($arg:tt)*) => { emit_error!(Prism, PRISM_SCRIPT_ERROR, $($arg)*) };
+    ($($arg:tt)*) => { emit_error!(Prism, PRISM_SCRIPT_EXEC_FAILED, $($arg)*) };
 }
 macro_rules! log_info {
-    ($($arg:tt)*) => { emit_info!(Prism, PRISM_SCRIPT_ERROR, $($arg)*) };
+    ($($arg:tt)*) => { emit_info!(Prism, PRISM_SCRIPT_INFO, $($arg)*) };
 }
 
 /// Result of executing a script with write-back.

--- a/apps/desktop/src-tauri/src/prism/smart_state.rs
+++ b/apps/desktop/src-tauri/src/prism/smart_state.rs
@@ -242,7 +242,7 @@ impl SmartState {
                     // 1. 立即追加到 WAL (崩溃安全)
                     if let Some(ref mut file) = wal_file {
                         if let Err(e) = Self::append_wal_to_file(file, &record).await {
-                            emit_warn!(Smart, SMART_SELECT_FAILED, "WAL append failed: {e}");
+                            emit_warn!(Smart, SMART_WAL_APPEND_FAILED, "WAL append failed: {e}");
                         }
                     }
 
@@ -258,7 +258,11 @@ impl SmartState {
                             // Windows 需要先关闭文件句柄才能删除
                             drop(wal_file);
                             if let Err(e) = tokio::fs::remove_file(&config.wal_path).await {
-                                emit_warn!(Smart, SMART_SELECT_FAILED, "WAL remove failed: {e}");
+                                emit_warn!(
+                                    Smart,
+                                    SMART_WAL_REMOVE_FAILED,
+                                    "WAL remove failed: {e}"
+                                );
                             }
                             // 重新打开 WAL 文件
                             wal_file = Self::open_wal_file(&config.wal_path).await.ok();

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -329,7 +329,11 @@ fn toggle_sys_proxy(app: &AppHandle) {
     };
 
     if let Err(e) = result {
-        eprintln!("Failed to toggle system proxy: {e}");
+        emit_error!(
+            System,
+            SYS_PROXY_TOGGLE_FAILED,
+            "Failed to toggle system proxy: {e}"
+        );
         // Operation failed — do not update state, rebuild menu with current state
         rebuild_tray_menu_from_state(app);
         return;

--- a/apps/desktop/src-tauri/src/webview_recovery.rs
+++ b/apps/desktop/src-tauri/src/webview_recovery.rs
@@ -80,7 +80,11 @@ pub fn arm_crash_recovery(window: &WebviewWindow) -> tauri::Result<()> {
         let core = match unsafe { controller.CoreWebView2() } {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("[webview_recovery] Failed to get CoreWebView2: {e}");
+                crate::emit_error!(
+                    System,
+                    SYS_WEBVIEW2_COM_INIT_FAILED,
+                    "Failed to get CoreWebView2 COM interface: {e}"
+                );
                 return;
             }
         };
@@ -96,7 +100,11 @@ pub fn arm_crash_recovery(window: &WebviewWindow) -> tauri::Result<()> {
         // created by `ProcessFailedEventHandler::create`) is reference-counted
         // by the COM runtime and kept alive as long as it is registered.
         if let Err(e) = unsafe { core.add_ProcessFailed(&handler, &mut token) } {
-            eprintln!("[webview_recovery] add_ProcessFailed failed: {e}");
+            crate::emit_error!(
+                System,
+                SYS_WEBVIEW2_HANDLER_FAILED,
+                "Failed to register ProcessFailed event handler: {e}"
+            );
         }
     })?;
     Ok(())
@@ -110,7 +118,11 @@ fn handle_process_failed(
     >,
 ) {
     let Some(a) = event_args else {
-        eprintln!("[webview_recovery] ProcessFailed but no event args");
+        crate::emit_warn!(
+            System,
+            SYS_WEBVIEW2_HANDLER_FAILED,
+            "ProcessFailed callback received no event args"
+        );
         return;
     };
 
@@ -118,12 +130,20 @@ fn handle_process_failed(
     // SAFETY: `ProcessFailedKind` is a simple getter that writes an i32
     // enum value into the output pointer. No lifetime concerns.
     if let Err(e) = unsafe { a.ProcessFailedKind(&mut raw_kind) } {
-        eprintln!("[webview_recovery] ProcessFailed but could not read kind: {e}");
+        crate::emit_error!(
+            System,
+            SYS_WEBVIEW2_HANDLER_FAILED,
+            "ProcessFailed: could not read failure kind: {e}"
+        );
         return;
     }
 
     if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED {
-        eprintln!("[webview_recovery] Browser process exited — recreating window");
+        crate::emit_info!(
+            System,
+            SYS_WEBVIEW_BROWSER_EXITED,
+            "Browser process exited — recreating window"
+        );
         UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
         recreate_window(app);
     } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED {
@@ -144,12 +164,18 @@ fn handle_process_failed(
             1
         };
 
-        eprintln!("[webview_recovery] Render process exited ({count}/{EXIT_THRESHOLD})");
+        crate::emit_info!(
+            System,
+            SYS_WEBVIEW_RENDER_EXITED,
+            "Render process exited ({count}/{EXIT_THRESHOLD})"
+        );
         UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
 
         if count >= EXIT_THRESHOLD {
-            eprintln!(
-                "[webview_recovery] Render process crashing repeatedly — escalating to full window recreation"
+            crate::emit_warn!(
+                System,
+                SYS_WEBVIEW_RENDER_CRASH_LOOP,
+                "Render process crashing repeatedly — escalating to full window recreation"
             );
             EXIT_COUNT.store(0, Ordering::Relaxed);
             recreate_window(app);
@@ -165,17 +191,25 @@ fn handle_process_failed(
             UNRESPONSIVE_COUNT.store(1, Ordering::Relaxed);
             1
         };
-        eprintln!(
-            "[webview_recovery] Render process unresponsive ({count}/{UNRESPONSIVE_THRESHOLD})"
+        crate::emit_info!(
+            System,
+            SYS_WEBVIEW_UNRESPONSIVE,
+            "Render process unresponsive ({count}/{UNRESPONSIVE_THRESHOLD})"
         );
         if count >= UNRESPONSIVE_THRESHOLD {
-            eprintln!("[webview_recovery] Unresponsive threshold reached — force reloading");
+            crate::emit_warn!(
+                System,
+                SYS_WEBVIEW_UNRESPONSIVE,
+                "Unresponsive threshold reached — force reloading"
+            );
             UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
             reload_webview(app);
         }
     } else {
-        eprintln!(
-            "[webview_recovery] ProcessFailed kind: {raw_kind:?} — no action needed (auto-recovered)"
+        crate::emit_info!(
+            System,
+            SYS_WEBVIEW_PROCESS_FAILED_OTHER,
+            "ProcessFailed kind: {raw_kind:?} — no action needed (auto-recovered)"
         );
         UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
     }
@@ -189,7 +223,11 @@ fn handle_process_failed(
 fn reload_webview(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         if let Err(e) = window.reload() {
-            eprintln!("[webview_recovery] reload failed: {e}");
+            crate::emit_error!(
+                System,
+                SYS_WEBVIEW_RELOAD_FAILED,
+                "WebView reload() failed: {e}"
+            );
         }
     }
 }
@@ -208,13 +246,21 @@ fn recreate_window(app: &AppHandle) {
     let cloned = app.clone();
     let _ = app.run_on_main_thread(move || {
         if !crate::try_acquire_reconstruct_gate(&cloned) {
-            eprintln!("[webview_recovery] Reconstruction already in progress — skipping");
+            crate::emit_info!(
+                System,
+                SYS_RECONSTRUCTION_SKIPPED,
+                "Reconstruction already in progress — skipping"
+            );
             return;
         }
         // Double-check: another path may have already recreated the window
         // while we were queued on the main thread.
         if cloned.get_webview_window("main").is_some() && crate::is_webview_alive(&cloned) {
-            eprintln!("[webview_recovery] Window already recreated and alive — skipping");
+            crate::emit_info!(
+                System,
+                SYS_RECONSTRUCTION_SKIPPED,
+                "Window already recreated and alive — skipping"
+            );
             crate::release_reconstruct_gate(&cloned);
             return;
         }
@@ -230,7 +276,6 @@ fn recreate_window(app: &AppHandle) {
                 let _ = window.set_focus();
             }
             Err(e) => {
-                eprintln!("[webview_recovery] recreate_main_window failed: {e}");
                 crate::emit_error!(
                     System,
                     SYS_WINDOW_RECREATE_FAILED,


### PR DESCRIPTION
## Summary

Replace all eprintln!/println! calls with structured emit_error!/emit_warn!/emit_info! calls that propagate to the frontend via the existing ackend-event channel.

## New Error Codes (23 total)

| Module | Code | Constant | Description |
|--------|------|----------|-------------|
| Core | 1009 | CORE_MODE_RESTORE_FAILED | Mihomo mode restore failed after subscription update |
| Core | 1010 | CORE_MODE_RESTORE_DROPPED | Mode restore failed in Drop guard |
| Subscription | 2015 | SUB_DIRECT_DOWNLOAD_FAILED | Direct download failed, falling back to proxy |
| Subscription | 2016 | SUB_PROXY_RETRY | Retrying fetch through local proxy |
| Prism | 3005 | PRISM_SCRIPT_EXEC_FAILED | Script pipeline execution returned error |
| Prism | 3006 | PRISM_SCRIPT_INFO | Script pipeline info output |
| Config | 4006-4008 | CONFIG_ENCRYPT_* | Encrypt read/write/encrypt failures |
| Config | 4009-4011 | CONFIG_DECRYPT_* | Decrypt read/write/decrypt failures |
| Config | 4012 | CONFIG_PERSIST_FAILED | Settings persist to disk failed |
| Config | 4013 | CONFIG_DANGLING_REF_CLEANED | Dangling last_config cleaned up |
| System | 6006-6009 | SYS_WEBVIEW2_* / SYS_CRASH_RECOVERY_* | WebView2 COM init, handler, crash recovery arming |
| System | 6010-6014 | SYS_WEBVIEW_* | Reload, browser exit, render exit, crash loop, unresponsive |
| System | 6015-6017 | SYS_HEARTBEAT_* / SYS_RECONSTRUCTION_* / SYS_PROXY_TOGGLE_* | Heartbeat stale, reconstruction skipped, proxy toggle |
| System | 6018 | SYS_WEBVIEW_PROCESS_FAILED_OTHER | Other unhandled ProcessFailedKind (GPU, utility — auto-recovered) |
| Smart | 10003 | SMART_WAL_APPEND_FAILED | WAL append operation failed |
| Smart | 10004 | SMART_WAL_REMOVE_FAILED | WAL remove operation failed |

## Refined Existing Codes

- smart_state.rs: SMART_SELECT_FAILED -> SMART_WAL_APPEND_FAILED / SMART_WAL_REMOVE_FAILED`n- pipeline.rs: PRISM_SCRIPT_ERROR -> PRISM_SCRIPT_EXEC_FAILED (error) / PRISM_SCRIPT_INFO (info)

## Files Changed (10)

- ackend_event.rs - Added 23 new error code constants
- webview_recovery.rs - 14 eprintln! -> emit calls
- lib.rs - 5 eprintln! -> emit calls
- 	ray.rs - 1 eprintln! -> emit_error!
- core/subscription.rs - 2 eprintln! + 1 println! -> emit calls
- core/fetch_util.rs - 2 eprintln! -> emit calls
- core/crypto.rs - 6 eprintln! -> emit_warn!
- core/config_manager.rs - 3 eprintln! -> emit calls
- prism/smart_state.rs - 2 code refinements
- prism/pipeline.rs - macro code refinement

## Design Decisions

- The only remaining eprintln! calls are in ackend_event.rs itself: (1) the stderr output inside emit_backend_event (the logging mechanism itself), (2) log writer failure (cannot use emit_error! to avoid infinite recursion).
- Frontend ackend-events.js already handles all codes generically via level/module/code/message extraction - no frontend changes needed.