### PR TITLE
feat(a11y): PR4 — focus-visible, disabled states, reduced-motion, transition tokens

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -85,8 +85,8 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   text-transform: var(--zephyr-button-transform);
   letter-spacing: var(--zephyr-button-tracking);
   transition-property: color, background-color, border-color, box-shadow, opacity;
-  transition-duration: var(--zephyr-transition-standard);
-  transition-timing-function: ease-out;
+  transition-duration: var(--zephyr-time-standard);
+  transition-timing-function: var(--zephyr-easing-ease-out);
   cursor: pointer;
 }
 
@@ -95,7 +95,7 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   border: 1px solid color-mix(in srgb, var(--color-accent) 12%, transparent);
   color: var(--zephyr-text-primary);
 }
-.btn-ghost:hover {
+.btn-ghost:hover:not(:disabled):not([aria-disabled="true"]) {
   background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
   color: var(--zephyr-text-primary);
 }
@@ -110,7 +110,7 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
   color: var(--color-accent);
 }
-.btn-accent:hover {
+.btn-accent:hover:not(:disabled):not([aria-disabled="true"]) {
   background-color: color-mix(in srgb, var(--color-accent) 25%, transparent);
 }
 
@@ -119,7 +119,7 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   border: 1px solid color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent);
   color: var(--zephyr-color-danger);
 }
-.btn-danger:hover {
+.btn-danger:hover:not(:disabled):not([aria-disabled="true"]) {
   background-color: color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent);
 }
 
@@ -128,7 +128,7 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   border: 1px solid color-mix(in srgb, var(--zephyr-color-warning) 20%, transparent);
   color: var(--zephyr-color-warning);
 }
-.btn-warning:hover {
+.btn-warning:hover:not(:disabled):not([aria-disabled="true"]) {
   background-color: color-mix(in srgb, var(--zephyr-color-warning) 20%, transparent);
 }
 
@@ -137,7 +137,7 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
   color: var(--color-accent);
 }
