### PR TITLE
feat(a11y): PR4 鈥?focus-visible unification, disabled states, reduced-motion, transition tokens

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -153,7 +153,14 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
 /* ── Button State Matrix (PR3 §3.3) ── */
 /* Disabled — through native attribute, no extra class needed */
 .btn:disabled,
-.btn[disabled] {
+.btn[disabled],
+.btn[aria-disabled="true"],
+.form-control:disabled,
+.form-control[disabled],
+.form-control[aria-disabled="true"],
+.select-common:disabled,
+.select-common[disabled],
+.select-common[aria-disabled="true"] {
   opacity: 0.4;
   cursor: not-allowed !important;
 }
@@ -252,6 +259,11 @@ input[type="range"],
   --z-sticky: var(--zephyr-z-index-sticky);
   --z-modal: var(--zephyr-z-index-modal);
   --z-toast: var(--zephyr-z-index-toast);
+
+  /* Focus ring adapter — compose CSS expressions from cross-platform tokens */
+  --zephyr-focus-ring: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-ring-alpha));
+  --zephyr-focus-ring-soft: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-ring-soft-alpha));
+  --zephyr-focus-border: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-border-alpha));
 }
 
 html:not(.dark) {
@@ -708,12 +720,9 @@ html:not(.dark) .script-output {
 
 /* Form control focus + placeholder (replaces old per-class overrides) */
 .form-control:focus-visible {
-  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
-  outline: none;
-}
-html:not(.dark) .form-control:focus-visible {
-  border-color: var(--color-accent);
+  border-color: var(--zephyr-focus-border);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 html:not(.dark) .form-control::placeholder,
 html:not(.dark) .select-common::placeholder {
@@ -944,23 +953,30 @@ html:not(.dark) .select-common::placeholder {
 /* ============================================
    Focus Visibility (theme-aware)
    ============================================ */
-:focus-visible {
-  outline: 4px solid rgba(var(--accent-rgb), 0.6);
-  outline-offset: 1px;
+/* Global outline for keyboard navigation visibility */
+:where(button, a, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--zephyr-focus-ring);
+  outline-offset: 2px;
 }
 
-/* Button focus ring using box-shadow */
+/* Buttons get a soft box-shadow supplement (outline preserved) */
 button:focus-visible,
 [role="button"]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 
 /* Select focus (pill-shaped, keeps its own focus style) */
 .select-common:focus {
   box-shadow: none;
-  outline: none;
+  outline: 2px solid transparent;
   border-color: var(--zephyr-border-strong);
+}
+
+.select-common:focus-visible {
+  outline: 2px solid var(--zephyr-focus-ring);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
 }
 
 /* ============================================
@@ -971,7 +987,50 @@ button:focus-visible,
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
+
+  /* Disable decorative animations */
+  .conn-line-dash,
+  .conn-pulse-dot,
+  .sr-fill.sr-dashing,
+  .sr-turn.sr-spinning {
+    animation: none !important;
+  }
+}
+
+/* ============================================
+   Transition System (PR4 §4.5)
+   ============================================ */
+.btn,
+.form-control,
+.select-common,
+.dropdown-item,
+.dropdown-panel {
+  transition-property: color, background-color, border-color, box-shadow, opacity;
+  transition-duration: var(--zephyr-transition-standard);
+  transition-timing-function: ease-out;
+}
+
+.glass-card {
+  transition-property: color, background-color, border-color, box-shadow, opacity, backdrop-filter, -webkit-backdrop-filter;
+  transition-duration: var(--zephyr-transition-standard);
+  transition-timing-function: ease-out;
+}
+
+.nav-button,
+.tab-button,
+.status-dot {
+  transition-property: color, background-color, border-color, box-shadow, opacity;
+  transition-duration: var(--zephyr-transition-micro);
+  transition-timing-function: ease-out;
+}
+
+[data-page],
+#modal-container {
+  transition-property: opacity, transform;
+  transition-duration: var(--zephyr-transition-page);
+  transition-timing-function: ease-out;
 }
 
 /* ============================================

--- a/packages/tokens/src/primitive.json
+++ b/packages/tokens/src/primitive.json
@@ -12,6 +12,7 @@
     "cyan":   { "500": { "value": "#06b6d4" } },
     "indigo": { "400": { "value": "#818cf8" }, "500": { "value": "#6366f1" }, "600": { "value": "#4f46e5" } },
     "close-btn": { "value": "#ff5f57" },
+    "accent": { "value": "{color.purple.500}" },
     "zinc":   { "100": { "value": "#f4f4f5" }, "200": { "value": "#e4e4e7" }, "300": { "value": "#d4d4d8" }, "400": { "value": "#a1a1aa" }, "500": { "value": "#71717a" }, "600": { "value": "#52525b" } }
   },
   "space": {

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -41,6 +41,12 @@
     "download":  { "value": "{color.purple.500}", "lightValue": "{color.purple.600}" },
     "upload":    { "value": "{color.sky.400}",   "lightValue": "{color.blue.600}" }
   },
+  "focus": {
+    "color":           { "value": "{color.accent}" },
+    "ring-alpha":      { "value": "0.50", "lightValue": "0.70" },
+    "ring-soft-alpha": { "value": "0.30", "lightValue": "0.45" },
+    "border-alpha":    { "value": "0.50", "lightValue": "0.70" }
+  },
   "shadow": {
     "dialog": {
       "value": "inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 0 0 0.5px rgba(0, 0, 0, 0.2), 0 8px 40px rgba(0, 0, 0, 0.55)",


### PR DESCRIPTION
## PR4: 鍔ㄦ晥涓庡彲璁块棶鎬n
> **Goal**: Unify interaction feedback, close a11y gaps.

### 4.1 Focus-visible 缁熶竴
- **semantic.json**: `focus` tokens (kebab-case + `lightValue` overrides for WCAG contrast)
- **primitive.json**: `color.accent` 鈫?`{color.purple.500}`
- **styles.css :root**: Focus ring adapter with `--accent-rgb` fallback (`175, 82, 222`)
- **Global**: `:where(...):focus-visible` with `2px solid var(--zephyr-focus-ring)`
- **Buttons + Form controls + Select**: `box-shadow` + `outline: 2px solid transparent` + separate `:focus-visible` for select

### 4.2 Disabled 鐘舵€乗n- `.btn`, `.form-control`, `.select-common` 鈥?`:disabled` + `[disabled]` + `[aria-disabled="true"]`
- `opacity: 0.4` + `cursor: not-allowed !important`

### 4.3+4.4 Reduced Motion
- `scroll-behavior: auto !important`
- Decorative animation shutdown

### 4.5 Transition 缁熶竴
- Standard: `.btn`, `.form-control`, `.select-common`, `.dropdown-item`, `.dropdown-panel` 鈥?5 properties + `var(--zephyr-transition-standard)` + `ease-out`
- **`.glass-card`**: Separate rule with `backdrop-filter` + `-webkit-backdrop-filter` preserved
- Micro: `.nav-button`, `.tab-button`, `.status-dot` 鈥?explicit properties + `var(--zephyr-transition-micro)`
- Page: `[data-page]`, `#modal-container` 鈥?`opacity, transform` + `var(--zephyr-transition-page)`

### Verification
- 鉁?362 tests pass | ESLint clean | UnoCSS 622 utilities | TypeScript OK | Style Dictionary OK

### Note
Cargo Deny Check (Rust) may fail 鈥?pre-existing, unrelated to frontend a11y changes.