### PR TITLE
feat(a11y): PR4 鈥?focus-visible unification, disabled states, reduced-motion, transition tokens

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -153,7 +153,8 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
 /* ── Button State Matrix (PR3 §3.3) ── */
 /* Disabled — through native attribute, no extra class needed */
 .btn:disabled,
-.btn[disabled] {
+.btn[disabled],
+.form-control:disabled {
   opacity: 0.4;
   cursor: not-allowed !important;
 }
@@ -252,6 +253,11 @@ input[type="range"],
   --z-sticky: var(--zephyr-z-index-sticky);
   --z-modal: var(--zephyr-z-index-modal);
   --z-toast: var(--zephyr-z-index-toast);
+
+  /* Focus ring adapter — compose CSS expressions from cross-platform tokens */
+  --zephyr-focus-ring: rgba(var(--accent-rgb), var(--zephyr-focus-ringAlpha));
+  --zephyr-focus-ring-soft: rgba(var(--accent-rgb), var(--zephyr-focus-ringSoftAlpha));
+  --zephyr-focus-border: rgba(var(--accent-rgb), var(--zephyr-focus-borderAlpha));
 }
 
 html:not(.dark) {
@@ -708,12 +714,8 @@ html:not(.dark) .script-output {
 
 /* Form control focus + placeholder (replaces old per-class overrides) */
 .form-control:focus-visible {
-  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
-  outline: none;
-}
-html:not(.dark) .form-control:focus-visible {
-  border-color: var(--color-accent);
+  border-color: var(--zephyr-focus-border);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
 }
 html:not(.dark) .form-control::placeholder,
 html:not(.dark) .select-common::placeholder {
@@ -944,16 +946,16 @@ html:not(.dark) .select-common::placeholder {
 /* ============================================
    Focus Visibility (theme-aware)
    ============================================ */
-:focus-visible {
-  outline: 4px solid rgba(var(--accent-rgb), 0.6);
-  outline-offset: 1px;
+/* Global outline for keyboard navigation visibility */
+:where(button, a, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--zephyr-focus-ring);
+  outline-offset: 2px;
 }
 
-/* Button focus ring using box-shadow */
+/* Buttons get a soft box-shadow supplement (outline preserved) */
 button:focus-visible,
 [role="button"]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
 }
 
 /* Select focus (pill-shaped, keeps its own focus style) */
@@ -971,7 +973,39 @@ button:focus-visible,
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
+
+  /* 关闭装饰性动画 */
+  .conn-line-dash,
+  .conn-pulse-dot,
+  .sr-fill.sr-dashing,
+  .sr-turn.sr-spinning {
+    animation: none !important;
+  }
+}
+
+/* ============================================
+   Transition System (PR4 §4.5)
+   ============================================ */
+.btn,
+.form-control,
+.glass-card,
+.dropdown-item,
+.dropdown-panel {
+  transition-duration: var(--zephyr-transition-standard);
+  transition-timing-function: ease-out;
+}
+
+.nav-button,
+.tab-button,
+.status-dot {
+  transition-duration: var(--zephyr-transition-micro);
+}
+
+[data-page],
+#modal-container {
+  transition-duration: var(--zephyr-transition-page);
 }
 
 /* ============================================

--- a/packages/tokens/src/primitive.json
+++ b/packages/tokens/src/primitive.json
@@ -12,6 +12,7 @@
     "cyan":   { "500": { "value": "#06b6d4" } },
     "indigo": { "400": { "value": "#818cf8" }, "500": { "value": "#6366f1" }, "600": { "value": "#4f46e5" } },
     "close-btn": { "value": "#ff5f57" },
+    "accent": { "value": "#AF52DE" },
     "zinc":   { "100": { "value": "#f4f4f5" }, "200": { "value": "#e4e4e7" }, "300": { "value": "#d4d4d8" }, "400": { "value": "#a1a1aa" }, "500": { "value": "#71717a" }, "600": { "value": "#52525b" } }
   },
   "space": {

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -41,6 +41,12 @@
     "download":  { "value": "{color.purple.500}", "lightValue": "{color.purple.600}" },
     "upload":    { "value": "{color.sky.400}",   "lightValue": "{color.blue.600}" }
   },
+  "focus": {
+    "color":         { "value": "{color.accent}" },
+    "ringAlpha":     { "value": "0.50" },
+    "ringSoftAlpha": { "value": "0.15" },
+    "borderAlpha":   { "value": "0.50" }
+  },
   "shadow": {
     "dialog": {
       "value": "inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 0 0 0.5px rgba(0, 0, 0, 0.2), 0 8px 40px rgba(0, 0, 0, 0.55)",


### PR DESCRIPTION
## PR4: 鍔ㄦ晥涓庡彲璁块棶鎬n
> **Goal**: Unify interaction feedback, close a11y gaps.

### 4.1 Focus-visible 缁熶竴
- **semantic.json**: Added `focus` tokens (`color`, `ringAlpha: 0.50`, `ringSoftAlpha: 0.15`, `borderAlpha: 0.50`)
- **primitive.json**: Added `color.accent` (#AF52DE) for cross-platform token reference
- **styles.css :root**: Focus ring CSS adapter 鈥?composes `rgba(var(--accent-rgb), ...)` from tokens
- **Global outline**: `:where(button, a, input, select, textarea, [tabindex]):focus-visible` with `2px solid var(--zephyr-focus-ring)` + `outline-offset: 2px`
- **Buttons**: Soft `box-shadow` supplement (outline preserved, not cancelled)
- **Form controls**: `border-color: var(--zephyr-focus-border)` + `box-shadow: var(--zephyr-focus-ring-soft)` (outline preserved)

### 4.2 Disabled 鐘舵€乗n- Added `.form-control:disabled` to the existing `.btn:disabled` rule
- `opacity: 0.4` + `cursor: not-allowed !important`

### 4.3+4.4 Loading + Reduced Motion
- Added `scroll-behavior: auto !important` to reduced-motion media query
- Added decorative animation shutdown: `.conn-line-dash`, `.conn-pulse-dot`, `.sr-fill.sr-dashing`, `.sr-turn.sr-spinning` 鈫?`animation: none !important`

### 4.5 Transition 缁熶竴
- Standard transitions: `.btn`, `.form-control`, `.glass-card`, `.dropdown-item`, `.dropdown-panel` 鈫?`var(--zephyr-transition-standard)` + `ease-out`
- Micro-interactions: `.nav-button`, `.tab-button`, `.status-dot` 鈫?`var(--zephyr-transition-micro)`
- Page-level: `[data-page]`, `#modal-container` 鈫?`var(--zephyr-transition-page)`

### Verification
- 鉁?362 tests pass
- 鉁?ESLint clean
- 鉁?UnoCSS 622 utilities
- 鉁?TypeScript typecheck OK
- 鉁?Style Dictionary build OK

### Note
Cargo Deny Check (Rust) may fail 鈥?pre-existing, unrelated to frontend a11y changes.