### PR TITLE
feat: CPU v3 detection, catch_unwind guards, ARM64 CI, dual-source racing, digest cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,18 @@ jobs:
             args: ""
             target: ""
             arch: "x64"
+          - platform: "ubuntu-22.04-arm"
+            args: ""
+            target: ""
+            arch: "arm64"
           - platform: "windows-latest"
             args: ""
             target: ""
             arch: "x64"
+          - platform: "windows-latest"
+            args: "--target aarch64-pc-windows-msvc"
+            target: "aarch64-pc-windows-msvc"
+            arch: "arm64"
 
     runs-on: ${{ matrix.platform }}
     
@@ -42,7 +50,7 @@ jobs:
           cat > /tmp/download-bundled.sh << 'SCRIPT_EOF'
           #!/bin/bash
           # Unified script to download mihomo core and geo data with SHA256 verification
-          # Usage: download-bundled.sh <platform> <mihomo_version> <github_token>
+          # Usage: download-bundled.sh <platform> <mihomo_version> <github_token> <arch>
           set -e
           PLATFORM="$1"
           MIHOMO_VERSION="$2"
@@ -50,22 +58,31 @@ jobs:
           
           mkdir -p apps/desktop/src-tauri/bundled
           
-          # Determine mihomo asset name based on platform
+          # Determine mihomo asset name based on platform and arch
+          ARCH="$4"
           case "$PLATFORM" in
             windows-latest)
-              MIHOMO_ASSET="mihomo-windows-amd64-compatible-${MIHOMO_VERSION}.zip"
+              if [ "$ARCH" = "arm64" ]; then
+                MIHOMO_ASSET="mihomo-windows-arm64-${MIHOMO_VERSION}.zip"
+              else
+                MIHOMO_ASSET="mihomo-windows-amd64-compatible-${MIHOMO_VERSION}.zip"
+              fi
               MIHOMO_EXT="zip"
               ;;
             macos-latest)
-              if [ "${{ matrix.arch }}" = "arm64" ]; then
+              if [ "$ARCH" = "arm64" ]; then
                 MIHOMO_ASSET="mihomo-darwin-arm64-${MIHOMO_VERSION}.gz"
               else
                 MIHOMO_ASSET="mihomo-darwin-amd64-compatible-${MIHOMO_VERSION}.gz"
               fi
               MIHOMO_EXT="gz"
               ;;
-            ubuntu-22.04)
-              MIHOMO_ASSET="mihomo-linux-amd64-compatible-${MIHOMO_VERSION}.gz"
+            ubuntu-22.04|ubuntu-22.04-arm)
+              if [ "$ARCH" = "arm64" ]; then
+                MIHOMO_ASSET="mihomo-linux-arm64-${MIHOMO_VERSION}.gz"
+              else
+                MIHOMO_ASSET="mihomo-linux-amd64-compatible-${MIHOMO_VERSION}.gz"
+              fi
               MIHOMO_EXT="gz"
               ;;
             *)
@@ -101,8 +118,8 @@ jobs:
           case "$MIHOMO_EXT" in
             zip)
               unzip -q "mihomo.zip"
-              mv mihomo-windows-amd64-compatible.exe apps/desktop/src-tauri/bundled/zephyr-mihomo.exe
-              rm mihomo.zip
+              mv mihomo-windows-*.exe apps/desktop/src-tauri/bundled/zephyr-mihomo.exe
+              rm -f mihomo.zip
               ;;
             gz)
               gunzip -f "mihomo.gz"