-.btn-success:hover {
+.btn-success:hover:not(:disabled):not([aria-disabled="true"]) {
   background-color: color-mix(in srgb, var(--color-accent) 25%, transparent);
 }
 
@@ -146,14 +146,24 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   color: var(--zephyr-text-on-accent);
   box-shadow: 0 10px 15px -3px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
-.btn-primary:hover {
+.btn-primary:hover:not(:disabled):not([aria-disabled="true"]) {
   opacity: 0.85;
 }
 
 /* ── Button State Matrix (PR3 §3.3) ── */
 /* Disabled — through native attribute, no extra class needed */
+button:disabled,
+button[disabled],
+input:disabled,
+select:disabled,
+textarea:disabled,
 .btn:disabled,
-.btn[disabled] {
+.btn[disabled],
+.form-control:disabled,
+.form-control[disabled],
+.select-common:disabled,
+.select-common[disabled],
+[aria-disabled="true"] {
   opacity: 0.4;
   cursor: not-allowed !important;
 }
@@ -252,6 +262,11 @@ input[type="range"],
   --z-sticky: var(--zephyr-z-index-sticky);
   --z-modal: var(--zephyr-z-index-modal);
   --z-toast: var(--zephyr-z-index-toast);
+
+  /* Focus ring adapter */
+  --zephyr-focus-ring: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-ring-alpha, 0.5));
+  --zephyr-focus-ring-soft: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-ring-soft-alpha, 0.3));
+  --zephyr-focus-border: rgba(var(--accent-rgb, 175, 82, 222), var(--zephyr-focus-border-alpha, 0.5));
 }
 
 html:not(.dark) {
@@ -465,8 +480,6 @@ html:not(.dark) #setting-lang-menu {
   background-color: var(--zephyr-surface-input);
   color: var(--text-primary);
   border: 1px solid var(--zephyr-border-subtle);
-  transition-property: color, background-color, border-color, box-shadow;
-  transition-duration: var(--zephyr-transition-standard);
 }
 .form-control::placeholder {
   color: var(--zephyr-text-tertiary);
@@ -707,13 +720,10 @@ html:not(.dark) .script-output {
 /* Textarea — use form-control + form-control-mono + resize-none utility */
 
 /* Form control focus + placeholder (replaces old per-class overrides) */
-.form-control:focus-visible {
-  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
-  outline: none;
-}
-html:not(.dark) .form-control:focus-visible {
-  border-color: var(--color-accent);
+.form-control:focus-visible:not(:disabled):not([aria-disabled="true"]) {
+  border-color: var(--zephyr-focus-border);
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 html:not(.dark) .form-control::placeholder,
 html:not(.dark) .select-common::placeholder {
@@ -944,23 +954,31 @@ html:not(.dark) .select-common::placeholder {
 /* ============================================
    Focus Visibility (theme-aware)
    ============================================ */
-:focus-visible {
-  outline: 4px solid rgba(var(--accent-rgb), 0.6);
-  outline-offset: 1px;
+/* Global outline for keyboard navigation visibility */
+:where(button, a, input, select, textarea, [tabindex]:not([tabindex^="-"])):focus-visible {
+  outline: 2px solid var(--zephyr-focus-ring);
+  outline-offset: 2px;
 }
 
-/* Button focus ring using box-shadow */
-button:focus-visible,
-[role="button"]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.6);
+/* Buttons get a soft box-shadow supplement (outline preserved) */
+button:focus-visible:not(:disabled):not([aria-disabled="true"]),
+.btn:focus-visible:not(:disabled):not([aria-disabled="true"]),
+[role="button"]:focus-visible:not([aria-disabled="true"]) {
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
+  outline: 2px solid transparent;
 }
 
 /* Select focus (pill-shaped, keeps its own focus style) */
 .select-common:focus {
   box-shadow: none;
-  outline: none;
+  outline: 2px solid transparent;
   border-color: var(--zephyr-border-strong);
+}
+
+.select-common:focus-visible:not(:disabled):not([aria-disabled="true"]) {
+  border-color: var(--zephyr-focus-border);
+  outline: 2px solid transparent;
+  box-shadow: 0 0 0 4px var(--zephyr-focus-ring-soft);
 }
 
 /* ============================================
@@ -970,8 +988,47 @@ button:focus-visible,
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0s !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+    scroll-behavior: auto !important;
   }
+
+  /* Disable decorative animations */
+  .conn-line-dash,
+  .conn-pulse-dot,
+  .sr-fill.sr-dashing,
+  .sr-turn.sr-spinning,
+  .scrolling-text,
+  #connections-empty svg {
+    animation: none !important;
+  }
+}
+
+/* ============================================
+   Transition System (PR4 4.5)
+   ============================================ */
+.form-control,
+.select-common,
+.dropdown-panel {
+  transition-property: color, background-color, border-color, box-shadow, opacity;
+  transition-duration: var(--zephyr-time-standard);
+  transition-timing-function: var(--zephyr-easing-ease-out);
+}
+
+.nav-button,
+.tab-button,
+.status-dot {
+  transition-property: color, background-color, border-color, box-shadow, opacity;
+  transition-duration: var(--zephyr-time-micro);
+  transition-timing-function: var(--zephyr-easing-ease-in);
+}
+
+[data-page],
+#modal-container {
+  transition-property: opacity, transform;
+  transition-duration: var(--zephyr-time-page);
+  transition-timing-function: var(--zephyr-easing-smooth);
 }
 
 /* ============================================

--- a/packages/tokens/src/primitive.json
+++ b/packages/tokens/src/primitive.json
@@ -12,6 +12,7 @@
     "cyan":   { "500": { "value": "#06b6d4" } },
     "indigo": { "400": { "value": "#818cf8" }, "500": { "value": "#6366f1" }, "600": { "value": "#4f46e5" } },
     "close-btn": { "value": "#ff5f57" },
+    "accent": { "value": "{color.purple.500}" },
     "zinc":   { "100": { "value": "#f4f4f5" }, "200": { "value": "#e4e4e7" }, "300": { "value": "#d4d4d8" }, "400": { "value": "#a1a1aa" }, "500": { "value": "#71717a" }, "600": { "value": "#52525b" } }
   },
   "space": {

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -41,6 +41,12 @@
     "download":  { "value": "{color.purple.500}", "lightValue": "{color.purple.600}" },
     "upload":    { "value": "{color.sky.400}",   "lightValue": "{color.blue.600}" }
   },
+  "focus": {
+    "color":           { "value": "{color.accent}" },
+    "ring-alpha":      { "value": "0.50", "lightValue": "0.70" },
+    "ring-soft-alpha": { "value": "0.30", "lightValue": "0.45" },
+    "border-alpha":    { "value": "0.50", "lightValue": "0.70" }
+  },
   "shadow": {
     "dialog": {
       "value": "inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 0 0 0.5px rgba(0, 0, 0, 0.2), 0 8px 40px rgba(0, 0, 0, 0.55)",


### PR DESCRIPTION
## PR4: A11y & Motion

### 4.1 Focus-visible
- semantic.json: focus tokens (kebab-case + lightValue)
- primitive.json: color.accent -> {color.purple.500}
- :root adapter with --accent-rgb + alpha fallbacks
- Global :where() :focus-visible (excludes tabindex=-1) with 2px outline
- Buttons (.btn + button + [role=button]) + Form + Select: box-shadow + outline transparent
- :not(:disabled):not([aria-disabled=true]) on all focus-visible + hover rules

### 4.2 Disabled
- Consolidated: native HTML (button/input/select/textarea) + .btn + .form-control + .select-common + [aria-disabled]
- opacity 0.4 + cursor not-allowed !important

### 4.3+4.4 Reduced Motion
- animation-delay + transition-delay: 0s + scroll-behavior: auto
- Decorative shutdown: .conn-* .sr-* .scrolling-text #connections-empty svg

### 4.5 Transition
- Standard: .form-control .select-common .dropdown-panel (old .form-control transition cleaned)
- .glass-card: keeps own transition
- .dropdown-item + [id$=-menu] button: keeps own dropdown transition
- Micro: .nav-button .tab-button .status-dot
- Page: [data-page] #modal-container
- Duration-only --zephyr-time-* tokens

### Verification
- 362 tests | ESLint | UnoCSS 622 | TypeScript | Style Dictionary

Cargo Deny (Rust) may fail — pre-existing.