### PR TITLE
feat: persist window size/position + fix Windows build + add Windows CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -393,3 +393,26 @@ jobs:
       - name: Check aarch64-apple-darwin
         working-directory: apps/desktop/src-tauri
         run: cargo check --target aarch64-apple-darwin
+
+  # ============================================================
+  # Job 12: Windows 编译检查（原生 Windows runner，编译 Windows 专属代码）
+  # ============================================================
+  # webview2-com、webview_recovery.rs 等 #[cfg(target_os = "windows")] 代码
+  # 在 Ubuntu CI 上完全不参与编译，导致 Windows 专属的编译错误无法被发现。
+  # 此 job 确保所有 Windows 平台条件编译的代码也能通过编译。
+  windows-build-check:
+    name: "Windows Build Check"
+    runs-on: windows-latest
+    needs: [rust-clippy, rust-fmt]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+      - name: Check x86_64-pc-windows-msvc
+        working-directory: apps/desktop/src-tauri
+        run: cargo check --target x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -5396,6 +5397,21 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.12.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.10"
 hex = "0.4"
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 regex = "1"
 tokio = { version = "1", features = ["time"] }
 uuid = { version = "1", features = ["v4"] }
@@ -84,9 +85,17 @@ windows-sys = { version = "0.59", features = [
 ] }
 winreg = "0.52"
 # webview2-com: direct dependency for ProcessFailed crash recovery.
-# MUST match the version in Cargo.lock (transitive via tauri → wry → webview2-com).
-# Re-check this version whenever Tauri is upgraded.
-webview2-com = "=0.39.1"
+#
+# PINNED to match the transitive dependency via tauri → wry → webview2-com.
+# webview2-com 0.39.x upgraded its `windows` crate dep from 0.61 → 0.62, which
+# is a breaking change — COM types from 0.39.x are incompatible with the 0.38.x
+# types returned by wry's controller. This causes E0277 trait bound errors.
+#
+# Do NOT bump this beyond what tauri/wry uses. When upgrading tauri, check
+# `cargo tree -i webview2-com` for the new version and update this pin to match.
+# Dependabot bumps for this crate should be closed (add to .github/dependabot.yml
+# ignore list if necessary).
+webview2-com = "=0.38.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS specific dependencies will be added as needed

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "core:resources:default",
     "core:app:default",
     "dialog:allow-message",
-    "notification:default"
+    "notification:default",
+    "window-state:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -42,12 +42,22 @@ use sys_proxy::{
 use tauri::Manager as _;
 #[cfg(desktop)]
 use tauri_plugin_autostart::Builder as AutostartBuilder;
+use tauri_plugin_window_state::WindowExt as _;
 use tray::{change_tray_icon, init_tray, update_tray_full_menu, TrayState};
 use updater::{
     get_latest_client_version, get_latest_client_versions, get_latest_version, update_client,
     update_core, update_geo_data,
 };
 use uwp_loopback::exempt_uwp_apps;
+
+/// Window state aspects to persist across sessions.
+///
+/// Excludes `FULLSCREEN` and `DECORATIONS` — the app uses custom frameless
+/// decorations (`decorations: false`) and does not support fullscreen mode.
+const WINDOW_STATE_FLAGS: tauri_plugin_window_state::StateFlags =
+    tauri_plugin_window_state::StateFlags::SIZE
+        .union(tauri_plugin_window_state::StateFlags::POSITION)
+        .union(tauri_plugin_window_state::StateFlags::MAXIMIZED);
 
 /// Rate limiter for Tauri commands
 pub struct RateLimiter {
@@ -990,7 +1000,7 @@ pub(crate) fn recreate_main_window(
             .min_inner_size(720.0, 540.0)
             .center()
             .decorations(false)
-            .visible(true)
+            .visible(false)
             .on_page_load(move |webview_window, payload| {
                 if payload.event() == tauri::webview::PageLoadEvent::Finished {
                     #[cfg(target_os = "windows")]
@@ -1015,7 +1025,12 @@ pub(crate) fn recreate_main_window(
     #[allow(clippy::shadow_reuse)]
     let window_builder = window_builder.transparent(true);
 
-    window_builder.build()
+    let window = window_builder.build()?;
+    // Restore saved window state (position, size, maximized) if available.
+    // Called while the window is still invisible to prevent a visual flash
+    // from the default position/size before the saved state is applied.
+    let _ = window.restore_state(WINDOW_STATE_FLAGS);
+    Ok(window)
 }
 
 /// Get current system proxy and core status for tray state determination
@@ -1204,7 +1219,12 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
-        .plugin(tauri_plugin_notification::init());
+        .plugin(tauri_plugin_notification::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(WINDOW_STATE_FLAGS)
+                .build(),
+        );
 
     // Single instance detection: only enabled in release builds.
     // In debug builds (pnpm run dev), multiple instances are allowed for testing.


### PR DESCRIPTION
## Summary

Three changes in one PR:

### 1. Window state persistence (all platforms)
Add 	auri-plugin-window-state to automatically save and restore the main window's size, position, and maximized state across application restarts.

- Uses StateFlags::SIZE | POSITION | MAXIMIZED (excludes FULLSCREEN and DECORATIONS since the app uses custom frameless decorations)
- ecreate_main_window creates window invisible, calls estore_state(), then lets caller show() it - prevents visual flash from default position before saved state is applied
- Adds window-state:default permission to capabilities

**Fixes:** Window size/position resets to default (860x620, centered) on every app launch.

### 2. Fix Windows compilation
Revert webview2-com from =0.39.1 to =0.38.2.

webview2-com 0.39.x upgraded its windows crate dependency from .61 to .62, which is a breaking change. COM types from .39.x are incompatible with the .38.x types returned by tauri/wry's controller, causing E0277 trait bound errors on Windows.

This was caused by Dependabot PR #755 which bumped the version without knowing about the pinning constraint. Added detailed comments explaining why this pin must match the tauri/wry transitive dependency.

### 3. Add Windows CI job
New windows-build-check job in security.yml runs on windows-latest to compile Windows-only code (webview2-com, webview_recovery.rs) that Ubuntu CI cannot catch.

This would have caught the webview2-com version mismatch before it was merged to main. Mirrors the existing macOS build check pattern.