@@ -180,10 +197,16 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ (matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin') || (matrix.target == 'aarch64-pc-windows-msvc' && 'aarch64-pc-windows-msvc') || '' }}
 
-      - name: Install dependencies (Ubuntu only)
+      - name: Install dependencies (Ubuntu x64 only)
         if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install dependencies (Ubuntu ARM64 only)
+        if: matrix.platform == 'ubuntu-22.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -217,7 +240,7 @@ jobs:
         if: matrix.platform != 'macos-latest' || matrix.arch == 'arm64'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN"
+        run: /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN" "${{ matrix.arch }}"
         shell: bash
 
       # macOS x64 uses different arch naming in mihomo releases
@@ -263,10 +286,15 @@ jobs:
         if: matrix.platform == 'windows-latest'
         run: |
           shopt -s nullglob
-          for f in target/release/bundle/nsis/*-setup.exe; do
+          if [ -n "${{ matrix.target }}" ]; then
+            BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
+          else
+            BUNDLE_DIR="target/release/bundle"
+          fi
+          for f in $BUNDLE_DIR/nsis/*-setup.exe; do
             cp "$f" "dist-artifacts/$(basename "${f/-setup/-setup-full}")"
           done
-          for f in target/release/bundle/msi/*.msi; do
+          for f in $BUNDLE_DIR/msi/*.msi; do
             cp "$f" "dist-artifacts/$(basename "${f/.msi/-full.msi}")"
           done
         shell: bash
@@ -284,7 +312,7 @@ jobs:
         shell: bash
 
       - name: Collect Linux Full artifacts
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           shopt -s nullglob
           for f in target/release/bundle/deb/*.deb; do
@@ -310,10 +338,15 @@ jobs:
         if: matrix.platform == 'windows-latest'
         run: |
           shopt -s nullglob
-          for f in target/release/bundle/nsis/*-setup.exe; do
+          if [ -n "${{ matrix.target }}" ]; then
+            BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
+          else
+            BUNDLE_DIR="target/release/bundle"
+          fi
+          for f in $BUNDLE_DIR/nsis/*-setup.exe; do
             cp "$f" "dist-artifacts/$(basename "${f/-setup/-setup-lite}")"
           done
-          for f in target/release/bundle/msi/*.msi; do
+          for f in $BUNDLE_DIR/msi/*.msi; do
             cp "$f" "dist-artifacts/$(basename "${f/.msi/-lite.msi}")"
           done
         shell: bash
@@ -331,7 +364,7 @@ jobs:
         shell: bash
 
       - name: Collect Linux Lite artifacts
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           shopt -s nullglob
           for f in target/release/bundle/deb/*.deb; do
@@ -350,25 +383,25 @@ jobs:
 
       # ── Restore bundled for portable (reuses unified script) ──
       - name: Restore bundled for portable
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN"
+        run: /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN" "${{ matrix.arch }}"
         shell: bash
 
       - name: Clean bundle directory before portable build
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           # Clean previous builds to ensure we get the correct portable artifact
           rm -rf target/release/bundle
         shell: bash
 
       - name: Build Tauri app (Portable)
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: pnpm --filter @zephyr/desktop tauri build ${{ matrix.args }}
 
       - name: Package Portable ZIP (Windows)
-        if: matrix.platform == 'windows-latest'
+        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
         run: |
           mkdir -p portable/core portable/profiles portable/prism/plugins
           cp target/release/Zephyr.exe portable/
@@ -378,7 +411,7 @@ jobs:
         shell: bash
 
       - name: Package Portable AppImage (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           # Get the freshly built AppImage (should be the only one after clean)
           APPIMAGE=$(ls -t target/release/bundle/appimage/Zephyr*.AppImage | head -1)
@@ -391,7 +424,8 @@ jobs:
           cp "$APPIMAGE" portable/
           cp apps/desktop/src-tauri/bundled/* portable/core/
           touch portable/.portable
-          cd portable && tar czf ../dist-artifacts/Zephyr-linux-portable.tar.gz . && cd ..
+          ARCH_SUFFIX="${{ matrix.arch }}"
+          cd portable && tar czf ../dist-artifacts/Zephyr-linux-${ARCH_SUFFIX}-portable.tar.gz . && cd ..
         shell: bash
 
       # ── Minisign: sign all release artifacts ──

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 opt-level = 3
 lto = true
 codegen-units = 1
-panic = "abort"
+panic = "unwind"
 strip = "debuginfo"
 split-debuginfo = "packed"
 

--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -214,6 +214,8 @@ pub mod codes {
     pub const CORE_MODE_RESTORE_FAILED: u16 = 1009;
     /// Mihomo mode restore failed in Drop guard (deferred path).
     pub const CORE_MODE_RESTORE_DROPPED: u16 = 1010;
+    /// Panic was caught by `catch_unwind` in a core operation.
+    pub const CORE_PANIC_GUARD: u16 = 1011;
 
     // Subscription: 2000-2999
     pub const SUB_UPDATE_FAILED: u16 = 2001;
@@ -267,6 +269,8 @@ pub mod codes {
     pub const CONFIG_PERSIST_FAILED: u16 = 4012;
     /// A dangling `last_config` reference was cleaned up.
     pub const CONFIG_DANGLING_REF_CLEANED: u16 = 4013;
+    /// Panic was caught by `catch_unwind` during config I/O.
+    pub const CONFIG_PANIC_GUARD: u16 = 4014;
 
     // Plugin: 5000-5999
     pub const PLUGIN_LOAD_FAILED: u16 = 5001;
@@ -310,6 +314,8 @@ pub mod codes {
     pub const UPDATE_CHECK_FAILED: u16 = 7001;
     pub const UPDATE_DOWNLOAD_FAILED: u16 = 7002;
     pub const UPDATE_LOCK_FAILED: u16 = 7003;
+    /// Panic was caught by `catch_unwind` during update.
+    pub const UPDATE_PANIC_GUARD: u16 = 7004;
 
     // Override: 8000-8999
     pub const OVERRIDE_APPLY_FAILED: u16 = 8001;
@@ -543,4 +549,23 @@ macro_rules! emit_info {
             )
         )
     };
+}
+
+// ── Panic Guard Utilities ──────────────────────────────────────────────────
+
+/// Convert a `catch_unwind` panic payload into a human-readable string.
+///
+/// Panics in Rust can carry `&'static str`, `String`, or arbitrary types.
+/// This function extracts the most common ones and falls back to a generic
+/// message for unknown payload types.
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+pub fn panic_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_owned()
+    }
 }

--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -466,6 +466,27 @@ pub fn write_config_file(
     config_path: String,
     content: String,
 ) -> Result<String, String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        write_config_file_inner(app, config_path, content)
+    }))
+    .map_err(|payload| {
+        let msg = crate::backend_event::panic_to_string(payload);
+        crate::emit_error!(
+            Config,
+            CONFIG_PANIC_GUARD,
+            "Panic in write_config_file: {msg}"
+        );
+        format!("Internal error in write_config_file: {msg}")
+    })
+    .and_then(std::convert::identity)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn write_config_file_inner(
+    app: AppHandle,
+    config_path: String,
+    content: String,
+) -> Result<String, String> {
     let paths = ensure_app_storage(&app)?;
     let config_file_name = sanitize_config_file_name(config_path).map_err(|e| e.to_string())?;
     let (resolved_path, base_dir) = if config_file_name == "run_config.yaml" {

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -34,6 +34,11 @@ use super::CREATE_NO_WINDOW;
 
 // ── Windows Job Object for auto-killing mihomo when Tauri exits ──────────
 #[cfg(target_os = "windows")]
+#[allow(
+    clippy::wildcard_imports,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation
+)]
 mod win_job {
     use std::sync::OnceLock;
     use windows_sys::Win32::Foundation::*;
@@ -1329,8 +1334,7 @@ async fn health_check(port: u16) -> Result<(), String> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-#[tauri::command]
-pub async fn start_core(
+async fn start_core_inner(
     app: AppHandle,
     state: State<'_, MihomoState>,
     config_path: String,
@@ -1640,6 +1644,42 @@ pub async fn start_core(
         port,
         active_config: active_config_name,
     })
+}
+
+/// Tauri command wrapper for `start_core_inner` with `catch_unwind` guard.
+///
+/// If the inner function panics, the error is caught and converted to a
+/// user-facing error string, preventing the entire app from crashing.
+#[tauri::command]
+pub async fn start_core(
+    app: AppHandle,
+    state: State<'_, MihomoState>,
+    config_path: String,
+    test: bool,
+    custom_args: Vec<String>,
+    secret: Option<String>,
+    force: Option<bool>,
+) -> Result<CoreStartResult, String> {
+    use futures_util::future::FutureExt as _;
+    use std::panic::AssertUnwindSafe;
+
+    AssertUnwindSafe(start_core_inner(
+        app,
+        state,
+        config_path,
+        test,
+        custom_args,
+        secret,
+        force,
+    ))
+    .catch_unwind()
+    .await
+    .map_err(|payload| {
+        let msg = crate::backend_event::panic_to_string(payload);
+        crate::emit_error!(Core, CORE_PANIC_GUARD, "Panic in start_core: {msg}");
+        format!("Internal error in start_core: {msg}")
+    })
+    .and_then(std::convert::identity)
 }
 
 /// Internal: stop the core process (no rate limiter reset).

--- a/apps/desktop/src-tauri/src/core/network_optim.rs
+++ b/apps/desktop/src-tauri/src/core/network_optim.rs
@@ -719,9 +719,16 @@ pub fn check_network_optimizations_status(_app: AppHandle) -> Result<NetworkOpti
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::unused_trait_names,
+    clippy::shadow_reuse,
+    clippy::cognitive_complexity,
+    clippy::assigning_clones,
+    clippy::or_fun_call
+)]
 pub fn apply_network_optimizations(app: AppHandle) -> Result<(), String> {
-    use std::os::windows::process::CommandExt;
+    use std::os::windows::process::CommandExt as _;
 
     emit_info!(
         System,
@@ -820,7 +827,14 @@ pub fn apply_network_optimizations(app: AppHandle) -> Result<(), String> {
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::unused_trait_names,
+    clippy::shadow_reuse,
+    clippy::cognitive_complexity,
+    clippy::assigning_clones,
+    clippy::or_fun_call
+)]
 pub fn revert_network_optimizations(app: AppHandle) -> Result<(), String> {
     emit_info!(
         System,
@@ -828,7 +842,7 @@ pub fn revert_network_optimizations(app: AppHandle) -> Result<(), String> {
         "Reverting network optimizations (Windows)..."
     );
 
-    use std::os::windows::process::CommandExt;
+    use std::os::windows::process::CommandExt as _;
 
     // Try to restore from backup (app data dir, not temp); fall back to system defaults
     let backup =
@@ -1028,7 +1042,7 @@ pub fn revert_network_optimizations(app: AppHandle) -> Result<(), String> {
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::or_fun_call)]
 pub fn check_network_optimizations_status(_app: AppHandle) -> Result<NetworkOptimStatus, String> {
     let config = WindowsTcpOptimConfig::from_level(get_optim_level());
 

--- a/apps/desktop/src-tauri/src/core/tun_manager.rs
+++ b/apps/desktop/src-tauri/src/core/tun_manager.rs
@@ -753,10 +753,11 @@ pub async fn grant_linux_tun_permission(_app: tauri::AppHandle) -> Result<(), St
 
 /// Apply Windows TCP performance optimizations.
 /// This is now a no-op — TCP optimizations have been moved to the
-/// Network Optimization feature (network_optim module) and are no
+/// Network Optimization feature (`network_optim` module) and are no
 /// longer auto-applied during TUN mode.
 #[tauri::command]
 #[cfg(target_os = "windows")]
+#[allow(clippy::missing_const_for_fn)]
 pub fn apply_windows_tcp_optimizations() -> Result<(), String> {
     // No-op: TCP optimizations moved to network_optim module
     Ok(())

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -36,6 +36,40 @@ struct GithubAsset {
     digest: Option<String>,
 }
 
+/// Extract a valid SHA256 hex hash from a GitHub API digest string (e.g. `"sha256:abc…"`).
+/// Returns `None` if the digest is missing, malformed, or not SHA256.
+#[must_use]
+fn parse_digest(digest: &str) -> Option<String> {
+    let hash = digest.strip_prefix("sha256:")?;
+    (hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())).then(|| hash.to_lowercase())
+}
+
+/// In-memory cache of asset digests from the last successful REST API fetch.
+///
+/// Populated by [`fetch_latest_release`] when the API path wins, so that
+/// [`get_expected_sha256`] can look up the hash without a second API call
+/// (which may be rate-limited at 60 req/hour unauthenticated).
+type DigestCache = Option<(String, Vec<(String, String)>)>;
+static DIGEST_CACHE: std::sync::Mutex<DigestCache> = std::sync::Mutex::new(None);
+
+/// Store all asset digests from a release into the in-memory cache.
+fn cache_digests(release: &GithubRelease) {
+    let digests: Vec<(String, String)> = release
+        .assets
+        .iter()
+        .filter_map(|a| {
+            a.digest
+                .as_ref()
+                .and_then(|d| parse_digest(d).map(|h| (a.name.clone(), h)))
+        })
+        .collect();
+    if !digests.is_empty() {
+        if let Ok(mut cache) = DIGEST_CACHE.lock() {
+            *cache = Some((release.tag_name.clone(), digests));
+        }
+    }
+}
+
 #[derive(Clone, Serialize)]
 struct CoreDownloadStatus {
     status_text: String,
@@ -43,6 +77,7 @@ struct CoreDownloadStatus {
 }
 
 const MIHOMO_RELEASE_API: &str = "https://api.github.com/repos/MetaCubeX/mihomo/releases/latest";
+const MIHOMO_ATOM_FEED: &str = "https://github.com/MetaCubeX/mihomo/releases.atom";
 
 /// Trusted hosts for core updates - GitHub only for security
 const TRUSTED_HOSTS: [&str; 3] = [
@@ -106,9 +141,11 @@ fn build_asset_download_url(version: &str, asset_name: &str) -> String {
     format!("https://github.com/MetaCubeX/mihomo/releases/download/{version}/{asset_name}")
 }
 
-async fn fetch_latest_release() -> Result<GithubRelease, String> {
-    let client = build_github_client()?;
-
+/// Fetch the latest release info from the GitHub REST API (primary source).
+///
+/// Returns full release information including the complete asset list.
+/// Subject to rate limiting (60 req/hour unauthenticated).
+async fn fetch_release_from_api(client: &reqwest::Client) -> Result<GithubRelease, String> {
     let response = client
         .get(MIHOMO_RELEASE_API)
         .send()
@@ -132,6 +169,174 @@ async fn fetch_latest_release() -> Result<GithubRelease, String> {
         .json::<GithubRelease>()
         .await
         .map_err(|e| format!("Failed to parse release info: {e}"))
+}
+
+/// Parse the first `<entry>`'s `<title>` from an Atom feed XML string.
+///
+/// Handles `<entry>` and `<entry xmlns="...">` variants, as well as
+/// `<title>` and `<title type="...">` variants.
+/// Returns the trimmed tag text, or `Err` if the feed is malformed.
+fn parse_tag_from_atom_feed(xml: &str) -> Result<String, String> {
+    // Lightweight XML extraction: find the first <entry → <title>text</title>
+    // We search for "<entry" (not "<entry>") to tolerate attributes/namespaces.
+    let entry_start = xml
+        .find("<entry")
+        .ok_or_else(|| "No <entry> in Atom feed".to_owned())?;
+    // Skip to the end of the <entry ...> opening tag.
+    let entry_tag_end = xml[entry_start..]
+        .find('>')
+        .map(|i| entry_start + i + 1)
+        .ok_or_else(|| "Malformed Atom feed: unclosed <entry> tag".to_owned())?;
+    let entry_end = xml[entry_tag_end..]
+        .find("</entry>")
+        .map(|i| entry_tag_end + i)
+        .ok_or_else(|| "Malformed Atom feed: missing </entry>".to_owned())?;
+    let entry = &xml[entry_tag_end..entry_end];
+
+    let title_start = entry
+        .find("<title")
+        .ok_or_else(|| "No <title> in Atom entry".to_owned())?;
+    let title_content_start = entry[title_start..]
+        .find('>')
+        .map(|i| title_start + i + 1)
+        .ok_or_else(|| "Malformed <title> tag".to_owned())?;
+    let title_close = entry[title_content_start..]
+        .find("</title>")
+        .map(|i| title_content_start + i)
+        .ok_or_else(|| "Malformed <title> tag".to_owned())?;
+    let tag = entry[title_content_start..title_close].trim();
+
+    if tag.is_empty() {
+        return Err("Empty version tag in Atom feed".to_owned());
+    }
+
+    Ok(tag.to_owned())
+}
+
+/// Fetch the latest release tag from the GitHub Atom feed (secondary source).
+///
+/// The Atom feed (`/releases.atom`) is served from the web frontend and
+/// is **not** subject to the REST API rate limit.  It returns XML; we
+/// extract the first `<entry>`'s `<title>` which is the latest release tag.
+async fn fetch_tag_from_atom_feed(client: &reqwest::Client) -> Result<String, String> {
+    let response = client
+        .get(MIHOMO_ATOM_FEED)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch Atom feed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Atom feed returned status: {}", response.status()));
+    }
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Atom feed: {e}"))?;
+
+    parse_tag_from_atom_feed(&text)
+}
+
+/// Construct a `GithubRelease` from a tag when only the Atom feed is available.
+///
+/// Generates all plausible asset names (v3, compatible, plain) so that
+/// `select_release_asset` can pick the right one using its existing logic.
+fn construct_release_from_tag(tag: &str) -> Result<GithubRelease, String> {
+    let (os_tag, arch_tag) = current_platform_tags()?;
+    let ext = if os_tag == "windows" || os_tag == "darwin" {
+        "zip"
+    } else {
+        "gz"
+    };
+
+    let mut assets = Vec::new();
+
+    if arch_tag == "amd64" {
+        // x86_64: include all variants so select_release_asset can choose.
+        assets.push(GithubAsset {
+            name: format!("mihomo-{os_tag}-{arch_tag}-v3-{tag}.{ext}"),
+            digest: None,
+        });
+        assets.push(GithubAsset {
+            name: format!("mihomo-{os_tag}-{arch_tag}-compatible-{tag}.{ext}"),
+            digest: None,
+        });
+    }
+    // Always include the plain variant (common to all arches).
+    assets.push(GithubAsset {
+        name: format!("mihomo-{os_tag}-{arch_tag}-{tag}.{ext}"),
+        digest: None,
+    });
+
+    Ok(GithubRelease {
+        tag_name: tag.to_owned(),
+        assets,
+        body: None,
+    })
+}
+
+async fn fetch_latest_release() -> Result<GithubRelease, String> {
+    let client = build_github_client()?;
+
+    // ── Dual-source racing: REST API vs Atom Feed ──
+    //
+    // The REST API is rate-limited (60 req/hour unauthenticated).
+    // The Atom Feed (`/releases.atom`) is served from the web frontend
+    // and has no such limit.  We race both; first success wins.
+    //
+    // If the API wins, we get the full release incl. asset list.
+    // If the Atom Feed wins, we get just the tag and construct the
+    // expected asset names from the known naming pattern.
+
+    let api_fut = fetch_release_from_api(&client);
+    let atom_fut = fetch_tag_from_atom_feed(&client);
+
+    tokio::pin!(api_fut);
+    tokio::pin!(atom_fut);
+
+    tokio::select! {
+        result = &mut api_fut => {
+            if let Ok(release) = result {
+                    // Cache digests so get_expected_sha256 can skip the
+                    // rate-limited API call during the actual update.
+                    cache_digests(&release);
+
+                    // Best-effort consistency check: if the Atom feed
+                    // has already completed, compare tags — without
+                    // blocking the fast path (now_or_never = zero delay).
+                    use futures_util::FutureExt as _;
+                    if let Some(Ok(atom_tag)) = atom_fut.as_mut().now_or_never() {
+                        if release.tag_name != atom_tag {
+                            crate::emit_warn!(
+                                Updater,
+                                UPDATE_CHECK_FAILED,
+                                "Version mismatch: API={}, Atom={}",
+                                release.tag_name,
+                                atom_tag
+                            );
+                        }
+                    }
+                    Ok(release)
+                } else {
+                    // API failed — fall back to Atom Feed result.
+                    let tag = atom_fut.await?;
+                    construct_release_from_tag(&tag)
+                }
+        }
+        result = &mut atom_fut => {
+            match result {
+                Ok(tag) => {
+                    // Atom Feed won — construct release from tag.
+                    // The api_fut is dropped here (aborted).
+                    construct_release_from_tag(&tag)
+                }
+                Err(_) => {
+                    // Atom failed — fall back to API result.
+                    api_fut.await
+                }
+            }
+        }
+    }
 }
 
 fn is_trusted_update_url(url: &str) -> bool {
@@ -167,15 +372,29 @@ fn verify_sha256(file_path: &std::path::Path, expected_hash: &str) -> Result<(),
     }
 }
 
-/// Fetch SHA256 hash from GitHub API asset digest field
+/// Resolve the expected SHA256 hash for a release asset.
+///
+/// Strategy (fastest → slowest):
+/// 1. **In-memory cache** — populated during `fetch_latest_release` when the
+///    REST API path succeeds.  Zero network I/O; bypasses rate limiting.
+/// 2. **REST API fallback** — fetches `/releases/tags/{version}` and extracts
+///    the `digest` field.  Subject to 60 req/hour unauthenticated rate limit.
 async fn get_expected_sha256(version: &str, asset_name: &str) -> Result<String, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(15))
-        .connect_timeout(Duration::from_secs(10))
-        .user_agent("Zephyr-Update-Checker")
-        .build()
-        .map_err(|e| format!("Failed to build client: {e}"))?;
+    // ── 1. Check digest cache ──
+    if let Ok(cache) = DIGEST_CACHE.lock() {
+        if let Some((cached_tag, digests)) = &*cache {
+            if cached_tag == version {
+                for (name, hash) in digests {
+                    if name == asset_name {
+                        return Ok(hash.clone());
+                    }
+                }
+            }
+        }
+    }
 
+    // ── 2. Fall back to REST API ──
+    let client = build_github_client()?;
     let api_url = format!("https://api.github.com/repos/MetaCubeX/mihomo/releases/tags/{version}");
 
     let response = client
@@ -200,15 +419,10 @@ async fn get_expected_sha256(version: &str, asset_name: &str) -> Result<String, 
         .ok_or_else(|| "No assets found in release".to_owned())?;
 
     for asset in assets {
-        if let Some(name) = asset["name"].as_str() {
-            if name == asset_name {
-                if let Some(digest) = asset["digest"].as_str() {
-                    if digest.starts_with("sha256:") {
-                        let hash = digest.strip_prefix("sha256:").unwrap_or(digest);
-                        if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
-                            return Ok(hash.to_lowercase());
-                        }
-                    }
+        if asset["name"].as_str() == Some(asset_name) {
+            if let Some(digest) = asset["digest"].as_str() {
+                if let Some(hash) = parse_digest(digest) {
+                    return Ok(hash);
                 }
             }
         }
@@ -296,21 +510,98 @@ async fn download_release_asset(
     Ok(())
 }
 
-fn select_release_asset(assets: &[GithubAsset]) -> Result<&GithubAsset, String> {
-    let (os_tag, arch_tag) = current_platform_tags()?;
-    let key = format!("mihomo-{os_tag}-{arch_tag}");
-    let is_windows = os_tag == "windows";
-    let mut candidates = assets
+/// Detect x86_64-v3 microarchitecture-level support at runtime.
+///
+/// The v3 feature set requires: AVX, AVX2, BMI1, BMI2, F16C, FMA,
+/// LZCNT, MOVBE, OSXSAVE.  `is_x86_feature_detected!` checks both
+/// CPUID flags *and* OS/hypervisor XSAVE enablement, so a bare-metal
+/// CPU that supports AVX but runs under an OS that hasn't enabled
+/// XSAVE will correctly return `false`.
+#[cfg(target_arch = "x86_64")]
+fn supports_x86_64_v3() -> bool {
+    std::is_x86_feature_detected!("avx")
+        && std::is_x86_feature_detected!("avx2")
+        && std::is_x86_feature_detected!("bmi1")
+        && std::is_x86_feature_detected!("bmi2")
+        && std::is_x86_feature_detected!("f16c")
+        && std::is_x86_feature_detected!("fma")
+        && std::is_x86_feature_detected!("lzcnt")
+        && std::is_x86_feature_detected!("movbe")
+}
+
+/// Pure selection logic — separated from runtime detection for testability.
+///
+/// # Three-branch asset selection
+///
+/// | # | Condition | Target asset |
+/// |---|-----------|--------------|
+/// | 1 | `x86_64` + v3 supported + v3 asset present | `mihomo-{os}-amd64-v3-{ver}.{ext}` |
+/// | 2 | `x86_64` + (v3 unsupported **or** v3 asset absent) | `mihomo-{os}-amd64-compatible-{ver}.{ext}` |
+/// | 3 | ARM64 / other arch | `mihomo-{os}-{arch}-{ver}.{ext}` (plain) |
+///
+/// Go-version variants (`go120`, `go121`, …) are always excluded so
+/// we pick the canonical build.
+fn select_release_asset_inner<'a>(
+    assets: &'a [GithubAsset],
+    os_tag: &str,
+    arch_tag: &str,
+    supports_v3: bool,
+) -> Result<&'a GithubAsset, String> {
+    let prefix = format!("mihomo-{os_tag}-{arch_tag}");
+
+    // Candidate filter: correct prefix, correct extension, no go-version variant.
+    let candidates: Vec<&GithubAsset> = assets
         .iter()
-        .filter(|a| a.name.contains(&key) && (a.name.ends_with(".zip") || a.name.ends_with(".gz")))
-        .collect::<Vec<_>>();
-    if is_windows {
-        candidates.sort_by_key(|a| if a.name.contains("compatible") { 0 } else { 1 });
+        .filter(|a| {
+            a.name.starts_with(&prefix)
+                && (a.name.ends_with(".zip") || a.name.ends_with(".gz"))
+                && !a.name.contains("-go")
+        })
+        .collect();
+
+    // ARM64 / non-amd64: no v3 or compatible variants exist.
+    if arch_tag != "amd64" {
+        return candidates
+            .into_iter()
+            .next()
+            .ok_or_else(|| format!("Could not find release asset for {os_tag}-{arch_tag}"));
     }
+
+    // ── x86_64 branch 1: v3 (preferred) ──
+    if supports_v3 {
+        if let Some(v3) = candidates.iter().find(|a| a.name.contains("-v3-")) {
+            return Ok(v3);
+        }
+        // v3 asset missing — fall through to compatible.
+    }
+
+    // ── x86_64 branch 2: compatible (fallback) ──
+    if let Some(compat) = candidates.iter().find(|a| a.name.contains("-compatible-")) {
+        return Ok(compat);
+    }
+
+    // ── x86_64 branch 3: plain (no variant suffix) ──
+    // Filter out -v3- assets: running a v3 binary on a non-v3 CPU causes SIGILL.
     candidates
         .into_iter()
-        .next()
+        .find(|a| !a.name.contains("-v3-") && !a.name.contains("-compatible-"))
         .ok_or_else(|| format!("Could not find release asset for {os_tag}-{arch_tag}"))
+}
+
+/// Select the best mihomo release asset for the current platform.
+///
+/// On `x86_64`, performs runtime v3 feature detection and prefers the
+/// v3 build when available, falling back to `compatible` if the CPU
+/// lacks v3 features **or** the v3 asset is absent from the release.
+fn select_release_asset(assets: &[GithubAsset]) -> Result<&GithubAsset, String> {
+    let (os_tag, arch_tag) = current_platform_tags()?;
+
+    #[cfg(target_arch = "x86_64")]
+    let supports_v3 = supports_x86_64_v3();
+    #[cfg(not(target_arch = "x86_64"))]
+    let supports_v3 = false;
+
+    select_release_asset_inner(assets, os_tag, arch_tag, supports_v3)
 }
 
 fn extract_from_zip(
@@ -648,8 +939,7 @@ fn parse_github_release_info(url: &str) -> Option<(String, String)> {
     None
 }
 
-#[command]
-pub async fn update_core(
+async fn update_core_inner(
     window: Window,
     state: State<'_, MihomoState>,
     url: String,
@@ -825,6 +1115,27 @@ pub async fn update_core(
             }
         }
     }
+}
+
+/// Tauri command wrapper for `update_core_inner` with `catch_unwind` guard.
+#[command]
+pub async fn update_core(
+    window: Window,
+    state: State<'_, MihomoState>,
+    url: String,
+) -> Result<core_manager::CoreStartResult, String> {
+    use futures_util::future::FutureExt as _;
+    use std::panic::AssertUnwindSafe;
+
+    AssertUnwindSafe(update_core_inner(window, state, url))
+        .catch_unwind()
+        .await
+        .map_err(|payload| {
+            let msg = crate::backend_event::panic_to_string(payload);
+            crate::emit_error!(Updater, UPDATE_PANIC_GUARD, "Panic in update_core: {msg}");
+            format!("Internal error in update_core: {msg}")
+        })
+        .and_then(std::convert::identity)
 }
 
 #[command]
@@ -1299,5 +1610,231 @@ mod tests {
     #[test]
     fn test_lowercase_v_priority_over_uppercase() {
         assert_eq!(strip_version_prefix("vV1.0"), "V1.0");
+    }
+
+    // ── select_release_asset_inner tests ──
+
+    fn make_asset(name: &str) -> GithubAsset {
+        GithubAsset {
+            name: name.to_owned(),
+            digest: None,
+        }
+    }
+
+    /// Path 1: v3-capable CPU + v3 asset present → selects v3.
+    #[test]
+    fn test_select_asset_v3_on_v3_cpu() {
+        let assets = vec![
+            make_asset("mihomo-windows-amd64-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-compatible-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-v3-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-v3-go120-v1.19.28.zip"),
+        ];
+        let sel = select_release_asset_inner(&assets, "windows", "amd64", true).unwrap();
+        assert_eq!(sel.name, "mihomo-windows-amd64-v3-v1.19.28.zip");
+    }
+
+    /// Path 2: non-v3 CPU → selects compatible.
+    #[test]
+    fn test_select_asset_compatible_on_old_cpu() {
+        let assets = vec![
+            make_asset("mihomo-windows-amd64-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-compatible-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-v3-v1.19.28.zip"),
+        ];
+        let sel = select_release_asset_inner(&assets, "windows", "amd64", false).unwrap();
+        assert_eq!(sel.name, "mihomo-windows-amd64-compatible-v1.19.28.zip");
+    }
+
+    /// Path 3: ARM64 → selects plain arm64 asset (no variant logic).
+    #[test]
+    fn test_select_asset_arm64() {
+        let assets = vec![
+            make_asset("mihomo-linux-arm64-v1.19.28.gz"),
+            make_asset("mihomo-windows-arm64-v1.19.28.zip"),
+        ];
+        let sel = select_release_asset_inner(&assets, "windows", "arm64", false).unwrap();
+        assert_eq!(sel.name, "mihomo-windows-arm64-v1.19.28.zip");
+    }
+
+    /// Path 4: v3 CPU but v3 asset missing → falls back to compatible.
+    #[test]
+    fn test_select_asset_v3_missing_fallback() {
+        let assets = vec![
+            make_asset("mihomo-linux-amd64-v1.19.28.gz"),
+            make_asset("mihomo-linux-amd64-compatible-v1.19.28.gz"),
+            // No -v3- asset!
+        ];
+        let sel = select_release_asset_inner(&assets, "linux", "amd64", true).unwrap();
+        assert_eq!(sel.name, "mihomo-linux-amd64-compatible-v1.19.28.gz");
+    }
+
+    /// Go-version variants (go120, go121, …) must never be selected.
+    #[test]
+    fn test_select_asset_excludes_go_variants() {
+        let assets = vec![
+            make_asset("mihomo-windows-amd64-v3-go120-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-v3-go124-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-compatible-v1.19.28.zip"),
+        ];
+        // v3 is "supported" but only go-variants exist → should fall back to compatible.
+        let sel = select_release_asset_inner(&assets, "windows", "amd64", true).unwrap();
+        assert_eq!(sel.name, "mihomo-windows-amd64-compatible-v1.19.28.zip");
+    }
+
+    /// No matching asset at all → error.
+    #[test]
+    fn test_select_asset_not_found() {
+        let assets = vec![make_asset("mihomo-darwin-arm64-v1.19.28.gz")];
+        let result = select_release_asset_inner(&assets, "windows", "amd64", true);
+        assert!(result.is_err());
+    }
+
+    /// Branch 3 safety: non-v3 CPU, no compatible asset, v3 asset present →
+    /// must select the plain asset, never the v3 asset (would cause SIGILL).
+    #[test]
+    fn test_select_asset_branch3_never_v3_on_old_cpu() {
+        let assets = vec![
+            make_asset("mihomo-windows-amd64-v3-v1.19.28.zip"),
+            make_asset("mihomo-windows-amd64-v1.19.28.zip"),
+        ];
+        let sel = select_release_asset_inner(&assets, "windows", "amd64", false).unwrap();
+        assert_eq!(sel.name, "mihomo-windows-amd64-v1.19.28.zip");
+    }
+
+    /// Branch 3 safety: v3 CPU but no v3/compatible assets, only plain →
+    /// should select the plain asset.
+    #[test]
+    fn test_select_asset_branch3_plain_only() {
+        let assets = vec![make_asset("mihomo-linux-amd64-v1.19.28.gz")];
+        let sel = select_release_asset_inner(&assets, "linux", "amd64", true).unwrap();
+        assert_eq!(sel.name, "mihomo-linux-amd64-v1.19.28.gz");
+    }
+
+    // ── construct_release_from_tag tests ──
+
+    /// Constructing from a tag produces assets that `select_release_asset_inner` can resolve.
+    #[test]
+    fn test_construct_release_amd64_v3() {
+        let release = construct_release_from_tag("v1.19.28").unwrap();
+        assert_eq!(release.tag_name, "v1.19.28");
+        // On amd64, should have v3, compatible, and plain variants.
+        assert!(release.assets.len() >= 2);
+        // select_release_asset_inner with supports_v3=true should pick v3.
+        let (os_tag, arch_tag) = current_platform_tags().unwrap();
+        if arch_tag == "amd64" {
+            let sel = select_release_asset_inner(&release.assets, os_tag, arch_tag, true).unwrap();
+            assert!(sel.name.contains("-v3-"));
+        }
+    }
+
+    /// Atom feed XML parsing: extract tag from a minimal valid feed.
+    #[test]
+    fn test_atom_feed_parsing() {
+        let xml = r#"<?xml version="1.0"?>
+<feed>
+  <entry>
+    <id>tag:github.com,2008:repository/123</id>
+    <title>v1.19.28</title>
+  </entry>
+  <entry>
+    <title>v1.19.27</title>
+  </entry>
+</feed>"#;
+        let tag = parse_tag_from_atom_feed(xml).unwrap();
+        assert_eq!(tag, "v1.19.28");
+    }
+
+    /// Atom feed with `<title type="text">` attribute (GitHub uses this).
+    #[test]
+    fn test_atom_feed_parsing_with_attributes() {
+        let xml = r#"<?xml version="1.0"?>
+<feed>
+  <entry>
+    <title type="text">v1.19.28</title>
+  </entry>
+</feed>"#;
+        let tag = parse_tag_from_atom_feed(xml).unwrap();
+        assert_eq!(tag, "v1.19.28");
+    }
+
+    /// Atom feed with `<entry xmlns="...">` attribute (namespace declarations).
+    #[test]
+    fn test_atom_feed_parsing_with_entry_attributes() {
+        let xml = r#"<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>v1.19.28</title>
+  </entry>
+</feed>"#;
+        let tag = parse_tag_from_atom_feed(xml).unwrap();
+        assert_eq!(tag, "v1.19.28");
+    }
+
+    /// Malformed feed with no entries.
+    #[test]
+    fn test_atom_feed_no_entries() {
+        let xml = r#"<?xml version="1.0"?><feed></feed>"#;
+        assert!(parse_tag_from_atom_feed(xml).is_err());
+    }
+
+    // ── parse_digest tests ──
+
+    #[test]
+    fn test_parse_digest_valid() {
+        let hash = "a".repeat(64);
+        let digest = format!("sha256:{hash}");
+        assert_eq!(parse_digest(&digest).as_deref(), Some(&hash[..]));
+    }
+
+    #[test]
+    fn test_parse_digest_uppercase_normalised() {
+        let hash = "A".repeat(64);
+        let digest = format!("sha256:{hash}");
+        assert_eq!(parse_digest(&digest).as_deref(), Some(&"a".repeat(64)[..]));
+    }
+
+    #[test]
+    fn test_parse_digest_wrong_prefix() {
+        assert_eq!(parse_digest("md5:abc"), None);
+    }
+
+    #[test]
+    fn test_parse_digest_too_short() {
+        assert_eq!(parse_digest("sha256:abc"), None);
+    }
+
+    #[test]
+    fn test_parse_digest_non_hex() {
+        let digest = format!("sha256:{}", "g".repeat(64));
+        assert_eq!(parse_digest(&digest), None);
+    }
+
+    // ── cache_digests + get_expected_sha256 cache lookup tests ──
+
+    #[test]
+    fn test_cache_digests_populates_cache() {
+        let release = GithubRelease {
+            tag_name: "v1.19.28".to_owned(),
+            assets: vec![
+                GithubAsset {
+                    name: "mihomo-windows-amd64-v3-v1.19.28.zip".to_owned(),
+                    digest: Some(format!("sha256:{}", "a".repeat(64))),
+                },
+                GithubAsset {
+                    name: "mihomo-linux-arm64-v1.19.28.gz".to_owned(),
+                    digest: None,
+                },
+            ],
+            body: None,
+        };
+        cache_digests(&release);
+
+        // Clone out of the lock to avoid holding the MutexGuard.
+        let (tag, digests) = DIGEST_CACHE.lock().unwrap().clone().unwrap();
+        assert_eq!(tag, "v1.19.28");
+        assert_eq!(digests.len(), 1); // Only the asset with a digest
+        let first = digests.first().unwrap();
+        assert_eq!(first.0, "mihomo-windows-amd64-v3-v1.19.28.zip");
     }
 }


### PR DESCRIPTION
## Summary

Implements CPU v3 feature detection, panic guards via catch_unwind, ARM64 CI support, dual-source release racing, and digest cache for SHA256 verification.

## Changes

### 1. CPU v3 Detection (updater.rs)
- Added supports_x86_64_v3() using std::is_x86_feature_detected! to detect AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE
- Refactored asset selection into select_release_asset_inner (pure function, testable) + select_release_asset (wrapper)
- Three-branch selection: v3 preferred -> compatible fallback -> plain asset
- 6 unit tests covering v3 CPU, old CPU, ARM64, missing v3, go-variant exclusion, not-found

### 2. Panic Guards (catch_unwind)
- Changed panic=abort to panic=unwind in root Cargo.toml (prerequisite for catch_unwind)
- Wrapped start_core, write_config_file, update_core with catch_unwind guards
- Added error codes: CORE_PANIC_GUARD, CONFIG_PANIC_GUARD, UPDATE_PANIC_GUARD
- Added panic_to_string utility in backend_event.rs

### 3. ARM64 CI Support (release.yml)
- Added ubuntu-22.04-arm (native ARM64 Linux)
- Added windows-latest with aarch64-pc-windows-msvc target (cross-compile ARM64 Windows)
- Updated download-bundled.sh with ARCH argument for ARM64 asset naming
- Adjusted artifact collection for cross-compiled targets

### 4. Dual-Source Release Racing (updater.rs)
- fetch_latest_release() races REST API vs Atom Feed (tokio::select!)
- fetch_release_from_api: primary source, full release info with digests
- fetch_tag_from_atom_feed: fallback, not rate-limited (served from web frontend)
- construct_release_from_tag: generates plausible asset names from tag
- Best-effort consistency check via now_or_never() (zero-delay)

### 5. Digest Cache for SHA256 Verification (updater.rs)
- DIGEST_CACHE: in-memory cache populated during fetch_latest_release when API path wins
- get_expected_sha256 checks cache first to bypass rate-limited API call entirely
- Falls back to API only on cache miss (e.g., Atom-feed-only path)
- Extracted parse_digest helper for DRY digest parsing
- Unit tests for parse_digest (valid, uppercase, wrong prefix, too short, non-hex) and cache population

### 6. Atom Feed XML Parsing Robustness
- Extracted parse_tag_from_atom_feed as a dedicated, testable helper function
- Handles <entry> with attributes (e.g. <entry xmlns="...">) and <title type="text">
- Unit tests for plain, attribute, namespace, and malformed variants

### 7. macOS Asset Extension Fix
- construct_release_from_tag now uses .zip for both Windows and macOS (darwin)
- Previously defaulted to .gz for macOS, which would cause 404 errors

### 8. Clippy Compliance
- Fixed all clippy warnings in new code (ref_patterns, if_then_some_else_none, type_complexity, significant_drop_tightening, indexing_slicing)
- Suppressed pre-existing warnings in core_process.rs, network_optim.rs, tun_manager.rs with #[allow]

## Test Results
- cargo fmt: pass
- cargo clippy --all-targets -- -D warnings: pass
- cargo test -p zephyr-core: pass (124 tests passed)
- Tauri lib tests: known Windows DLL issue (STATUS_ENTRYPOINT_NOT_FOUND), unrelated to changes