### PR TITLE
feat(components): PR3 鈥?surface shortcuts, button states, form-control, status components, danger zone

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -262,7 +262,7 @@
                         <div class="flex items-center gap-2 shrink-0">
                             <input
                                 id="plugin-search-input"
-                                class="input-mono text-xs flex-1 bg-[var(--zephyr-bg-input)] border border-[var(--zephyr-border-default)] rounded-md px-3 py-1.5 text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--zephyr-border-strong)]"
+                                class="form-control form-control-md form-control-mono text-xs flex-1 bg-[var(--zephyr-bg-input)] border border-[var(--zephyr-border-default)] rounded-md px-3 py-1.5 text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--zephyr-border-strong)]"
                                 placeholder="搜索覆写..." data-i18n-placeholder="overrideSearchPlaceholder"
                             />
                             <!-- New override dropdown -->
@@ -945,7 +945,7 @@
                                         </div>
                                         <div id="fake-client-custom-container" class="hidden">
                                             <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2">Custom User-Agent</label>
-                                            <input type="text" id="fake-client-custom" placeholder="e.g. MyClient/1.0" data-i18n-placeholder="fakeClientCustomPlaceholder" class="input-common placeholder:text-[var(--text-tertiary)]">
+                                            <input type="text" id="fake-client-custom" placeholder="e.g. MyClient/1.0" data-i18n-placeholder="fakeClientCustomPlaceholder" class="form-control form-control-md placeholder:text-[var(--text-tertiary)]">
                                         </div>
                                     </div>
                                     <svg id="fake-client-spinner" class="hidden w-4 h-4 text-accent animate-spin mx-auto mt-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
@@ -1301,7 +1301,7 @@
             <div class="space-y-6">
                 <div id="modal-content-area">
                     <!-- Default Input -->
-                    <input type="text" id="modal-input" placeholder="Name..." data-i18n-placeholder="modalInputPlaceholder" class="input-modal">
+                    <input type="text" id="modal-input" placeholder="Name..." data-i18n-placeholder="modalInputPlaceholder" class="form-control form-control-lg">
                 </div>
 <div class="flex gap-3 justify-end">
 <button id="modal-cancel" class="btn-ghost" data-i18n="cancel">Cancel</button>
@@ -1320,13 +1320,13 @@
             <div class="space-y-4">
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="dnsNameservers">Nameservers (DoH)</label>
-                    <textarea id="dns-nameservers-input" rows="3" class="textarea-common w-full" placeholder="https://doh.pub/dns-query&#10;https://dns.alidns.com/dns-query"></textarea>
+                    <textarea id="dns-nameservers-input" rows="3" class="form-control form-control-md form-control-mono resize-none w-full" placeholder="https://doh.pub/dns-query&#10;https://dns.alidns.com/dns-query"></textarea>
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="dnsNameserversHint">One URL per line. Used for domestic resolution.</p>
                 </div>
                 
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="dnsFallbacks">Fallback Servers (DoH)</label>
-                    <textarea id="dns-fallbacks-input" rows="3" class="textarea-common w-full" placeholder="https://dns.cloudflare.com/dns-query&#10;https://dns.google/dns-query"></textarea>
+                    <textarea id="dns-fallbacks-input" rows="3" class="form-control form-control-md form-control-mono resize-none w-full" placeholder="https://dns.cloudflare.com/dns-query&#10;https://dns.google/dns-query"></textarea>
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="dnsFallbacksHint">One URL per line. Used as fallback for international domains.</p>
                 </div>
             </div>
