### PR TITLE
feat(a11y): PR4 鈥?focus-visible unification, disabled states, reduced-motion, transition tokens

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -153,7 +153,8 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
 /* ── Button State Matrix (PR3 §3.3) ── */
 /* Disabled — through native attribute, no extra class needed */
 .btn:disabled,
-.btn[disabled] {
+.btn[disabled],
+.form-control:disabled {
   opacity: 0.4;
   cursor: not-allowed !important;
 }
@@ -252,6 +253,11 @@ input[type="range"],
   --z-sticky: var(--zephyr-z-index-sticky);
   --z-modal: var(--zephyr-z-index-modal);
   --z-toast: var(--zephyr-z-index-toast);
+
+  /* Focus ring adapter — compose CSS expressions from cross-platform tokens */
+  --zephyr-focus-ring: rgba(var(--accent-rgb), var(--zephyr-focus-ring-alpha));
+  --zephyr-focus-ring-soft: rgba(var(--accent-rgb), var(--zephyr-focus-ring-soft-alpha));
+  --zephyr-focus-border: rgba(var(--accent-rgb), var(--zephyr-focus-border-alpha));
 }
 
 html:not(.dark) {
@@ -708,12 +714,9 @@ html:not(.dark) .script-output {
 
 /* Form control focus + placeholder (replaces old per-class overrides) */
 .form-control:focus-visible {
-  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
-  outline: none;
-}
-html:not(.dark) .form-control:focus-visible {
-  border-color: var(--color-accent);
+  border-color: var(--zephyr-focus-border);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 html:not(.dark) .form-control::placeholder,
 html:not(.dark) .select-common::placeholder {
@@ -944,16 +947,17 @@ html:not(.dark) .select-common::placeholder {
 /* ============================================
    Focus Visibility (theme-aware)
    ============================================ */
-:focus-visible {
-  outline: 4px solid rgba(var(--accent-rgb), 0.6);
-  outline-offset: 1px;
+/* Global outline for keyboard navigation visibility */
+:where(button, a, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--zephyr-focus-ring);
+  outline-offset: 2px;
 }
 
-/* Button focus ring using box-shadow */
+/* Buttons get a soft box-shadow supplement (outline preserved) */
 button:focus-visible,
 [role="button"]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 
 /* Select focus (pill-shaped, keeps its own focus style) */
@@ -971,7 +975,40 @@ button:focus-visible,
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
+
+  /* 关闭装饰性动画 */
+  .conn-line-dash,
+  .conn-pulse-dot,
+  .sr-fill.sr-dashing,
+  .sr-turn.sr-spinning {
+    animation: none !important;
+  }
+}
+
+/* ============================================
+   Transition System (PR4 §4.5)
+   ============================================ */
+.btn,
+.form-control,
+.glass-card,
+.dropdown-item,
+.dropdown-panel {
+  transition-property: color, background-color, border-color, box-shadow, opacity, transform, backdrop-filter;
+  transition-duration: var(--zephyr-transition-standard);
+  transition-timing-function: ease-out;
+}
+
+.nav-button,
+.tab-button,
+.status-dot {
+  transition-duration: var(--zephyr-transition-micro);
+}
+
+[data-page],
+#modal-container {
+  transition-duration: var(--zephyr-transition-page);
 }
 
 /* ============================================

--- a/packages/tokens/src/primitive.json
+++ b/packages/tokens/src/primitive.json
@@ -12,6 +12,7 @@
     "cyan":   { "500": { "value": "#06b6d4" } },
     "indigo": { "400": { "value": "#818cf8" }, "500": { "value": "#6366f1" }, "600": { "value": "#4f46e5" } },
     "close-btn": { "value": "#ff5f57" },
+    "accent": { "value": "#AF52DE" },
     "zinc":   { "100": { "value": "#f4f4f5" }, "200": { "value": "#e4e4e7" }, "300": { "value": "#d4d4d8" }, "400": { "value": "#a1a1aa" }, "500": { "value": "#71717a" }, "600": { "value": "#52525b" } }
   },
   "space": {

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -41,6 +41,12 @@
     "download":  { "value": "{color.purple.500}", "lightValue": "{color.purple.600}" },
     "upload":    { "value": "{color.sky.400}",   "lightValue": "{color.blue.600}" }
   },
+  "focus": {
+    "color":           { "value": "{color.accent}" },
+    "ring-alpha":      { "value": "0.50" },
+    "ring-soft-alpha": { "value": "0.30" },
+    "border-alpha":    { "value": "0.50" }
+  },
   "shadow": {
     "dialog": {
       "value": "inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 0 0 0.5px rgba(0, 0, 0, 0.2), 0 8px 40px rgba(0, 0, 0, 0.55)",


### PR DESCRIPTION
## PR4: 鍔ㄦ晥涓庡彲璁块棶鎬n
> **Goal**: Unify interaction feedback, close a11y gaps.

### 4.1 Focus-visible 缁熶竴
- **semantic.json**: `focus` tokens (kebab-case: `ring-alpha: 0.50`, `ring-soft-alpha: 0.30`, `border-alpha: 0.50`)
- **primitive.json**: `color.accent` (#AF52DE)
- **styles.css :root**: Focus ring CSS adapter
- **Global**: `:where(button, a, input, select, textarea, [tabindex]):focus-visible` with `2px solid var(--zephyr-focus-ring)`
- **Buttons + Form controls**: `box-shadow` + `outline: 2px solid transparent` (no visual overlap, high-contrast compatible)
- **`.select-common:focus`**: Removed `outline: none` to preserve global focus visibility

### 4.2 Disabled 鐘舵€乗n- `.btn:disabled`, `.form-control:disabled`, `.select-common:disabled` 鈥?`opacity: 0.4` + `cursor: not-allowed !important`

### 4.3+4.4 Reduced Motion
- `scroll-behavior: auto !important`
- Decorative animation shutdown: `.conn-line-dash`, `.conn-pulse-dot`, `.sr-fill.sr-dashing`, `.sr-turn.sr-spinning`

### 4.5 Transition 缁熶竴
- Standard: `.btn`, `.form-control`, `.glass-card`, `.dropdown-item`, `.dropdown-panel` 鈥?`transition-property: color, background-color, border-color, box-shadow, opacity` + `var(--zephyr-transition-standard)` + `ease-out`
- Micro: `.nav-button`, `.tab-button`, `.status-dot` 鈥?`var(--zephyr-transition-micro)`
- Page: `[data-page]`, `#modal-container` 鈥?`var(--zephyr-transition-page)`

### Verification
- 鉁?362 tests pass | ESLint clean | UnoCSS 622 utilities | TypeScript OK | Style Dictionary OK

### Note
Cargo Deny Check (Rust) may fail 鈥?pre-existing, unrelated to frontend a11y changes.