### PR TITLE
fix(ui): light mode glass-card backdrop-filter and empty confirm modal block

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -434,16 +434,18 @@ html:not(.dark) #app-main-container {
 
 html:not(.dark) .glass-card {
   background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(20px) saturate(1.5);
-  -webkit-backdrop-filter: blur(20px) saturate(1.5);
   border-color: rgba(255, 255, 255, 0.6);
   box-shadow: 0 4px 16px -4px rgba(15, 23, 42, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 html:not(.dark) .glass-card:hover {
   background: rgba(255, 255, 255, 0.6);
   border-color: rgba(255, 255, 255, 0.8);
   box-shadow: 0 12px 24px -6px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 html:not(.dark) #setting-lang-menu {

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -248,10 +248,12 @@ export function showConfirmModal(title, message = '') {
 
          
         contentArea.innerHTML = '';
-        const msgDiv = document.createElement('div');
-        msgDiv.className = 'rounded-lg border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
-        msgDiv.textContent = message;
-        contentArea.appendChild(msgDiv);
+        if (message) {
+            const msgDiv = document.createElement('div');
+            msgDiv.className = 'rounded-lg border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
+            msgDiv.textContent = message;
+            contentArea.appendChild(msgDiv);
+        }
 
         // Focus trap: Tab cycles inside modal, Escape closes
         const trap = createFocusTrap(bg, { onEscape: () => close(false) });


### PR DESCRIPTION
## Summary

Two UI fixes for the desktop frontend:

### 1. Light mode `glass-card` appears too dark
**Root cause:** `backdrop-filter: blur(20px) saturate(1.5)` was applied to `.glass-card` in light mode. On a transparent Tauri window (`transparent: true`), this blurs the desktop background behind the card, making it visually darker than intended.

**Fix:** Set `backdrop-filter: none` and `-webkit-backdrop-filter: none` for both `html:not(.dark) .glass-card` and `html:not(.dark) .glass-card:hover`.

### 2. Empty amber block in confirmation modal
**Root cause:** `showConfirmModal()` always created a yellow warning block (`bg-amber-500/10`) even when the `message` parameter was an empty string (e.g., the backup import confirmation dialog).

**Fix:** Only render the amber message block when `message` is non-empty.

## Files changed
- `apps/desktop/src/styles.css` 鈥?disabled `backdrop-filter` in light mode `.glass-card`
- `apps/desktop/src/ui/notifications.js` 鈥?conditional rendering of confirm modal message block