### PR TITLE
feat(tokens): PR2 鈥?radius convergence, hardcoded color elimination, surface three-layer

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -21,11 +21,11 @@
         <div id="glow-home" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-accent/10 blur-[120px] pointer-events-none rounded-full z-0"></div>
         <div id="glow-subscriptions" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-proxies" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-connections" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-cyan-500/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-connections" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-cyan/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-rule-library" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
         <div id="glow-logs" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-settings" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
-        <div id="glow-advanced" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-blue-600/10 blur-[120px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-advanced" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-info/10 blur-[120px] pointer-events-none rounded-full z-0 hidden"></div>
 
         <!-- Sidebar -->
         <nav id="sidebar-nav" class="w-20 flex flex-col items-center py-8 rounded-lg gap-8 relative z-10 backdrop-blur-sm" aria-label="Main navigation">
@@ -82,7 +82,7 @@
                     <span class="text-xs font-semibold text-[var(--text-secondary)] tracking-wide">Zephyr</span>
                 </div>
                 <div class="flex items-center gap-3">
-                    <button id="close-btn" class="group relative flex items-center justify-center w-3.5 h-3.5 rounded-full bg-[#ff5f57] hover:bg-[#ff5f57]/80 transition-colors shadow-sm before:absolute before:-inset-1.5 before:content-['']" aria-label="Close window">
+                    <button id="close-btn" class="group relative flex items-center justify-center w-3.5 h-3.5 rounded-full bg-close-btn hover:bg-close-btn/80 transition-colors shadow-sm before:absolute before:-inset-1.5 before:content-['']" aria-label="Close window">
                         <svg class="opacity-0 group-hover:opacity-100 w-2 h-2 text-black/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
                             <line x1="18" y1="6" x2="6" y2="18"></line>
                             <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -161,7 +161,7 @@
                     <!-- Proxy Mode Selector -->
                     <div class="glass-card p-4 relative z-10 group hover:translate-y-[-2px] transition-transform duration-300">
                         <div class="flex items-center gap-3 mb-3">
-                            <div class="w-8 h-8 rounded-md bg-blue-500/10 border border-blue-500/20 flex items-center justify-center text-blue-400">
+                            <div class="w-8 h-8 rounded-md bg-info/10 border border-info/20 flex items-center justify-center text-info">
                                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
                             </div>
                             <h3 class="text-xs font-bold text-[var(--text-primary)] tracking-tight" data-i18n="mode">Proxy Mode</h3>
@@ -178,7 +178,7 @@
                     <div class="glass-card p-4 flex flex-col justify-between relative z-10 group hover:translate-y-[-2px] transition-transform duration-300">
                         <div class="flex items-center justify-between">
                             <div class="flex items-center gap-3">
-                                <div class="w-8 h-8 rounded-md bg-rose-500/10 border border-rose-500/20 flex items-center justify-center text-rose-400">
+                                <div class="w-8 h-8 rounded-md bg-danger/10 border border-danger/20 flex items-center justify-center text-danger">
                                     <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
                                 </div>
                                 <h3 class="text-xs font-bold text-[var(--text-primary)] tracking-tight" data-i18n="tunMode">TUN Mode</h3>
@@ -205,11 +205,11 @@
                         <!-- Legend -->
                         <div class="flex items-center gap-4">
                             <div class="flex items-center gap-1.5">
-                                <div class="w-2 h-2 rounded-sm bg-purple-500/80"></div>
+                                <div class="w-2 h-2 rounded-sm bg-download/80"></div>
                                 <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="downstream">Down</span>
                             </div>
                             <div class="flex items-center gap-1.5">
-                                <div class="w-2 h-2 rounded-sm bg-blue-500/80"></div>
+                                <div class="w-2 h-2 rounded-sm bg-upload/80"></div>
                                 <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="upstream">Up</span>
                             </div>
                         </div>
@@ -361,7 +361,7 @@
                     </div>
                 </header>
                 <!-- Group Explanation Bar: shown when uiGroup differs from effectiveGroup -->
-                <div id="group-explanation-bar" class="hidden items-center gap-2 px-4 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 relative z-10 shrink-0" data-flex-class="flex"></div>
+                <div id="group-explanation-bar" class="hidden items-center gap-2 px-4 py-2 rounded-lg bg-warning/10 border border-warning/20 relative z-10 shrink-0" data-flex-class="flex"></div>
                 <!-- Container added p-4 to prevent 3D scale clipping -->
                 <div id="proxies-list" role="listbox" aria-label="Proxy Nodes" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 overflow-y-auto p-4 -mx-4 -mt-4 -mb-8 custom-scrollbar relative z-10">
                     <!-- Cards will be injected here -->
@@ -470,11 +470,11 @@
                                     </div>
                                 </div>
                                 <div class="flex items-center gap-2">
-                                    <div data-theme="purple" class="w-6 h-6 rounded-full bg-[#AF52DE] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
-                                    <div data-theme="blue" class="w-6 h-6 rounded-full bg-[#007AFF] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
-                                    <div data-theme="green" class="w-6 h-6 rounded-full bg-[#34C759] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
-                                    <div data-theme="orange" class="w-6 h-6 rounded-full bg-[#FF9500] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
-                                    <div data-theme="pink" class="w-6 h-6 rounded-full bg-[#FF2D55] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
+                                    <div data-theme="purple" class="w-6 h-6 rounded-full bg-[var(--zephyr-color-purple-500)] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
+                                    <div data-theme="blue" class="w-6 h-6 rounded-full bg-[var(--zephyr-color-blue-500)] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
+                                    <div data-theme="green" class="w-6 h-6 rounded-full bg-[var(--zephyr-color-green-500)] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
+                                    <div data-theme="orange" class="w-6 h-6 rounded-full bg-[var(--zephyr-color-orange-500)] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
+                                    <div data-theme="pink" class="w-6 h-6 rounded-full bg-[var(--zephyr-color-pink-500)] cursor-pointer ring-2 ring-transparent hover:ring-[var(--zephyr-border-strong)] transition-[transform,box-shadow] border-2 border-[var(--zephyr-bg-elevated)] shadow-lg active:scale-90"></div>
                                     <div class="relative group">
                                         <input type="color" id="custom-theme-color" class="opacity-0 absolute inset-0 w-6 h-6 cursor-pointer z-10">
                                         <div class="w-6 h-6 rounded-full bg-gradient-to-tr from-purple-500 via-blue-500 to-pink-500 border-2 border-[var(--zephyr-bg-elevated)] shadow-lg group-hover:ring-2 ring-[var(--zephyr-border-strong)] transition-[box-shadow]"></div>
@@ -1233,14 +1233,14 @@
                             </div>
 
                             <!-- Danger Zone: Restore Defaults -->
-                            <div class="border-t mt-6 pt-4" style="border-color: rgba(239, 68, 68, 0.2);">
+                            <div class="border-t mt-6 pt-4" style="border-color: color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent);">
                                 <button type="button" id="btn-restore-defaults" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-left">
                                     <div class="flex items-center gap-4">
-                                        <div class="w-10 h-10 rounded-md bg-red-500/10 border border-red-500/20 flex items-center justify-center text-red-500 group-hover:bg-red-500/20 transition-colors">
+                                        <div class="w-10 h-10 rounded-md bg-danger/10 border border-danger/20 flex items-center justify-center text-danger group-hover:bg-danger/20 transition-colors">
                                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
                                         </div>
                                         <div>
-                                            <p class="text-sm font-semibold text-red-500 group-hover:text-red-400 transition-colors" data-i18n="restoreDefaults">Restore Defaults</p>
+                                            <p class="text-sm font-semibold text-danger group-hover:text-danger transition-colors" data-i18n="restoreDefaults">Restore Defaults</p>
                                             <p class="text-2xs text-[var(--text-muted)]" data-i18n="restoreDefaultsDesc">Reset all settings to default values</p>
                                         </div>
                                     </div>
@@ -1384,7 +1384,7 @@
             <div class="flex items-center justify-between px-6 py-4 border-b shrink-0" style="border-color: var(--border-primary, rgba(255,255,255,0.1));">
                 <div class="flex items-center gap-3">
                     <h3 id="fullscreen-editor-title" class="text-lg font-medium" data-i18n="overrideEditScript">编辑脚本</h3>
-                    <span id="fullscreen-editor-type-badge" class="text-2xs px-2 py-0.5 rounded-sm bg-blue-500/20 text-blue-400">JS</span>
+                    <span id="fullscreen-editor-type-badge" class="text-2xs px-2 py-0.5 rounded-sm bg-info/20 text-info">JS</span>
                 </div>
                 <div class="flex items-center gap-2">
                     <button id="fullscreen-editor-validate-btn" class="btn-ghost text-sm">

--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -105,15 +105,15 @@ const PAGE_HTML = `
         <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="totalConn">Total</span>
     </div>
     <div class="flex flex-col items-center justify-center">
-        <span id="stat-dl-total" class="text-lg font-semibold text-purple-400 tabular-nums">0 B</span>
+        <span id="stat-dl-total" class="text-lg font-semibold text-download tabular-nums">0 B</span>
         <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="dlTotal">↓ Total</span>
     </div>
     <div class="flex flex-col items-center justify-center">
-        <span id="stat-ul-total" class="text-lg font-semibold text-blue-400 tabular-nums">0 B</span>
+        <span id="stat-ul-total" class="text-lg font-semibold text-upload tabular-nums">0 B</span>
         <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="ulTotal">↑ Total</span>
     </div>
     <div class="flex flex-col items-center justify-center">
-        <span id="stat-active" class="text-lg font-semibold text-emerald-400 tabular-nums">0</span>
+        <span id="stat-active" class="text-lg font-semibold text-success tabular-nums">0</span>
         <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="activeConn">Active</span>
     </div>
 </div>
@@ -134,10 +134,10 @@ const PAGE_HTML = `
             <div style="padding-left:0.25rem; font-size:9px; font-weight:700; color:#71717a; text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable" data-sort="host" data-i18n="hostCol">Host</div>
             <div style="font-size:9px; font-weight:700; color:#71717a; text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable" data-sort="rule" data-i18n="ruleCol">Rule</div>
             <div style="text-align:right; padding-right:0.5rem; font-size:9px; font-weight:700; color:#71717a; text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable" data-sort="chains" data-i18n="chainsCol">Chains</div>
-            <div style="text-align:right; padding-right:0.25rem; font-size:9px; font-weight:700; color:rgba(168,85,247,0.7); text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable hover:text-purple-400 transition-colors" data-sort="dlSpeed" data-i18n="dlSpeedCol">↓ Speed</div>
-            <div style="text-align:right; padding-right:0.25rem; font-size:9px; font-weight:700; color:rgba(168,85,247,0.5); text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable hover:text-purple-300 transition-colors" data-sort="dlTotal" data-i18n="dlTotalCol">↓ Total</div>
-            <div style="text-align:right; padding-right:0.25rem; font-size:9px; font-weight:700; color:rgba(59,130,246,0.7); text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable hover:text-blue-400 transition-colors" data-sort="ulSpeed" data-i18n="ulSpeedCol">↑ Speed</div>
-            <div style="text-align:right; padding-right:0.5rem; font-size:9px; font-weight:700; color:rgba(59,130,246,0.5); text-transform:uppercase; letter-spacing:0.1em; cursor:pointer;" class="sortable hover:text-blue-300 transition-colors" data-sort="ulTotal" data-i18n="ulTotalCol">↑ Total</div>
+            <div class="sortable text-right pr-1 text-[9px] font-bold text-download uppercase tracking-widest cursor-pointer hover:text-download transition-colors" data-sort="dlSpeed" data-i18n="dlSpeedCol">↓ Speed</div>
+            <div class="sortable text-right pr-1 text-[9px] font-bold text-download/50 uppercase tracking-widest cursor-pointer hover:text-download/70 transition-colors" data-sort="dlTotal" data-i18n="dlTotalCol">↓ Total</div>
+            <div class="sortable text-right pr-1 text-[9px] font-bold text-upload uppercase tracking-widest cursor-pointer hover:text-upload transition-colors" data-sort="ulSpeed" data-i18n="ulSpeedCol">↑ Speed</div>
+            <div class="sortable text-right pr-2 text-[9px] font-bold text-upload/50 uppercase tracking-widest cursor-pointer hover:text-upload/70 transition-colors" data-sort="ulTotal" data-i18n="ulTotalCol">↑ Total</div>
         </div>
     </div>
     <!-- List Body -->
@@ -595,11 +595,13 @@ function updateSortIndicators() {
     for (const cell of header.querySelectorAll('.sortable')) {
         const sortKey = /** @type {HTMLElement} */ (cell).dataset.sort;
 
-        // Each column's original color (matches the inline style in PAGE_HTML)
+        // Each column's original color (matches the utility classes in PAGE_HTML)
         const originalColors = {
             host:   '#71717a', rule: '#71717a', chains: '#71717a',
-            dlSpeed: 'rgba(168,85,247,0.7)', dlTotal: 'rgba(168,85,247,0.5)',
-            ulSpeed: 'rgba(59,130,246,0.7)',  ulTotal: 'rgba(59,130,246,0.5)',
+            dlSpeed: 'var(--zephyr-color-download)',
+            dlTotal: 'color-mix(in srgb, var(--zephyr-color-download) 50%, transparent)',
+            ulSpeed: 'var(--zephyr-color-upload)',
+            ulTotal: 'color-mix(in srgb, var(--zephyr-color-upload) 50%, transparent)',
         };
         const origColor = (/** @type {Record<string, string>} */ (originalColors))[/** @type {string} */ (sortKey)] || '';
 
@@ -760,8 +762,8 @@ function buildConnectionRow(conn, mode) {
 /** @param {string} rule */
 function getRuleColorClass(rule) {
     const r = (rule ?? '').toLowerCase();
-    if (r.includes('direct') || r === 'direct') return 'bg-emerald-500/15 text-emerald-400';
-    if (r.includes('reject') || r === 'reject') return 'bg-rose-500/15 text-rose-400';
+    if (r.includes('direct') || r === 'direct') return 'bg-success/15 text-success';
+    if (r.includes('reject') || r === 'reject') return 'bg-danger/15 text-danger';
     if (r.includes('match')) return 'bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]';
     return 'bg-accent/15 text-accent';
 }
@@ -812,7 +814,7 @@ function showConnDetail(conn, mode) {
 
     // Build close button HTML (only for active connections)
     const closeBtnHtml = mode === 'active'
-        ? `<button id="detail-close-btn" class="mt-6 w-full flex items-center justify-center gap-2 px-4 py-3 rounded-sm bg-rose-500/10 border border-rose-500/20 text-2xs font-bold text-rose-400 hover:bg-rose-500/20 transition-colors uppercase tracking-wider">
+        ? `<button id="detail-close-btn" class="mt-6 w-full flex items-center justify-center gap-2 px-4 py-3 rounded-sm bg-danger/10 border border-danger/20 text-2xs font-bold text-danger hover:bg-danger/20 transition-colors uppercase tracking-wider">
              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
              <span>${t.closeConn || 'Close Connection'}</span>
            </button>`
@@ -841,10 +843,10 @@ function showConnDetail(conn, mode) {
         <div class="grid grid-cols-2 gap-3 mb-5">
             <div class="bg-[var(--zephyr-bg-muted)] rounded-lg p-3 border border-[var(--zephyr-border-subtle)]">
                 <div class="flex items-center justify-between mb-1.5">
-                    <span class="text-2xs text-purple-500/70 dark:text-purple-400/70 font-medium uppercase tracking-wider">${t.dlSpeedLabel || 'Download Speed'}</span>
+                    <span class="text-2xs text-download/70 font-medium uppercase tracking-wider">${t.dlSpeedLabel || 'Download Speed'}</span>
                     <span class="text-[8px] text-[var(--text-secondary)]">${t.totalLabel || 'Total'}</span>
                 </div>
-                <span class="text-sm font-semibold text-purple-500 dark:text-purple-400 tabular-nums block" id="detail-dl-speed">${dlSpeed}</span>
+                <span class="text-sm font-semibold text-download tabular-nums block" id="detail-dl-speed">${dlSpeed}</span>
                 <div class="flex items-center justify-between mt-1.5 pt-1.5 border-t border-[var(--zephyr-border-subtle)]">
                     <span class="text-[8px] text-[var(--text-secondary)]">${t.totalLabel || 'Total'}</span>
                     <span class="text-2xs text-[var(--text-muted)] tabular-nums" id="detail-dl-total">${dlTotal}</span>
@@ -852,10 +854,10 @@ function showConnDetail(conn, mode) {
             </div>
             <div class="bg-[var(--zephyr-bg-muted)] rounded-lg p-3 border border-[var(--zephyr-border-subtle)]">
                 <div class="flex items-center justify-between mb-1.5">
-                    <span class="text-2xs text-blue-500/70 dark:text-blue-400/70 font-medium uppercase tracking-wider">${t.ulSpeedLabel || 'Upload Speed'}</span>
+                    <span class="text-2xs text-upload/70 font-medium uppercase tracking-wider">${t.ulSpeedLabel || 'Upload Speed'}</span>
                     <span class="text-[8px] text-[var(--text-secondary)]">${t.totalLabel || 'Total'}</span>
                 </div>
-                <span class="text-sm font-semibold text-blue-500 dark:text-blue-400 tabular-nums block" id="detail-ul-speed">${ulSpeed}</span>
+                <span class="text-sm font-semibold text-upload tabular-nums block" id="detail-ul-speed">${ulSpeed}</span>
                 <div class="flex items-center justify-between mt-1.5 pt-1.5 border-t border-[var(--zephyr-border-subtle)]">
                     <span class="text-[8px] text-[var(--text-secondary)]">${t.totalLabel || 'Total'}</span>
                     <span class="text-2xs text-[var(--text-muted)] tabular-nums" id="detail-ul-total">${ulTotal}</span>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -22,21 +22,21 @@
   --color-accent: var(--accent-primary);
   --color-accent-glow: var(--accent-glow);
   --color-accent-rgb: var(--accent-rgb);
-  --radius-sm: var(--zephyr-radius-sm);
-  --radius-md: var(--zephyr-radius-md);
-  --radius-lg: var(--zephyr-radius-lg);
+  --radius-sm: var(--zephyr-radius-control);
+  --radius-md: var(--zephyr-radius-surface);
+  --radius-lg: var(--zephyr-radius-overlay);
   --radius-full: var(--zephyr-radius-full);
   --radius-dropdown-option: var(--zephyr-radius-dropdown-option);
-  --radius-button: var(--zephyr-radius-lg);
-  --radius-input: var(--zephyr-radius-md);
-  --radius-card: var(--zephyr-radius-lg);
-  --radius-panel: var(--zephyr-radius-lg);
-  --radius-modal: var(--zephyr-radius-lg);
-  --radius-nav: var(--zephyr-radius-md);
-  --radius-badge: var(--zephyr-radius-sm);
-  --radius-dropdown: var(--zephyr-radius-lg);
-  --radius-option: var(--zephyr-radius-dropdown-option);
-  --radius-switch: var(--zephyr-radius-full);
+  --radius-button: var(--zephyr-button-radius);
+  --radius-input: var(--zephyr-input-radius);
+  --radius-card: var(--zephyr-card-radius);
+  --radius-panel: var(--zephyr-panel-radius);
+  --radius-modal: var(--zephyr-modal-radius);
+  --radius-nav: var(--zephyr-radius-surface);
+  --radius-badge: var(--zephyr-badge-radius);
+  --radius-dropdown: var(--zephyr-dropdown-radius);
+  --radius-option: var(--zephyr-dropdown-item-radius);
+  --radius-switch: var(--zephyr-switch-radius);
 }
 
 /* Thin scrollbar - visible on hover */

--- a/apps/desktop/src/ui/advanced.js
+++ b/apps/desktop/src/ui/advanced.js
@@ -257,7 +257,7 @@ export async function renderAdvancedSettings() {
         advancedLogger.error('Advanced settings render error', err);
         container.innerHTML = '';
         const errDiv = document.createElement('div');
-        errDiv.className = 'p-8 text-center text-rose-400 text-xs font-bold';
+        errDiv.className = 'p-8 text-center text-danger text-xs font-bold';
         errDiv.textContent = toError(err).message;
         container.appendChild(errDiv);
     }

--- a/apps/desktop/src/ui/global-shortcut.js
+++ b/apps/desktop/src/ui/global-shortcut.js
@@ -454,7 +454,7 @@ function addShortcutRow(t, actionId, existingAccelerator) {
 
     // --- Clear/delete button ---
     const clearBtn = document.createElement('button');
-    clearBtn.className = 'text-[var(--text-muted)] hover:text-rose-400 transition-colors p-1';
+    clearBtn.className = 'text-[var(--text-muted)] hover:text-danger transition-colors p-1';
     clearBtn.title = t.delete || 'Delete';
     clearBtn.innerHTML = '<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>';
     clearBtn.addEventListener('click', async () => {

--- a/apps/desktop/src/ui/network-optim.js
+++ b/apps/desktop/src/ui/network-optim.js
@@ -62,7 +62,7 @@ function updateUI() {
     btn.classList.remove('opacity-50');
 
     if (isApplied) {
-        dot.className = 'w-2 h-2 rounded-full bg-green-500 transition-colors';
+        dot.className = 'w-2 h-2 rounded-full bg-success transition-colors';
         const span = document.createElement('span');
         span.setAttribute('data-i18n', 'networkOptimRevert');
         span.textContent = t('networkOptimRevert');
@@ -124,7 +124,7 @@ async function showApplyModal() {
             wrapper.appendChild(changesBox);
 
             const infoBox = document.createElement('div');
-            infoBox.className = 'bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-400';
+            infoBox.className = 'bg-info/10 border border-info/20 rounded-lg p-3 text-xs text-info';
             infoBox.textContent = t('networkOptimModalInfo');
             wrapper.appendChild(infoBox);
 

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -172,7 +172,7 @@ async function populateAndShowWheel(trigger, dropdown, scrollContainer, list, up
             const dot = document.createElement('div');
             let dotColor;
             if (isSelected) dotColor = 'bg-accent animate-pulse';
-            else if (proxy.udp) dotColor = 'bg-green-500';
+            else if (proxy.udp) dotColor = 'bg-success';
             else dotColor = 'bg-[var(--text-tertiary)]';
             dot.className = `w-1.5 h-1.5 rounded-full ${dotColor}`;
 

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -47,9 +47,9 @@ export function showNotification(message, type = 'info', title = null) {
 
     const colors = {
         info: 'border-accent text-accent',
-        success: 'border-emerald-500 text-emerald-400',
-        error: 'border-rose-500 text-rose-400',
-        warning: 'border-amber-500 text-amber-400',
+        success: 'border-success text-success',
+        error: 'border-danger text-danger',
+        warning: 'border-warning text-warning',
     };
     notif.className += ` ${colors[type] || colors.info}`;
     notif.dataset.priority = String(NOTIFICATION_PRIORITY[type] ?? 2);
@@ -249,7 +249,7 @@ export function showConfirmModal(title, message = '') {
          
         contentArea.innerHTML = '';
         const msgDiv = document.createElement('div');
-        msgDiv.className = 'rounded-lg border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
+        msgDiv.className = 'rounded-lg border border-warning/20 bg-warning/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
         msgDiv.textContent = message;
         contentArea.appendChild(msgDiv);
 

--- a/apps/desktop/src/ui/plugins-smart.js
+++ b/apps/desktop/src/ui/plugins-smart.js
@@ -118,7 +118,7 @@ async function renderPluginsList(plugins) {
         <div class="glass-card p-4">
             <div class="flex items-center justify-between">
                 <div class="flex items-center gap-4">
-                    <div class="w-10 h-10 rounded-md ${isLoaded ? 'bg-green-500/10 border-green-500/20 text-green-400' : 'bg-[var(--zephyr-bg-muted)] border-[var(--zephyr-border-subtle)] text-[var(--text-muted)]'} border flex items-center justify-center">
+                    <div class="w-10 h-10 rounded-md ${isLoaded ? 'bg-success/10 border-success/20 text-success' : 'bg-[var(--zephyr-bg-muted)] border-[var(--zephyr-border-subtle)] text-[var(--text-muted)]'} border flex items-center justify-center">
                         <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
                     </div>
                     <div>
@@ -133,7 +133,7 @@ async function renderPluginsList(plugins) {
                     <button class="p-action-btn btn-ghost text-2xs" data-id="${esc(id)}" data-action="execute" title="Run entry script">
                         Run
                     </button>
-                    <button class="p-action-btn btn-ghost text-2xs text-red-400" data-id="${esc(id)}" data-action="delete">Delete</button>
+                    <button class="p-action-btn btn-ghost text-2xs text-danger" data-id="${esc(id)}" data-action="delete">Delete</button>
                 </div>
             </div>
         </div>`;
@@ -186,7 +186,7 @@ async function loadHooksList() {
             <div class="flex items-center justify-between py-1 px-2 rounded-md hover:bg-[var(--zephyr-bg-muted)]">
                 <span class="text-xs text-[var(--text-secondary)]">${esc(h.name)}</span>
                 <div class="flex items-center gap-2">
-                    ${h.isHighFrequency ? '<span class="text-2xs text-yellow-500">high-freq</span>' : ''}
+                    ${h.isHighFrequency ? '<span class="text-2xs text-warning">high-freq</span>' : ''}
                     <button class="hook-trigger-btn btn-ghost text-2xs" data-hook="${esc(h.name)}">Trigger</button>
                 </div>
             </div>
@@ -206,7 +206,7 @@ async function loadHooksList() {
         });
     } catch (e) {
         // eslint-disable-next-line no-unsanitized/property -- values escaped via esc()
-    container.innerHTML = `<div class="text-red-400 text-xs text-center py-2">${esc(String(e))}</div>`;
+    container.innerHTML = `<div class="text-danger text-xs text-center py-2">${esc(String(e))}</div>`;
     }
 }
 
@@ -230,14 +230,14 @@ async function loadPermissionsList() {
                     <span class="text-2xs text-[var(--text-muted)] ml-2">${esc(p.displayName)}</span>
                 </div>
                 <div class="flex gap-2">
-                    ${p.allowedForConfigPlugin ? '<span class="text-2xs text-blue-400">config</span>' : ''}
-                    ${p.allowedForUiExtension ? '<span class="text-2xs text-green-400">ui</span>' : ''}
+                    ${p.allowedForConfigPlugin ? '<span class="text-2xs text-info">config</span>' : ''}
+                    ${p.allowedForUiExtension ? '<span class="text-2xs text-success">ui</span>' : ''}
                 </div>
             </div>
         `).join('');
     } catch (e) {
         // eslint-disable-next-line no-unsanitized/property -- values escaped via esc()
-    container.innerHTML = `<div class="text-red-400 text-xs text-center py-2">${esc(String(e))}</div>`;
+    container.innerHTML = `<div class="text-danger text-xs text-center py-2">${esc(String(e))}</div>`;
     }
 }
 
@@ -266,8 +266,8 @@ async function loadKvStore() {
                     <span class="text-2xs text-[var(--text-tertiary)] ml-2 truncate">${esc(JSON.stringify(e.value)?.slice(0, 60) || 'null')}</span>
                 </div>
                 <div class="flex items-center gap-1 ml-2">
-                    <button class="kv-edit-btn text-2xs text-blue-400 hover:text-blue-300" data-key="${esc(e.key)}">edit</button>
-                    <button class="kv-delete-key-btn text-2xs text-red-400 hover:text-red-300" data-key="${esc(e.key)}">✕</button>
+                    <button class="kv-edit-btn text-2xs text-info hover:text-info/70" data-key="${esc(e.key)}">edit</button>
+                    <button class="kv-delete-key-btn text-2xs text-danger hover:text-danger/70" data-key="${esc(e.key)}">✕</button>
                 </div>
             </div>
         `).join('');
@@ -303,7 +303,7 @@ async function loadKvStore() {
         });
     } catch (e) {
         // eslint-disable-next-line no-unsanitized/property -- values escaped via esc()
-    container.innerHTML = `<div class="text-red-400 text-xs text-center py-2">${esc(String(e))}</div>`;
+    container.innerHTML = `<div class="text-danger text-xs text-center py-2">${esc(String(e))}</div>`;
     }
 }
 