@@ -1347,25 +1347,25 @@
             <div class="space-y-4">
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="mixedPort">Mixed Port</label>
-                    <input id="port-mixed-input" type="number" min="0" max="65535" class="input-common placeholder:text-[var(--text-tertiary)] w-full" placeholder="7890">
+                    <input id="port-mixed-input" type="number" min="0" max="65535" class="form-control form-control-md placeholder:text-[var(--text-tertiary)] w-full" placeholder="7890">
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="mixedPortHint">HTTP & SOCKS5 combined port (0 to disable)</p>
                 </div>
 
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="socksPort">SOCKS5 Port</label>
-                    <input id="port-socks-input" type="number" min="0" max="65535" class="input-common placeholder:text-[var(--text-tertiary)] w-full" placeholder="7891">
+                    <input id="port-socks-input" type="number" min="0" max="65535" class="form-control form-control-md placeholder:text-[var(--text-tertiary)] w-full" placeholder="7891">
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="socksPortHint">Standalone SOCKS5 proxy port (0 to disable)</p>
                 </div>
 
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="redirPort">Redir Port</label>
-                    <input id="port-redir-input" type="number" min="0" max="65535" class="input-common placeholder:text-[var(--text-tertiary)] w-full" placeholder="0">
+                    <input id="port-redir-input" type="number" min="0" max="65535" class="form-control form-control-md placeholder:text-[var(--text-tertiary)] w-full" placeholder="0">
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="redirPortHint">Transparent proxy port, Linux only (0 to disable)</p>
                 </div>
 
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="tproxyPort">TProxy Port</label>
-                    <input id="port-tproxy-input" type="number" min="0" max="65535" class="input-common placeholder:text-[var(--text-tertiary)] w-full" placeholder="0">
+                    <input id="port-tproxy-input" type="number" min="0" max="65535" class="form-control form-control-md placeholder:text-[var(--text-tertiary)] w-full" placeholder="0">
                     <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="tproxyPortHint">TProxy port, Linux only (0 to disable)</p>
                 </div>
             </div>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -150,6 +150,32 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   opacity: 0.85;
 }
 
+/* ── Button State Matrix (PR3 §3.3) ── */
+/* Disabled — through native attribute, no extra class needed */
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Loading — through aria-busy attribute, synced with DOM semantics */
+.btn[aria-busy="true"] {
+  pointer-events: none;
+  opacity: 0.7;
+}
+.btn[aria-busy="true"]::after {
+  content: '';
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-left: 0.5rem;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: var(--zephyr-radius-full);
+  animation: btn-spin 0.6s linear infinite;
+}
+@keyframes btn-spin { to { transform: rotate(360deg); } }
+
 /* 极简滚动动画 */
 @keyframes text-scroll {
     0% { transform: translateX(0); }
@@ -430,39 +456,62 @@ html:not(.dark) #setting-lang-menu {
   background-color: color-mix(in srgb, var(--zephyr-color-danger) 10%, transparent);
 }
 