@@ -399,7 +399,7 @@ async function loadSandboxConfig() {
         const indicator = document.getElementById('sandbox-safe-indicator');
         if (indicator) {
             indicator.textContent = safe ? '● Safe' : '● Unsafe';
-            indicator.className = `text-xs ${safe ? 'text-green-400' : 'text-red-400'}`;
+            indicator.className = `text-xs ${safe ? 'text-success' : 'text-danger'}`;
         }
     } catch {}
 }
@@ -598,7 +598,7 @@ async function loadSmartRankings() {
     container.innerHTML = rankings.map((r, i) => {
             const score = typeof r.score === 'number' ? r.score.toFixed(1) : '?';
             const barWidth = Math.min(100, Math.max(0, Number(r.score) || 0));
-            const barColor = barWidth >= 80 ? 'bg-green-500' : barWidth >= 50 ? 'bg-yellow-500' : 'bg-red-500';
+            const barColor = barWidth >= 80 ? 'bg-success' : barWidth >= 50 ? 'bg-warning' : 'bg-danger';
             return `
                 <div class="flex items-center gap-3 py-1">
                     <span class="text-2xs text-[var(--text-tertiary)] w-6 text-right">#${i + 1}</span>
@@ -611,7 +611,7 @@ async function loadSmartRankings() {
         }).join('');
     } catch (e) {
         // eslint-disable-next-line no-unsanitized/property -- values escaped via esc()
-    container.innerHTML = `<div class="text-red-400 text-xs text-center py-4">${esc(String(e))}</div>`;
+    container.innerHTML = `<div class="text-danger text-xs text-center py-4">${esc(String(e))}</div>`;
     }
 }
 

--- a/apps/desktop/src/ui/plugins.js
+++ b/apps/desktop/src/ui/plugins.js
@@ -203,20 +203,20 @@ export function initPlugins() {
             const result = await overrideSetContent(activeOverrideId, source, true);
             if (result.success) {
                 scriptStatus.textContent = t('overrideScriptSafe') ?? '✓ Script safe';
-                scriptStatus.className = 'text-xs text-emerald-400';
+                scriptStatus.className = 'text-xs text-success';
             } else {
                 scriptStatus.textContent = '✗ ' + (formatScriptError(result.error) ?? (t('overrideScriptUnsafe') ?? 'Script may be unsafe'));
-                scriptStatus.className = 'text-xs text-rose-400';
+                scriptStatus.className = 'text-xs text-danger';
             }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             // If core is not running, show a friendlier message instead of a hard error
             if (msg.includes('Failed to read running config') || msg.includes('No such file')) {
                 scriptStatus.textContent = t('overrideCoreNotRunning') ?? '⚠ Core not running, cannot validate';
-                scriptStatus.className = 'text-xs text-amber-400';
+                scriptStatus.className = 'text-xs text-warning';
             } else {
                 scriptStatus.textContent = '✗ ' + msg;
-                scriptStatus.className = 'text-xs text-rose-400';
+                scriptStatus.className = 'text-xs text-danger';
             }
         }
     });
@@ -266,8 +266,8 @@ export function initPlugins() {
             const outputText = lines.join('\n');
             scriptOutput.textContent = outputText;
             scriptOutput.className = result.success
-                ? 'script-output px-4 pb-3 text-emerald-400 whitespace-pre-wrap break-all custom-scrollbar'
-                : 'script-output px-4 pb-3 text-rose-400 whitespace-pre-wrap break-all custom-scrollbar';
+                ? 'script-output px-4 pb-3 text-success whitespace-pre-wrap break-all custom-scrollbar'
+                : 'script-output px-4 pb-3 text-danger whitespace-pre-wrap break-all custom-scrollbar';
             // Auto-expand collapsible output
             scriptOutput.style.display = '';
             scriptOutput.style.maxHeight = '120px';
@@ -283,7 +283,7 @@ export function initPlugins() {
             }
         } catch (err) {
             scriptOutput.textContent = err instanceof Error ? err.message : String(err);
-            scriptOutput.className = 'script-output px-4 pb-3 text-rose-400 whitespace-pre-wrap break-all custom-scrollbar';
+            scriptOutput.className = 'script-output px-4 pb-3 text-danger whitespace-pre-wrap break-all custom-scrollbar';
             scriptOutput.style.display = '';
             scriptOutput.style.maxHeight = '120px';
             scriptOutput.style.overflowY = 'auto';
@@ -498,7 +498,7 @@ function openScopeEditor(overrideId, currentGlobal, currentProfileIds) {
 
     // Fetch and render profiles
     const saveBtn = document.createElement('button');
-    saveBtn.className = 'bg-indigo-600 hover:bg-indigo-500 text-white text-xs px-4 py-1.5 rounded-sm font-medium';
+    saveBtn.className = 'bg-info hover:bg-info/80 text-white text-xs px-4 py-1.5 rounded-sm font-medium';
     saveBtn.textContent = t('confirm') ?? 'OK';
     saveBtn.disabled = true; // Disabled until profiles are loaded
 
@@ -947,8 +947,8 @@ function updateOverrideCardContent(card, item) {
         const statusColor = !item.enabled
             ? 'bg-[var(--text-tertiary)]'
             : item.lastSuccess === false
-                ? 'bg-red-400'
-                : 'bg-emerald-400';
+                ? 'bg-danger'
+                : 'bg-success';
         let summaryText;
         if (!item.enabled) {
             summaryText = t('overrideDisabled');
@@ -964,7 +964,7 @@ function updateOverrideCardContent(card, item) {
     // Update scope badge
     const scopeBadge = card.querySelector('[data-action="edit-scope"]');
     if (scopeBadge) {
-        const scopeClass = item.global ? 'bg-emerald-500/20 text-emerald-400' : 'bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]';
+        const scopeClass = item.global ? 'bg-success/20 text-success' : 'bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]';
         const scopeLabel = item.global
             ? t('overrideScopeGlobal')
             : (item.profileIds?.length
@@ -982,7 +982,7 @@ function updateOverrideCardContent(card, item) {
             statusText.className = 'text-xs text-[var(--text-muted)]';
         } else if (item.lastSuccess === false) {
             statusText.textContent = t('overrideFailed');
-            statusText.className = 'text-xs text-red-400';
+            statusText.className = 'text-xs text-danger';
         } else {
             statusText.textContent = t('overrideEnabled');
             statusText.className = 'text-xs text-[var(--text-muted)]';
@@ -998,7 +998,7 @@ function updateOverrideCardContent(card, item) {
             : t('overrideEnable');
         // eslint-disable-next-line no-unsanitized/property -- static SVG icon
         toggleBtn.innerHTML = item.enabled
-            ? `<svg class="w-3.5 h-3.5 text-emerald-400" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>`
+            ? `<svg class="w-3.5 h-3.5 text-success" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>`
             : `<svg class="w-3.5 h-3.5 text-[var(--text-muted)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></svg>`;
     }
 
@@ -1028,11 +1028,11 @@ function buildOverrideCard(item) {
 
     // ── Type badge color ───────────────────────────────────────
     const isJs = item.ext === 'js';
-    const typeColor = isJs ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400';
+    const typeColor = isJs ? 'bg-info/20 text-info' : 'bg-download/20 text-download';
     const typeLabel = isJs ? 'JS' : 'Prism';
 
     // ── Scope badge ───────────────────────────────────────────
-    const scopeClass = item.global ? 'bg-emerald-500/20 text-emerald-400' : 'bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]';
+    const scopeClass = item.global ? 'bg-success/20 text-success' : 'bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]';
     const scopeLabel = item.global
         ? t('overrideScopeGlobal')
         : (item.profileIds?.length
@@ -1043,8 +1043,8 @@ function buildOverrideCard(item) {
     const statusColor = !item.enabled
         ? 'bg-[var(--text-tertiary)]'
         : item.lastSuccess === false
-            ? 'bg-red-400'
-            : 'bg-emerald-400';
+            ? 'bg-danger'
+            : 'bg-success';
 
     // ── Status summary line ────────────────────────────────────
     let summaryText;
@@ -1054,7 +1054,7 @@ function buildOverrideCard(item) {
         summaryClass = 'text-[var(--text-muted)]';
     } else if (item.lastSuccess === false) {
         summaryText = t('overrideFailed');
-        summaryClass = 'text-red-400';
+        summaryClass = 'text-danger';
     } else {
         summaryText = t('overrideEnabled');
         summaryClass = 'text-[var(--text-muted)]';
@@ -1068,7 +1068,7 @@ function buildOverrideCard(item) {
                 <div class="flex items-center gap-2">
                     <span class="text-sm text-[var(--text-primary)] font-medium truncate">${escapeHtml(item.name ?? '')}</span>
                     <span class="text-2xs px-1.5 py-0.5 rounded-sm ${typeColor} shrink-0">${typeLabel}</span>
-                    ${item.type === 'remote' ? '<span class="text-2xs px-1.5 py-0.5 rounded-sm bg-sky-500/20 text-sky-400 shrink-0">🌐</span>' : ''}
+                    ${item.type === 'remote' ? '<span class="text-2xs px-1.5 py-0.5 rounded-sm bg-info/20 text-info shrink-0">🌐</span>' : ''}
                 </div>
                 <div class="flex items-center gap-2">
                     <span class="text-2xs px-1.5 py-0.5 rounded-sm ${scopeClass} cursor-pointer hover:opacity-80 transition-opacity" data-action="edit-scope">${escapeHtml(scopeLabel)}</span>
@@ -1079,7 +1079,7 @@ function buildOverrideCard(item) {
         <div class="flex items-center gap-2 shrink-0">
             <button class="override-toggle-btn opacity-0 group-hover:opacity-100 p-1.5 rounded-sm hover:bg-accent/10 transition-[opacity,color]" title="${item.enabled ? (escapeAttr(t('overrideDisable') || '禁用')) : (escapeAttr(t('overrideEnable') || '启用'))}" data-id="${item.id}" data-enabled="${item.enabled}">
                 ${item.enabled
-                    ? `<svg class="w-3.5 h-3.5 text-emerald-400" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>`
+                    ? `<svg class="w-3.5 h-3.5 text-success" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>`
                     : `<svg class="w-3.5 h-3.5 text-[var(--text-muted)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></svg>`
                 }
             </button>
@@ -1316,7 +1316,7 @@ function showDeleteConfirm(overrideId, overrideName) {
     cancelBtn.addEventListener('click', () => overlay.remove());
 
     const confirmBtn = document.createElement('button');
-    confirmBtn.className = 'bg-rose-600 hover:bg-rose-500 text-white text-xs px-4 py-1.5 rounded-sm font-medium';
+    confirmBtn.className = 'bg-danger hover:bg-danger/80 text-white text-xs px-4 py-1.5 rounded-sm font-medium';
     confirmBtn.textContent = t('confirm') ?? '确认';
     confirmBtn.addEventListener('click', async () => {
         confirmBtn.disabled = true;
@@ -1418,7 +1418,7 @@ function openFullscreenEditor() {
     const isJs = activeOverrideExt === 'js';
     if (typeBadge) {
         typeBadge.textContent = isJs ? 'JS' : 'Prism';
-        typeBadge.className = `text-2xs px-2 py-0.5 rounded-sm ${isJs ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400'}`;
+        typeBadge.className = `text-2xs px-2 py-0.5 rounded-sm ${isJs ? 'bg-info/20 text-info' : 'bg-download/20 text-download'}`;
     }
 
     // Create fullscreen editor
@@ -1510,18 +1510,18 @@ async function validateFullscreenEditor() {
         if (result.success) {
             if (status) {
                 status.textContent = t('overrideScriptSafe') ?? '✓ Script safe';
-                status.className = 'text-emerald-400';
+                status.className = 'text-success';
             }
         } else {
             if (status) {
                 status.textContent = '✗ ' + (formatScriptError(result.error) ?? (t('overrideScriptUnsafe') ?? 'Script may be unsafe'));
-                status.className = 'text-rose-400';
+                status.className = 'text-danger';
             }
         }
     } catch (err) {
         if (status) {
             status.textContent = '✗ ' + (err instanceof Error ? err.message : String(err));
-            status.className = 'text-rose-400';
+            status.className = 'text-danger';
         }
     }
 }
@@ -1580,14 +1580,14 @@ async function runFullscreenEditor() {
 
         if (output) {
             output.textContent = outputText;
-            output.className = `flex-1 p-4 text-sm font-mono whitespace-pre-wrap break-all overflow-y-auto custom-scrollbar ${result.success ? 'text-emerald-400' : 'text-rose-400'}`;
+            output.className = `flex-1 p-4 text-sm font-mono whitespace-pre-wrap break-all overflow-y-auto custom-scrollbar ${result.success ? 'text-success' : 'text-danger'}`;
         }
 
         if (status) {
             status.textContent = result.success
                 ? (t('overrideExecSuccess') ?? '✓ Execution successful')
                 : (t('overrideExecFailed') ?? '✗ Execution failed');
-            status.className = result.success ? 'text-emerald-400' : 'text-rose-400';
+            status.className = result.success ? 'text-success' : 'text-danger';
         }
 
         if (result.success && result.configModified) {
@@ -1597,11 +1597,11 @@ async function runFullscreenEditor() {
         const errorText = err instanceof Error ? err.message : String(err);
         if (output) {
             output.textContent = errorText;
-            output.className = 'flex-1 p-4 text-sm font-mono text-rose-400 whitespace-pre-wrap break-all overflow-y-auto custom-scrollbar';
+            output.className = 'flex-1 p-4 text-sm font-mono text-danger whitespace-pre-wrap break-all overflow-y-auto custom-scrollbar';
         }
         if (status) {
             status.textContent = `✗ ${errorText}`;
-            status.className = 'text-rose-400';
+            status.className = 'text-danger';
         }
         setTimeout(() => {
             startSmartAutoTest();

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1001,7 +1001,7 @@ function renderGroupExplanationBar(uiGroupName, effectiveGroupName, observedGrou
 
     // Info icon
     const icon = document.createElement('span');
-    icon.className = 'text-amber-400 text-sm flex-shrink-0';
+    icon.className = 'text-warning text-sm flex-shrink-0';
      
     icon.innerHTML = '&#9888;';
 
@@ -1456,8 +1456,8 @@ function buildProxyWrappers(container, proxies, data, current, mainGroup) {
         left.className = 'flex items-center gap-2';
         const dot = document.createElement('div');
         // All indicators use green color as requested
-        const dotColor = 'bg-green-500';
-        dot.className = `w-1.5 h-1.5 rounded-full shadow-[0_0_8px_rgba(34,197,94,0.4)] ${dotColor}`;
+        const dotColor = 'bg-success';
+        dot.className = `w-1.5 h-1.5 rounded-full shadow-[0_0_8px_color-mix(in_srgb,var(--zephyr-color-success)_40%,transparent)] ${dotColor}`;
         const transportText = document.createElement('span');
         transportText.className = 'text-2xs text-[var(--text-muted)] font-medium';
         transportText.textContent = transport;
@@ -1634,7 +1634,7 @@ export async function renderProxies() {
     if (!data || !data.proxies) {
         container.innerHTML = '';
         const errWrap = document.createElement('div');
-        errWrap.className = 'col-span-full text-center py-10 text-rose-400 bg-rose-400/5 rounded-lg border border-rose-400/20 flex flex-col items-center gap-4';
+        errWrap.className = 'col-span-full text-center py-10 text-danger bg-danger/5 rounded-lg border border-danger/20 flex flex-col items-center gap-4';
         const errText = document.createElement('span');
         errText.textContent = t.failedToConnect;
         errWrap.appendChild(errText);

--- a/apps/desktop/src/ui/rule-library.js
+++ b/apps/desktop/src/ui/rule-library.js
@@ -151,9 +151,9 @@ async function updateStatusBar() {
             const isError = state === 'error';
             const isCompiling = state === 'compiling';
             let dotColor;
-            if (isError) dotColor = 'bg-rose-500';
-            else if (isCompiling) dotColor = 'bg-amber-400 animate-pulse';
-            else dotColor = 'bg-emerald-400';
+            if (isError) dotColor = 'bg-danger';
+            else if (isCompiling) dotColor = 'bg-warning animate-pulse';
+            else dotColor = 'bg-success';
             let stateLabel;
             if (isError) stateLabel = t.ruleLibraryStatusError || 'Error';
             else if (isCompiling) stateLabel = t.ruleLibraryStatusCompiling || 'Compiling';
@@ -170,7 +170,7 @@ async function updateStatusBar() {
     } catch {
         // Fallback to local computation
         if (statusEl) {
-            const dot = '<span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 mr-1.5"></span>';
+            const dot = '<span class="inline-block w-1.5 h-1.5 rounded-full bg-success mr-1.5"></span>';
             // eslint-disable-next-line no-unsanitized/property -- values escaped via escapeHtml()
             statusEl.innerHTML = dot + escapeHtml(t.ruleLibraryStatusReady || 'Ready');
         }
@@ -456,7 +456,7 @@ function getSourceBadge(source) {
     const t = /** @type {Record<string, string>} */ (/** @type {any} */ (translations)[currentLang]);
     const s = (source || '').toLowerCase();
     if (s.includes('extract') || s.includes('subscription')) {
-        return { cls: 'bg-blue-500/15 text-blue-400', label: t.ruleLibraryExtracted || 'Extracted' };
+        return { cls: 'bg-info/15 text-info', label: t.ruleLibraryExtracted || 'Extracted' };
     }
     if (s.includes('import')) {
         return { cls: 'bg-accent/15 text-accent', label: t.ruleLibraryImported || 'Imported' };
@@ -631,7 +631,7 @@ function renderActiveRules(container) {
                         <span class="text-[10px] text-[var(--text-muted)]">${ruleCount} rules</span>
                     </div>
                     <div class="flex items-center gap-2">
-                        <span class="text-[10px] ${enabled ? 'text-emerald-500' : 'text-[var(--text-muted)]'}">${enabled ? '● ON' : '○ OFF'}</span>
+                        <span class="text-[10px] ${enabled ? 'text-success' : 'text-[var(--text-muted)]'}">${enabled ? '● ON' : '○ OFF'}</span>
                     </div>
                 `;
                 header.addEventListener('click', () => {
@@ -688,16 +688,15 @@ function renderActiveRules(container) {
 function getGroupBadgeColor(label) {
     // 预定义的柔和色彩方案（bg + text）
     const palette = [
-        'bg-blue-500/15 text-blue-400',
+        'bg-info/15 text-info',
         'bg-accent/15 text-accent',
-        'bg-emerald-500/15 text-emerald-400',
-        'bg-amber-500/15 text-amber-400',
-        'bg-rose-500/15 text-rose-400',
-        'bg-cyan-500/15 text-cyan-400',
-        'bg-orange-500/15 text-orange-400',
-        'bg-indigo-500/15 text-indigo-400',
-        'bg-teal-500/15 text-teal-400',
-        'bg-pink-500/15 text-pink-400',
+        'bg-success/15 text-success',
+        'bg-warning/15 text-warning',
+        'bg-danger/15 text-danger',
+        'bg-download/15 text-download',
+        'bg-orange/15 text-orange',
+        'bg-upload/15 text-upload',
+        'bg-pink/15 text-pink',
     ];
     // 简单哈希：取字符串 charCode 之和取模
     let hash = 0;
@@ -1384,28 +1383,28 @@ async function handleViewChanges(filename) {
         if (added.length > 0) {
             diffHtml += `<div class="space-y-1">
                 <div class="flex items-center gap-2 mb-1">
-                    <span class="inline-block w-2 h-2 rounded-full bg-emerald-400"></span>
-                    <span class="text-xs font-medium text-emerald-400">+${added.length} ${t.ruleLibraryDiffAdded || 'added'}</span>
+                    <span class="inline-block w-2 h-2 rounded-full bg-success"></span>
+                    <span class="text-xs font-medium text-success">+${added.length} ${t.ruleLibraryDiffAdded || 'added'}</span>
                 </div>
-                ${added.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-xs text-emerald-300 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
+                ${added.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-success/10 border border-success/20 text-xs text-success/70 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
             </div>`;
         }
         if (removed.length > 0) {
             diffHtml += `<div class="space-y-1">
                 <div class="flex items-center gap-2 mb-1">
-                    <span class="inline-block w-2 h-2 rounded-full bg-rose-400"></span>
-                    <span class="text-xs font-medium text-rose-400">-${removed.length} ${t.ruleLibraryDiffRemoved || 'removed'}</span>
+                    <span class="inline-block w-2 h-2 rounded-full bg-danger"></span>
+                    <span class="text-xs font-medium text-danger">-${removed.length} ${t.ruleLibraryDiffRemoved || 'removed'}</span>
                 </div>
-                ${removed.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-rose-500/10 border border-rose-500/20 text-xs text-rose-300 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
+                ${removed.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-danger/10 border border-danger/20 text-xs text-danger/70 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
             </div>`;
         }
         if (modified.length > 0) {
             diffHtml += `<div class="space-y-1">
                 <div class="flex items-center gap-2 mb-1">
-                    <span class="inline-block w-2 h-2 rounded-full bg-amber-400"></span>
-                    <span class="text-xs font-medium text-amber-400">~${modified.length} ${t.ruleLibraryDiffModified || 'modified'}</span>
+                    <span class="inline-block w-2 h-2 rounded-full bg-warning"></span>
+                    <span class="text-xs font-medium text-warning">~${modified.length} ${t.ruleLibraryDiffModified || 'modified'}</span>
                 </div>
-                ${modified.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs text-amber-300 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
+                ${modified.map((/** @type {any} */ r) => `<div class="px-3 py-1.5 rounded-lg bg-warning/10 border border-warning/20 text-xs text-warning/70 font-mono">${escapeHtml(typeof r === 'string' ? r : JSON.stringify(r))}</div>`).join('')}
             </div>`;
         }
 

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -1359,7 +1359,7 @@ export function initSubscriptionSettings({
                     barBg.className = 'h-1.5 w-full bg-[var(--zephyr-bg-input)] rounded-full overflow-hidden border border-[var(--zephyr-border-subtle)]';
 
                     const barFill = document.createElement('div');
-                    barFill.className = `h-full rounded-full transition-[width] duration-1000 ${percentage > 90 ? 'bg-rose-500' : 'bg-accent'}`;
+                    barFill.className = `h-full rounded-full transition-[width] duration-1000 ${percentage > 90 ? 'bg-danger' : 'bg-accent'}`;
                     barFill.style.width = `${percentage}%`;
 
                     barBg.appendChild(barFill);

--- a/apps/desktop/src/utils/format.js
+++ b/apps/desktop/src/utils/format.js
@@ -14,16 +14,16 @@ import { getDateTimeFormat } from './intl-cache.js';
  * @returns {string} Tailwind text color class name
  *
  * @example
- * getDelayColorClass(120);  // 'text-emerald-400'
- * getDelayColorClass(350);  // 'text-amber-400'
- * getDelayColorClass(800);  // 'text-rose-400'
+ * getDelayColorClass(120);  // 'text-success'
+ * getDelayColorClass(350);  // 'text-warning'
+ * getDelayColorClass(800);  // 'text-danger'
  * getDelayColorClass(null); // 'text-[var(--zephyr-text-tertiary)]'
  */
 export function getDelayColorClass(delay) {
     if (delay === null || delay === 0 || delay >= 999999) return 'text-[var(--zephyr-text-tertiary)]';
-    if (delay < 200) return 'text-emerald-400';
-    if (delay < 500) return 'text-amber-400';
-    return 'text-rose-400';
+    if (delay < 200) return 'text-success';
+    if (delay < 500) return 'text-warning';
+    return 'text-danger';
 }
 
 /**

--- a/apps/desktop/src/utils/format.test.js
+++ b/apps/desktop/src/utils/format.test.js
@@ -5,13 +5,13 @@ describe('getDelayColorClass', () => {
     it('returns tertiary for null', () => expect(getDelayColorClass(null)).toBe('text-[var(--zephyr-text-tertiary)]'));
     it('returns tertiary for 0', () => expect(getDelayColorClass(0)).toBe('text-[var(--zephyr-text-tertiary)]'));
     it('returns tertiary for 999999+', () => expect(getDelayColorClass(999999)).toBe('text-[var(--zephyr-text-tertiary)]'));
-    it('returns emerald for < 200', () => expect(getDelayColorClass(120)).toBe('text-emerald-400'));
-    it('returns emerald for 199', () => expect(getDelayColorClass(199)).toBe('text-emerald-400'));
-    it('returns amber for 200', () => expect(getDelayColorClass(200)).toBe('text-amber-400'));
-    it('returns amber for 499', () => expect(getDelayColorClass(499)).toBe('text-amber-400'));
-    it('returns rose for 500', () => expect(getDelayColorClass(500)).toBe('text-rose-400'));
-    it('returns rose for 800', () => expect(getDelayColorClass(800)).toBe('text-rose-400'));
-    it('boundary: 1', () => expect(getDelayColorClass(1)).toBe('text-emerald-400'));
+    it('returns success for < 200', () => expect(getDelayColorClass(120)).toBe('text-success'));
+    it('returns success for 199', () => expect(getDelayColorClass(199)).toBe('text-success'));
+    it('returns warning for 200', () => expect(getDelayColorClass(200)).toBe('text-warning'));
+    it('returns warning for 499', () => expect(getDelayColorClass(499)).toBe('text-warning'));
+    it('returns danger for 500', () => expect(getDelayColorClass(500)).toBe('text-danger'));
+    it('returns danger for 800', () => expect(getDelayColorClass(800)).toBe('text-danger'));
+    it('boundary: 1', () => expect(getDelayColorClass(1)).toBe('text-success'));
 });
 
 describe('formatFileSize', () => {

--- a/apps/desktop/src/utils/rule-utils.js
+++ b/apps/desktop/src/utils/rule-utils.js
@@ -12,7 +12,7 @@
  */
 export function getPolicyColor(policy) {
     const p = (policy || '').toUpperCase();
-    if (p === 'DIRECT') return 'text-green-400';
-    if (p === 'REJECT') return 'text-rose-500';
+    if (p === 'DIRECT') return 'text-success';
+    if (p === 'REJECT') return 'text-danger';
     return 'text-accent';
 }

--- a/apps/desktop/uno.config.js
+++ b/apps/desktop/uno.config.js
@@ -22,6 +22,18 @@ export default defineConfig({
         DEFAULT: 'var(--accent-primary)',
         glow: 'var(--accent-glow)',
       },
+      // ── Semantic color aliases (map to design-token CSS variables) ──
+      success:   'var(--zephyr-color-success)',
+      danger:    'var(--zephyr-color-danger)',
+      warning:   'var(--zephyr-color-warning)',
+      info:      'var(--zephyr-color-info)',
+      'close-btn': 'var(--zephyr-color-close-btn)',
+      download:  'var(--zephyr-color-download)',
+      upload:    'var(--zephyr-color-upload)',
+      orange:    'var(--zephyr-color-orange-500)',
+      pink:      'var(--zephyr-color-pink-500)',
+      cyan:      'var(--zephyr-color-cyan-500)',
+      indigo:    'var(--zephyr-color-indigo-500)',
     },
     fontSize: {
       '2xs': ['0.625rem', { lineHeight: '1.4' }],

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -3,27 +3,27 @@
     "gap":       { "value": "{space.2}" },
     "padding-y": { "value": "{space.3}" },
     "padding-x": { "value": "{space.5}" },
-    "radius":    { "value": "{radius.lg}" },
+    "radius":    { "value": "{radius.control}" },
     "font-size": { "value": "0.625rem" },
     "weight":    { "value": "700" },
     "tracking":  { "value": "0.05em" },
     "transform": { "value": "uppercase" }
   },
   "input": {
-    "radius":   { "value": "{radius.md}" },
+    "radius":   { "value": "{radius.control}" },
     "padding":  { "value": "{space.5} {space.3}" }
   },
   "card": {
-    "radius":   { "value": "{radius.lg}" },
+    "radius":   { "value": "{radius.surface}" },
     "blur":     { "value": "{glass.blur}" }
   },
   "badge": {
-    "radius":    { "value": "{radius.sm}" },
+    "radius":    { "value": "{radius.control}" },
     "padding":   { "value": "0.125rem 0.375rem" },
     "font-size": { "value": "0.625rem" }
   },
   "dropdown": {
-    "radius":      { "value": "{radius.lg}" },
+    "radius":      { "value": "{radius.surface}" },
     "padding":     { "value": "{space.3} {space.4}" },
     "item-radius": { "value": "{radius.dropdown-option}" }
   },
@@ -33,9 +33,9 @@
     "height": { "value": "24px" }
   },
   "modal": {
-    "radius": { "value": "{radius.lg}" }
+    "radius": { "value": "{radius.overlay}" }
   },
   "panel": {
-    "radius": { "value": "{radius.lg}" }
+    "radius": { "value": "{radius.surface}" }
   }
 }

--- a/packages/tokens/src/primitive.json
+++ b/packages/tokens/src/primitive.json
@@ -9,6 +9,9 @@
     "amber":  { "500": { "value": "#f59e0b" }, "600": { "value": "#d97706" } },
     "emerald":{ "400": { "value": "#4ade80" }, "500": { "value": "#22c55e" }, "600": { "value": "#16a34a" } },
     "sky":    { "400": { "value": "#38bdf8" }, "500": { "value": "#0ea5e9" } },
+    "cyan":   { "500": { "value": "#06b6d4" } },
+    "indigo": { "400": { "value": "#818cf8" }, "500": { "value": "#6366f1" }, "600": { "value": "#4f46e5" } },
+    "close-btn": { "value": "#ff5f57" },
     "zinc":   { "100": { "value": "#f4f4f5" }, "200": { "value": "#e4e4e7" }, "300": { "value": "#d4d4d8" }, "400": { "value": "#a1a1aa" }, "500": { "value": "#71717a" }, "600": { "value": "#52525b" } }
   },
   "space": {
@@ -23,11 +26,11 @@
     "8": { "value": "48px", "comment": "3rem" }
   },
   "radius": {
-    "sm":              { "value": "8px" },
-    "md":              { "value": "16px" },
-    "lg":              { "value": "24px" },
+    "control":         { "value": "8px" },
+    "surface":         { "value": "12px" },
+    "overlay":         { "value": "16px" },
     "full":            { "value": "9999px" },
-    "dropdown-option": { "value": "18px" }
+    "dropdown-option": { "value": "10px" }
   },
   "shadow": {
     "sm":       { "value": "0 4px 20px rgba(0, 0, 0, 0.2)" },

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -20,6 +20,13 @@
     "elevated":  { "value": "rgba(24, 24, 27, 0.97)",     "lightValue": "#ffffff" },
     "overlay":   { "value": "rgba(0, 0, 0, 0.4)", "lightValue": "rgba(0, 0, 0, 0.25)" }
   },
+  "surface": {
+    "page":     { "value": "transparent" },
+    "raised":   { "value": "{bg.secondary}" },
+    "elevated": { "value": "{bg.elevated}" },
+    "input":    { "value": "{bg.input}" },
+    "overlay":  { "value": "{bg.overlay}" }
+  },
   "border": {
     "primary": { "value": "hsla(0, 0%, 100%, 0.1)",       "lightValue": "rgba(0, 0, 0, 0.15)" },
     "subtle":  { "value": "rgba(255, 255, 255, 0.05)",     "lightValue": "rgba(30, 41, 59, 0.1)" },
@@ -27,10 +34,12 @@
     "strong":  { "value": "rgba(255, 255, 255, 0.2)",      "lightValue": "rgba(30, 41, 59, 0.2)" }
   },
   "color": {
-    "danger":  { "value": "#ef4444",  "lightValue": "#dc2626" },
-    "warning": { "value": "#f59e0b",  "lightValue": "#d97706" },
-    "success": { "value": "#4ade80",  "lightValue": "#16a34a" },
-    "info":    { "value": "#38bdf8",  "lightValue": "#2563eb" }
+    "danger":    { "value": "#ef4444",  "lightValue": "#dc2626" },
+    "warning":   { "value": "#f59e0b",  "lightValue": "#d97706" },
+    "success":   { "value": "#4ade80",  "lightValue": "#16a34a" },
+    "info":      { "value": "#38bdf8",  "lightValue": "#2563eb" },
+    "download":  { "value": "{color.purple.500}", "lightValue": "{color.purple.600}" },
+    "upload":    { "value": "{color.sky.400}",   "lightValue": "{color.blue.600}" }
   },
   "shadow": {
     "dialog": {


### PR DESCRIPTION
## PR2: Token Convergence

### 2.1 Radius Scale Convergence
Converged from 5 ad-hoc values to a **4-level semantic system**:

| Level | Token | Value | Used by |
|-------|-------|-------|---------|
| Control | `radius.control` | 8px | button, input, badge |
| Surface | `radius.surface` | 12px | card, panel, dropdown, nav |
| Overlay | `radius.overlay` | 16px | modal |
| Full | `radius.full` | 9999px | switch |

### 2.2 Hardcoded Color Elimination
Replaced **all** hardcoded Tailwind color utilities with semantic token-based classes across 15+ files:

- `text-emerald-400` 鈫?`text-success`, `text-rose-400` 鈫?`text-danger`, `text-amber-400` 鈫?`text-warning`
- `text-blue-400` 鈫?`text-info`, `text-purple-400` 鈫?`text-download`, `text-blue-500` 鈫?`text-upload`
- `bg-[#ff5f57]` 鈫?`bg-close-btn`, `bg-indigo-600` 鈫?`bg-info`
- Theme swatches 鈫?`bg-[var(--zephyr-color-purple-500)]` etc.
- Shadow `rgba(34,197,94,0.4)` 鈫?`color-mix(in_srgb,var(--zephyr-color-success)_40%,transparent)`
- Inline `rgba(239,68,68,0.2)` 鈫?`color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent)`
- Sortable headers: inline styles 鈫?utility classes (`text-download`, `text-upload`)
- Badge palette: deduplicated 3 identical `bg-info` entries 鈫?distinct `download`/`upload`/`orange`/`pink` tokens
- `originalColors` in `updateSortIndicators()`: hardcoded `rgba` 鈫?CSS variable tokens
- Outdated code comment updated to reflect new implementation

**New tokens**: `color.close-btn`, `color.download`, `color.upload`, `color.cyan`, `color.indigo` (with dark/light variants)

**Semantic color aliases in uno.config.js**: `success`, `danger`, `warning`, `info`, `close-btn`, `download`, `upload`, `orange`, `pink`, `cyan`, `indigo`

### 2.3 Surface Three-Layer Definition
Added `surface.*` semantic tokens in `semantic.json`:

```json
"surface": {
  "page":     "transparent",
  "raised":   "{bg.secondary}",
  "elevated": "{bg.elevated}",
  "input":    "{bg.input}",
  "overlay":  "{bg.overlay}"
}
```

### Verification
- 鉁?362 tests pass
- 鉁?ESLint clean
- 鉁?Style Dictionary build OK
- 鉁?UnoCSS build OK (622 utilities)
- 鉁?TypeScript typecheck OK
- 鉁?BOM removed from styles.css

### Note on CI
The `Cargo Deny Check` (Rust dependency audit) may fail 鈥?this is a pre-existing issue unrelated to the frontend token changes in this PR.