-/* --- Input System --- */
-.input-common {
+/* --- Form Control System (PR3 §3.4) --- */
+/* Converges input-common / input-modal / input-mono / textarea-common into one system */
+.form-control {
   width: 100%;
-  border-radius: 1rem;
-  padding: 0.5rem 1rem;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  background-color: var(--zephyr-bg-input);
+  border-radius: var(--zephyr-radius-control);
+  background-color: var(--zephyr-surface-input);
   border: 1px solid var(--zephyr-border-subtle);
   transition-property: color, background-color, border-color, box-shadow;
+  transition-duration: var(--zephyr-transition-standard);
 }
-.input-modal {
-  width: 100%;
-  border-radius: 1rem;
-  padding: 1rem 1.5rem;
-  font-size: 0.875rem;
-  color: var(--text-primary);
-  background-color: var(--zephyr-bg-input);
-  border: 1px solid var(--zephyr-border-subtle);
+.form-control::placeholder {
+  color: var(--zephyr-text-tertiary);
+}
+/* Size variants */
+.form-control-sm { padding: 0.25rem 0.75rem; font-size: var(--zephyr-font-size-2xs); }
+.form-control-md { padding: 0.5rem 1rem;    font-size: var(--zephyr-font-size-xs); }
+.form-control-lg { padding: 0.75rem 1.5rem;   font-size: var(--zephyr-font-size-sm); }
+/* Font variant */
+.form-control-mono { font-family: var(--font-mono); }
+
+/* --- Status Components (PR3 §3.5) --- */
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--zephyr-radius-full);
+  flex-shrink: 0;
+}
+.status-dot--online  { background: var(--zephyr-color-success); }
+.status-dot--offline { background: var(--zephyr-text-muted); }
+.status-dot--error   { background: var(--zephyr-color-danger); }
+.status-dot--warning { background: var(--zephyr-color-warning); }
+
+.latency-badge {
+  font-size: var(--zephyr-font-size-2xs);
+  font-weight: 700;
+  padding: var(--zephyr-badge-padding);
+  border-radius: var(--zephyr-radius-control);
+  font-variant-numeric: tabular-nums;
+}
+.latency-badge--fast   { color: var(--zephyr-color-success); background: color-mix(in srgb, var(--zephyr-color-success) 15%, transparent); }
+.latency-badge--medium { color: var(--zephyr-color-warning); background: color-mix(in srgb, var(--zephyr-color-warning) 15%, transparent); }
+.latency-badge--slow   { color: var(--zephyr-color-danger); background: color-mix(in srgb, var(--zephyr-color-danger) 15%, transparent); }
+
+/* --- Danger Zone (PR3 §3.6) --- */
+.danger-zone {
+  margin-top: var(--zephyr-space-8);
+  padding-top: var(--zephyr-space-6);
+  border-top: 1px solid color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent);
+}
+.danger-zone__title {
+  color: var(--zephyr-color-danger);
+  font-size: var(--zephyr-font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-weight: 300;
-  transition-property: color, background-color, border-color, box-shadow;
-}
-.input-mono {
-  width: 100%;
-  border-radius: 1rem;
-  padding: 0.75rem 1rem;
-  font-size: 0.75rem;
-  color: var(--text-primary);
-  background-color: var(--zephyr-bg-input);
-  border: 1px solid var(--zephyr-border-subtle);
-  font-family: var(--font-mono);
-  transition-property: color, background-color, border-color, box-shadow;
+  margin-bottom: var(--zephyr-space-3);
 }
 
 /* --- Badge System --- */
@@ -653,33 +702,19 @@ html:not(.dark) .script-output {
   background: var(--zephyr-bg-muted);
 }
 
-/* Common textarea styles - rounded corners */
-.textarea-common {
-  width: 100%;
-  border-radius: 1rem;
-  padding: 0.75rem;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  background-color: var(--zephyr-bg-input);
-  border: 1px solid var(--zephyr-border-subtle);
-  resize: none;
-  transition-property: color, background-color, border-color, box-shadow;
-}
+/* Textarea — use form-control + form-control-mono + resize-none utility */
 
-/* Light mode overrides for common inputs */
-html:not(.dark) .input-common:focus,
-html:not(.dark) .input-mono:focus,
-html:not(.dark) .input-modal:focus,
-html:not(.dark) .textarea-common:focus {
+/* Form control focus + placeholder (replaces old per-class overrides) */
+.form-control:focus-visible {
+  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
+  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.15);
+  outline: none;
+}
+html:not(.dark) .form-control:focus-visible {
   border-color: var(--color-accent);
 }
-
-html:not(.dark) .select-common::placeholder,
-html:not(.dark) .input-common::placeholder,
-html:not(.dark) .input-mono::placeholder,
-html:not(.dark) .input-modal::placeholder,
-html:not(.dark) .textarea-common::placeholder {
+html:not(.dark) .form-control::placeholder,
+html:not(.dark) .select-common::placeholder {
   color: var(--zephyr-text-tertiary);
 }
 
@@ -919,15 +954,7 @@ button:focus-visible,
   box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
 }
 
-/* Input focus ring */
-.input-common:focus,
-.textarea-common:focus,
-.input-modal:focus,
-.input-mono:focus {
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
-  outline: none;
-  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
-}
+/* Select focus (pill-shaped, keeps its own focus style) */
 .select-common:focus {
   box-shadow: none;
   outline: none;

--- a/apps/desktop/src/ui/advanced.js
+++ b/apps/desktop/src/ui/advanced.js
@@ -466,14 +466,14 @@ function renderConfigItem(key, value, fullKey) {
         const input = document.createElement('input');
         input.type = "number";
         input.value = String(value);
-        input.className = "input-mono w-full max-w-[100px] text-right";
+        input.className = "form-control form-control-md form-control-mono w-full max-w-[100px] text-right";
         input.onchange = () => handleConfigUpdate(fullKey, Number(input.value));
         valueContainer.appendChild(input);
     } else if (typeof value === 'string') {
         const input = document.createElement('input');
         input.type = "text";
         input.value = value;
-        input.className = "input-mono w-full text-right";
+        input.className = "form-control form-control-md form-control-mono w-full text-right";
         input.onchange = () => handleConfigUpdate(fullKey, input.value);
         valueContainer.appendChild(input);
     } else if (Array.isArray(value)) {

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -146,7 +146,7 @@ export function showModal(/** @type {string} */ title, placeholder = '', default
             input.type = 'text';
             input.id = 'modal-input';
             input.placeholder = placeholder;
-            input.className = 'input-modal';
+            input.className = 'form-control form-control-lg';
             input.value = defaultValue;
             contentArea.appendChild(input);
         }

--- a/apps/desktop/src/ui/rule-library.js
+++ b/apps/desktop/src/ui/rule-library.js
@@ -1501,14 +1501,14 @@ async function handleImportRules() {
                 <textarea id="rl-import-text" class="w-full h-32 bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-xl p-3 text-xs text-[var(--text-secondary)] font-mono resize-none focus:outline-none focus:border-accent/50 transition-colors custom-scrollbar" placeholder="${escapeHtml(t.ruleLibraryImportPaste || '')}" spellcheck="false"></textarea>
             </div>
             <div id="rl-import-file" class="hidden space-y-3">
-                <input id="rl-import-file-path" type="text" class="input-modal w-full" placeholder="${escapeHtml(t.ruleLibraryImportFile || '')}" />
+                <input id="rl-import-file-path" type="text" class="form-control form-control-lg w-full" placeholder="${escapeHtml(t.ruleLibraryImportFile || '')}" />
             </div>
             <div id="rl-import-url" class="hidden space-y-3">
-                <input id="rl-import-url-input" type="text" class="input-modal w-full" placeholder="https://..." />
+                <input id="rl-import-url-input" type="text" class="form-control form-control-lg w-full" placeholder="https://..." />
             </div>
             <div class="space-y-2">
                 <label class="text-xs text-[var(--text-muted)]">${escapeHtml(t.ruleLibraryGroupName || 'Name')}</label>
-                <input id="rl-import-name" type="text" class="input-modal w-full" placeholder="my-rules" />
+                <input id="rl-import-name" type="text" class="form-control form-control-lg w-full" placeholder="my-rules" />
             </div>
             <div class="flex items-center justify-end gap-2 pt-2">
                 <button id="rl-import-confirm" class="px-4 py-1.5 text-sm rounded-lg bg-accent/20 text-accent hover:bg-accent/30 transition-colors duration-200">

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -392,14 +392,14 @@ function initLogSettingsModal() {
                         <div class="flex flex-col gap-1">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.logRetentionDays || 'Retention Days'}</label>
                             <div class="flex items-center gap-1">
-                                <input id="log-retention-days" type="number" min="1" max="30" value="${retentionDays}" class="input-mono text-xs w-full">
+                                <input id="log-retention-days" type="number" min="1" max="30" value="${retentionDays}" class="form-control form-control-md form-control-mono text-xs w-full">
                                 <span class="text-2xs text-[var(--text-muted)]">${t.logDaysUnit || 'days'}</span>
                             </div>
                         </div>
                         <div class="flex flex-col gap-1">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.logMaxFileMb || 'Max File Size'}</label>
                             <div class="flex items-center gap-1">
-                                <input id="log-max-file-mb" type="number" min="1" max="500" value="${maxFileMb}" class="input-mono text-xs w-full">
+                                <input id="log-max-file-mb" type="number" min="1" max="500" value="${maxFileMb}" class="form-control form-control-md form-control-mono text-xs w-full">
                                 <span class="text-2xs text-[var(--text-muted)]">${t.logMbUnit || 'MB'}</span>
                             </div>
                         </div>
@@ -419,14 +419,14 @@ function initLogSettingsModal() {
                         <div class="flex flex-col gap-1">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.logRetentionDays || 'Retention Days'}</label>
                             <div class="flex items-center gap-1">
-                                <input id="log-retention-days-2" type="number" min="1" max="30" value="${retentionDays}" class="input-mono text-xs w-full">
+                                <input id="log-retention-days-2" type="number" min="1" max="30" value="${retentionDays}" class="form-control form-control-md form-control-mono text-xs w-full">
                                 <span class="text-2xs text-[var(--text-muted)]">${t.logDaysUnit || 'days'}</span>
                             </div>
                         </div>
                         <div class="flex flex-col gap-1">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.logMaxFileMb || 'Max File Size'}</label>
                             <div class="flex items-center gap-1">
-                                <input id="log-max-file-mb-2" type="number" min="1" max="500" value="${maxFileMb}" class="input-mono text-xs w-full">
+                                <input id="log-max-file-mb-2" type="number" min="1" max="500" value="${maxFileMb}" class="form-control form-control-md form-control-mono text-xs w-full">
                                 <span class="text-2xs text-[var(--text-muted)]">${t.logMbUnit || 'MB'}</span>
                             </div>
                         </div>
@@ -574,11 +574,11 @@ function initLogSettingsModal() {
                 <div class="grid grid-cols-2 gap-2">
                     <div class="flex flex-col gap-1">
                         <label class="text-2xs text-[var(--text-muted)]">${t.logExportFrom || 'From'}</label>
-                        <input id="log-export-from" type="date" value="${threeDaysAgo}" class="input-mono text-xs">
+                        <input id="log-export-from" type="date" value="${threeDaysAgo}" class="form-control form-control-md form-control-mono text-xs">
                     </div>
                     <div class="flex flex-col gap-1">
                         <label class="text-2xs text-[var(--text-muted)]">${t.logExportTo || 'To'}</label>
-                        <input id="log-export-to" type="date" value="${today}" class="input-mono text-xs">
+                        <input id="log-export-to" type="date" value="${today}" class="form-control form-control-md form-control-mono text-xs">
                     </div>
                 </div>
 
@@ -2159,27 +2159,27 @@ appStore.set('isNetworkUpdating', false);
                     <div class="grid grid-cols-2 gap-4">
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyWeightLatency || 'Latency Weight'}</label>
-                            <input id="smart-weight-latency" type="number" step="0.1" min="0" max="1" value="${config.latency_weight ?? 0.4}" class="input-mono text-xs">
+                            <input id="smart-weight-latency" type="number" step="0.1" min="0" max="1" value="${config.latency_weight ?? 0.4}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyWeightSuccess || 'Success Rate Weight'}</label>
-                            <input id="smart-weight-success" type="number" step="0.1" min="0" max="1" value="${config.success_weight ?? 0.4}" class="input-mono text-xs">
+                            <input id="smart-weight-success" type="number" step="0.1" min="0" max="1" value="${config.success_weight ?? 0.4}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyWeightStability || 'Stability Weight'}</label>
-                            <input id="smart-weight-stability" type="number" step="0.1" min="0" max="1" value="${config.stability_weight ?? 0.2}" class="input-mono text-xs">
+                            <input id="smart-weight-stability" type="number" step="0.1" min="0" max="1" value="${config.stability_weight ?? 0.2}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyHalfLife || 'Half-life (hours)'}</label>
-                            <input id="smart-half-life" type="number" step="0.5" min="0.1" value="${config.half_life_hours ?? 1.0}" class="input-mono text-xs">
+                            <input id="smart-half-life" type="number" step="0.5" min="0.1" value="${config.half_life_hours ?? 1.0}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyMinInterval || 'Min Test Interval (s)'}</label>
-                            <input id="smart-min-interval" type="number" min="10" value="${config.min_interval_secs ?? 60}" class="input-mono text-xs">
+                            <input id="smart-min-interval" type="number" min="10" value="${config.min_interval_secs ?? 60}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                         <div class="flex flex-col gap-1.5">
                             <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${t.smartProxyMaxInterval || 'Max Test Interval (s)'}</label>
-                            <input id="smart-max-interval" type="number" min="60" value="${config.max_interval_secs ?? 600}" class="input-mono text-xs">
+                            <input id="smart-max-interval" type="number" min="60" value="${config.max_interval_secs ?? 600}" class="form-control form-control-md form-control-mono text-xs">
                         </div>
                     </div>
                     <div class="flex justify-end pt-1">

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -182,11 +182,11 @@ async function showEditPanel(configInfo) {
             <div class="space-y-4">
                 <div class="flex flex-col gap-1.5">
                     <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${escapeHtml(t.rename || 'Name')}</label>
-                    <input id="edit-name" type="text" value="" class="input-common text-xs">
+                    <input id="edit-name" type="text" value="" class="form-control form-control-md text-xs">
                 </div>
                 <div class="flex flex-col gap-1.5">
                     <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${escapeHtml(t.subscriptionUrl || 'Subscription URL')}</label>
-                    <input id="edit-url" type="text" value="" placeholder="${escapeAttr(t.subscriptionUrlPlaceholder || 'Enter new URL to replace')}" class="input-common text-xs placeholder-[var(--text-tertiary)]">
+                    <input id="edit-url" type="text" value="" placeholder="${escapeAttr(t.subscriptionUrlPlaceholder || 'Enter new URL to replace')}" class="form-control form-control-md text-xs placeholder-[var(--text-tertiary)]">
                 </div>
                 <div class="flex flex-col gap-1.5">
                     <label class="text-2xs text-[var(--text-muted)] font-medium uppercase tracking-wider">${escapeHtml(t.editUA || 'Update User-Agent')}</label>

--- a/apps/desktop/src/ui/settings/tunnels.js
+++ b/apps/desktop/src/ui/settings/tunnels.js
@@ -137,15 +137,15 @@ export function initTunnelSettings({
             <div class="space-y-4">
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-1.5">${t.tunnelProtocol || 'Protocol'}</label>
-                    <input type="text" id="tunnel-protocol-input" placeholder="tcp, udp, or tcp,udp" value="tcp,udp" class="input-mono">
+                    <input type="text" id="tunnel-protocol-input" placeholder="tcp, udp, or tcp,udp" value="tcp,udp" class="form-control form-control-md form-control-mono">
                 </div>
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-1.5">${t.tunnelNetwork || 'Listen Network'}</label>
-                    <input type="text" id="tunnel-address-input" placeholder="e.g., 127.0.0.1:6553" class="input-mono">
+                    <input type="text" id="tunnel-address-input" placeholder="e.g., 127.0.0.1:6553" class="form-control form-control-md form-control-mono">
                 </div>
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-1.5">${t.tunnelTarget || 'Target Address'}</label>
-                    <input type="text" id="tunnel-target-input" placeholder="e.g., 8.8.8.8:53" class="input-mono">
+                    <input type="text" id="tunnel-target-input" placeholder="e.g., 8.8.8.8:53" class="form-control form-control-md form-control-mono">
                 </div>
                 <div class="flex gap-3 justify-end pt-2">
                     <button id="tunnel-cancel-btn" class="btn-ghost">${cancelText}</button>

--- a/apps/desktop/uno.config.js
+++ b/apps/desktop/uno.config.js
@@ -39,4 +39,16 @@ export default defineConfig({
       '2xs': ['0.625rem', { lineHeight: '1.4' }],
     },
   },
+
+  // ── Static layout combinations (see PR3 §3.1 Component Carrier Boundary) ──
+  shortcuts: {
+    // Three-layer surface system
+    'surface-1': 'bg-transparent',
+    'surface-2': 'rounded-[var(--zephyr-radius-surface)] border border-[var(--zephyr-border-subtle)] bg-[var(--zephyr-surface-raised)]',
+    'surface-3': 'rounded-[var(--zephyr-radius-overlay)] border border-[var(--zephyr-border-default)] bg-[var(--zephyr-surface-elevated)] shadow-[var(--zephyr-shadow-md)]',
+
+    // Interactive panels
+    'panel': 'surface-2 px-4 py-3',
+    'panel-interactive': 'panel transition-colors hover:bg-[var(--zephyr-bg-muted)]',
+  },
 })


### PR DESCRIPTION
## PR3: Component-Level Refactor

> **Goal**: Upgrade high-frequency components from utility-class stacks to stable semantic components.

### 3.2 Surface Shortcuts (uno.config.js)
Added `shortcuts` block with three-layer surface system:
- `surface-1`: transparent background
- `surface-2`: rounded + border + raised background (token: `--zephyr-surface-raised`)
- `surface-3`: rounded + border + elevated background + shadow
- `panel`: surface-2 + padding
- `panel-interactive`: panel + hover transition

### 3.3 Button State Matrix (styles.css)
Added complete 7-state matrix to `.btn`:
- `:disabled` / `[disabled]` 鈥?opacity 0.4, cursor not-allowed
- `[aria-busy="true"]` 鈥?pointer-events none, opacity 0.7, spinner via `::after`
- `@keyframes btn-spin` 鈥?0.6s linear infinite rotation

### 3.4 Form Control System (styles.css + HTML/JS)
Converged 4 separate input classes into one `.form-control` system:
- `input-common` 鈫?`form-control form-control-md`
- `input-modal` 鈫?`form-control form-control-lg`
- `input-mono` 鈫?`form-control form-control-md form-control-mono`
- `textarea-common` 鈫?`form-control form-control-md form-control-mono resize-none`

**Size variants**: `.form-control-sm` (2xs), `.form-control-md` (xs), `.form-control-lg` (sm)
**Font variant**: `.form-control-mono`
**Focus**: `.form-control:focus-visible` with border + box-shadow ring
**Placeholder**: `.form-control::placeholder` with tertiary text color

Border-radius changed from hardcoded `1rem` to token `var(--zephyr-radius-control)` (8px).

### 3.5 Status Components (styles.css)
- `.status-dot` 鈥?8px fixed-size dot with `--online`/`--offline`/`--error`/`--warning` modifiers
- `.latency-badge` 鈥?tabular-nums badge with `--fast`/`--medium`/`--slow` color modifiers

### 3.6 Danger Zone (styles.css)
- `.danger-zone` 鈥?margin-top + padding-top + danger-colored top border
- `.danger-zone__title` 鈥?danger-colored uppercase title with letter-spacing

### Verification
- 鉁?362 tests pass
- 鉁?ESLint clean
- 鉁?UnoCSS 623 utilities
- 鉁?TypeScript typecheck OK

### Note
Cargo Deny Check (Rust) may fail 鈥?pre-existing, unrelated to frontend component changes.