### PR TITLE
feat: window state persistence, Windows build fix, CI, and UI fixes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -393,3 +393,26 @@ jobs:
       - name: Check aarch64-apple-darwin
         working-directory: apps/desktop/src-tauri
         run: cargo check --target aarch64-apple-darwin
+
+  # ============================================================
+  # Job 12: Windows 编译检查（原生 Windows runner，编译 Windows 专属代码）
+  # ============================================================
+  # webview2-com、webview_recovery.rs 等 #[cfg(target_os = "windows")] 代码
+  # 在 Ubuntu CI 上完全不参与编译，导致 Windows 专属的编译错误无法被发现。
+  # 此 job 确保所有 Windows 平台条件编译的代码也能通过编译。
+  windows-build-check:
+    name: "Windows Build Check"
+    runs-on: windows-latest
+    needs: [rust-clippy, rust-fmt]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+      - name: Check x86_64-pc-windows-msvc
+        working-directory: apps/desktop/src-tauri
+        run: cargo check --target x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -5396,6 +5397,21 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.12.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.10"
 hex = "0.4"
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 regex = "1"
 tokio = { version = "1", features = ["time"] }
 uuid = { version = "1", features = ["v4"] }
@@ -84,9 +85,17 @@ windows-sys = { version = "0.59", features = [
 ] }
 winreg = "0.52"
 # webview2-com: direct dependency for ProcessFailed crash recovery.
-# MUST match the version in Cargo.lock (transitive via tauri → wry → webview2-com).
-# Re-check this version whenever Tauri is upgraded.
-webview2-com = "=0.39.1"
+#
+# PINNED to match the transitive dependency via tauri → wry → webview2-com.
+# webview2-com 0.39.x upgraded its `windows` crate dep from 0.61 → 0.62, which
+# is a breaking change — COM types from 0.39.x are incompatible with the 0.38.x
+# types returned by wry's controller. This causes E0277 trait bound errors.
+#
+# Do NOT bump this beyond what tauri/wry uses. When upgrading tauri, check
+# `cargo tree -i webview2-com` for the new version and update this pin to match.
+# Dependabot bumps for this crate should be closed (add to .github/dependabot.yml
+# ignore list if necessary).
+webview2-com = "=0.38.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS specific dependencies will be added as needed

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "core:resources:default",
     "core:app:default",
     "dialog:allow-message",
-    "notification:default"
+    "notification:default",
+    "window-state:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -42,12 +42,22 @@ use sys_proxy::{
 use tauri::Manager as _;
 #[cfg(desktop)]
 use tauri_plugin_autostart::Builder as AutostartBuilder;
+use tauri_plugin_window_state::WindowExt as _;
 use tray::{change_tray_icon, init_tray, update_tray_full_menu, TrayState};
 use updater::{
     get_latest_client_version, get_latest_client_versions, get_latest_version, update_client,
     update_core, update_geo_data,
 };
 use uwp_loopback::exempt_uwp_apps;
+
+/// Window state aspects to persist across sessions.
+///
+/// Excludes `FULLSCREEN` and `DECORATIONS` — the app uses custom frameless
+/// decorations (`decorations: false`) and does not support fullscreen mode.
+const WINDOW_STATE_FLAGS: tauri_plugin_window_state::StateFlags =
+    tauri_plugin_window_state::StateFlags::SIZE
+        .union(tauri_plugin_window_state::StateFlags::POSITION)
+        .union(tauri_plugin_window_state::StateFlags::MAXIMIZED);
 
 /// Rate limiter for Tauri commands
 pub struct RateLimiter {
@@ -990,7 +1000,7 @@ pub(crate) fn recreate_main_window(
             .min_inner_size(720.0, 540.0)
             .center()
             .decorations(false)
-            .visible(true)
+            .visible(false)
             .on_page_load(move |webview_window, payload| {
                 if payload.event() == tauri::webview::PageLoadEvent::Finished {
                     #[cfg(target_os = "windows")]
@@ -1015,7 +1025,12 @@ pub(crate) fn recreate_main_window(
     #[allow(clippy::shadow_reuse)]
     let window_builder = window_builder.transparent(true);
 
-    window_builder.build()
+    let window = window_builder.build()?;
+    // Restore saved window state (position, size, maximized) if available.
+    // Called while the window is still invisible to prevent a visual flash
+    // from the default position/size before the saved state is applied.
+    let _ = window.restore_state(WINDOW_STATE_FLAGS);
+    Ok(window)
 }
 
 /// Get current system proxy and core status for tray state determination
@@ -1204,7 +1219,12 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
-        .plugin(tauri_plugin_notification::init());
+        .plugin(tauri_plugin_notification::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(WINDOW_STATE_FLAGS)
+                .build(),
+        );
 
     // Single instance detection: only enabled in release builds.
     // In debug builds (pnpm run dev), multiple instances are allowed for testing.

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -29,46 +29,39 @@
 
         <!-- Sidebar -->
         <nav id="sidebar-nav" class="w-20 flex flex-col items-center py-8 rounded-[var(--zephyr-radius-overlay)] gap-8 relative z-10 backdrop-blur-sm" aria-label="Main navigation">
-            <button type="button" data-nav="home" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-all duration-[var(--zephyr-time-standard)] bg-[var(--zephyr-bg-muted)] text-[var(--text-primary)] shadow-lg ring-1 ring-[var(--zephyr-border-strong)]" title="Home" aria-current="page">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <button type="button" data-nav="home" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-all duration-[var(--zephyr-time-standard)] bg-[var(--zephyr-bg-muted)] text-[var(--text-primary)] shadow-lg ring-1 ring-[var(--zephyr-border-strong)] is-active" title="Home" aria-current="page">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path class="p-draw" pathLength="1" d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path class="p-draw d2" pathLength="1" d="M9 22V12h6v10"/></svg>
                 <span class="sr-only" data-i18n="home">Home</span>
             </button>
-            <button type="button" data-nav="proxies" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Proxies">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+            <button type="button" data-nav="proxies" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Proxies">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path class="p-shaft" pathLength="1" d="M5 12h14"/><path class="p-head" d="m12 5 7 7-7 7"/></svg>
                 <span class="sr-only" data-i18n="proxies">Proxies</span>
             </button>
-            <button type="button" data-nav="subscriptions" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Subscriptions">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m3 15 2 2 4-4"/></svg>
+            <button type="button" data-nav="subscriptions" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Subscriptions">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path class="p-doc" d="M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4"/><path class="p-fold" d="M14 2v4a2 2 0 0 0 2 2h4"/><path class="p-check" pathLength="1" d="m3 15 2 2 4-4"/></svg>
                 <span class="sr-only" data-i18n="subscriptions">Subscriptions</span>
             </button>
-            <button type="button" data-nav="connections" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Connections">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                    <!-- Left node (client) -->
-                    <circle cx="5" cy="12" r="2.5"/>
-                    <!-- Right node (destination) -->
-                    <circle cx="19" cy="12" r="2.5"/>
-                    <!-- Connection line with activity wave -->
-                    <path d="M7.5 12h9" stroke-dasharray="3 3" class="conn-line-dash"/>
-                    <!-- Activity pulse dots on the line -->
-                    <circle cx="10.5" cy="12" r="0.8" fill="currentColor" class="conn-pulse-dot conn-dot-1"/>
-                    <circle cx="13.5" cy="12" r="0.8" fill="currentColor" class="conn-pulse-dot conn-dot-2"/>
+            <button type="button" data-nav="connections" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Connections">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <circle class="c-node" cx="5" cy="12" r="2.5"/>
+                    <circle class="c-node c-node-r" cx="19" cy="12" r="2.5"/>
+                    <path class="conn-line-dash" d="M7.5 12h9"/>
+                    <circle class="conn-pulse-dot conn-dot-1" cx="10.5" cy="12" r="0.8" fill="currentColor"/>
+                    <circle class="conn-pulse-dot conn-dot-2" cx="13.5" cy="12" r="0.8" fill="currentColor"/>
                 </svg>
                 <span class="sr-only" data-i18n="connections">Connections</span>
             </button>
-            <button type="button" data-nav="rule-library" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Rule Library">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
+            <button type="button" data-nav="rule-library" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Rule Library">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path class="p-draw p-book" pathLength="1" d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
                 <span class="sr-only" data-i18n="ruleLibrary">Rule Library</span>
             </button>
-            <button type="button" data-nav="logs" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Logs">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="4 17 10 11 4 5"/>
-                    <line x1="12" y1="19" x2="20" y2="19"/>
-                </svg>
+            <button type="button" data-nav="logs" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Logs">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path class="p-prompt" pathLength="1" d="m4 17 6-6-6-6"/><path class="p-cursor" d="M12 19h8"/></svg>
                 <span class="sr-only" data-i18n="logs">Logs</span>
             </button>
             <div class="flex-1"></div>
-            <button type="button" data-nav="settings" class="w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Settings">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            <button type="button" data-nav="settings" class="nav-btn w-12 h-12 flex items-center justify-center rounded-md cursor-pointer transition-colors duration-[var(--zephyr-time-standard)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--zephyr-bg-muted)]" title="Settings">
+                <svg class="w-6 h-6 icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><g class="gear"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></g></svg>
                 <span class="sr-only" data-i18n="settings">Settings</span>
             </button>
         </nav>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -434,16 +434,18 @@ html:not(.dark) #app-main-container {
 
 html:not(.dark) .glass-card {
   background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(20px) saturate(1.5);
-  -webkit-backdrop-filter: blur(20px) saturate(1.5);
   border-color: rgba(255, 255, 255, 0.6);
   box-shadow: 0 4px 16px -4px rgba(15, 23, 42, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 html:not(.dark) .glass-card:hover {
   background: rgba(255, 255, 255, 0.6);
   border-color: rgba(255, 255, 255, 0.8);
   box-shadow: 0 12px 24px -6px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 html:not(.dark) #setting-lang-menu {
@@ -474,7 +476,7 @@ html:not(.dark) #setting-lang-menu {
 /* Converges input-common / input-modal / input-mono / textarea-common into one system */
 .form-control {
   width: 100%;
-  border-radius: var(--zephyr-radius-control);
+  border-radius: var(--zephyr-radius-md);
   background-color: var(--zephyr-surface-input);
   color: var(--text-primary);
   border: 1px solid var(--zephyr-border-subtle);
@@ -722,6 +724,11 @@ html:not(.dark) .select-common::placeholder {
   color: var(--zephyr-text-tertiary);
 }
 
+/* Light mode focus border for form controls (matches original input-common/input-modal/textarea-common) */
+html:not(.dark) .form-control:focus {
+  border-color: var(--color-accent);
+}
+
 /* ============================================
    Connections Page Styles
    ============================================ */
@@ -773,67 +780,138 @@ html:not(.dark) .select-common::placeholder {
 }
 
 /* ============================================
-   Connections Nav Icon Animation
+   Sidebar — Luxury Micro-Animations
+   奢侈品级微动效系统（pathLength=1 零漂移描绘 + 触觉反馈 + 离场呼气）
    ============================================ */
 
-/* Dashed line subtle flow */
+/* —— 动效曲线 —— */
+:root {
+  --nav-glide: cubic-bezier(.22, 1, .36, 1);
+  --nav-spring: cubic-bezier(.34, 1.4, .64, 1);
+}
+
+/* —— 图标基底：按压触感 + 选中弹出 + 离场呼气 —— */
+.nav-btn .icon {
+  transition: transform .45s var(--nav-spring), filter .45s var(--nav-glide);
+}
+.nav-btn:active .icon {
+  transform: scale(.82);
+  transition-duration: .12s;
+}
+.nav-btn.is-active .icon {
+  animation: nav-icon-pop .6s var(--nav-spring);
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--color-accent) 40%, transparent));
+}
+@keyframes nav-icon-pop {
+  0% { transform: scale(.78); }
+  100% { transform: scale(1); }
+}
+.nav-btn.is-leaving .icon { animation: nav-icon-exhale .5s var(--nav-glide); }
+@keyframes nav-icon-exhale {
+  0% { transform: scale(1); }
+  45% { transform: scale(.84); }
+  100% { transform: scale(1); }
+}
+
+/* ============================================
+   Draw-On 引擎：pathLength=1 归一化，dashoffset 描绘（零漂移）
+   ============================================ */
+.p-draw, .p-shaft, .p-prompt, .p-check {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 0;
+}
+@keyframes nav-draw-on {
+  from { stroke-dashoffset: 1; }
+  to { stroke-dashoffset: 0; }
+}
+
+/* — 1. Home：屋顶先落笔，门后落笔（By-Layer 错峰） — */
+.is-active .p-draw { animation: nav-draw-on .55s var(--nav-glide) both; }
+.is-active .p-draw.d2 { animation: nav-draw-on .4s var(--nav-glide) .18s both; }
+
+/* — 2. Proxies：箭杆一笔到位 → 箭头以箭尖为轴弹性释放 — */
+.is-active .p-shaft { animation: nav-draw-on .32s var(--nav-glide) both; }
+.p-head { transform-box: fill-box; transform-origin: 100% 50%; }
+.is-active .p-head { animation: nav-arrow-release .55s var(--nav-spring) .2s both; }
+@keyframes nav-arrow-release {
+  from { transform: scaleX(.08); }
+  to { transform: scaleX(1); }
+}
+
+/* — 3. Subscriptions：折角翻开 → 对勾以墨色描绘（accent 着色） — */
+.p-fold { transform-box: fill-box; transform-origin: 0 0; }
+.is-active .p-fold { animation: nav-fold-flip .5s var(--nav-spring) .1s both; }
+@keyframes nav-fold-flip {
+  from { transform: scale(.2); opacity: .3; }
+  to { transform: scale(1); opacity: 1; }
+}
+.is-active .p-check { animation: nav-draw-on .45s var(--nav-glide) .3s both; stroke: var(--color-accent); }
+.p-check { transition: stroke .4s var(--nav-glide); }
+
+/* — 4. Connections：节点弹入 + 数据流（保留 conn-nav-paused 语义） — */
+.c-node { transform-box: fill-box; transform-origin: center; }
+.is-active .c-node { animation: nav-node-pop .5s var(--nav-spring) both; }
+.is-active .c-node-r { animation-delay: .09s; }
+@keyframes nav-node-pop {
+  from { transform: scale(.3); }
+  to { transform: scale(1); }
+}
 .conn-line-dash {
-  animation: dash-flow 2s linear infinite;
+  stroke-dasharray: 3 3;
+  animation: nav-conn-flow 1.2s linear infinite;
+  animation-play-state: paused;
 }
-
-@keyframes dash-flow {
-  to { stroke-dashoffset: -12; }
-}
-
-/* Pulse dots traveling along the connection line */
 .conn-pulse-dot {
-  animation: dot-travel 1.8s ease-in-out infinite;
-}
-
-.conn-dot-1 {
-  animation-delay: 0s;
-}
-
-.conn-dot-2 {
-  animation-delay: 0.9s;
-}
-
-@keyframes dot-travel {
-  0% {
-    opacity: 0.15;
-    transform: translateX(-1.5px);
-  }
-  30% {
-    opacity: 1;
-  }
-  70% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0.15;
-    transform: translateX(1.5px);
-  }
-}
-
-/* Pause animations when nav item is inactive (not selected) */
-[data-nav="connections"]:not([aria-current="page"]) .conn-line-dash,
-[data-nav="connections"]:not([aria-current="page"]) .conn-pulse-dot {
+  opacity: 0;
+  animation: nav-dot-pulse 1.2s ease-in-out infinite;
   animation-play-state: paused;
+  transition: fill .4s;
+}
+.conn-dot-2 { animation-delay: .6s; }
+.is-active .conn-pulse-dot { opacity: 1; fill: var(--color-accent); }
+.is-active:not(.conn-nav-paused) .conn-line-dash,
+.is-active:not(.conn-nav-paused) .conn-pulse-dot { animation-play-state: running; }
+@keyframes nav-conn-flow { to { stroke-dashoffset: -12; } }
+@keyframes nav-dot-pulse {
+  0%, 100% { opacity: .15; }
+  50% { opacity: 1; }
 }
 
-/* Pause animations when closed tab is selected (no live connections to show) */
-[data-nav="connections"].conn-nav-paused .conn-line-dash,
-[data-nav="connections"].conn-nav-paused .conn-pulse-dot {
-  animation-play-state: paused;
+/* — 5. Rule Library：整本书一笔勾勒，钢笔速写感 — */
+.is-active .p-book { animation: nav-draw-on .75s var(--nav-glide) both; }
+
+/* — 6. Logs：提示符描绘 + 光标绘入并呼吸闪烁 — */
+.is-active .p-prompt { animation: nav-draw-on .38s var(--nav-glide) both; }
+.p-cursor {
+  transform-box: fill-box;
+  transform-origin: 0 50%;
+  opacity: .45;
+  transition: opacity .4s var(--nav-glide), stroke .4s var(--nav-glide);
+}
+.is-active .p-cursor {
+  opacity: 1;
+  stroke: var(--color-accent);
+  animation: nav-cursor-in .3s var(--nav-glide) .28s both,
+             nav-cursor-blink 1.1s steps(1) .9s infinite;
+}
+@keyframes nav-cursor-in { from { transform: scaleX(0); } }
+@keyframes nav-cursor-blink {
+  0%, 55% { opacity: 1; }
+  56%, 100% { opacity: .15; }
 }
 
-/* Boost animation when active */
-[data-nav="connections"][aria-current="page"] .conn-pulse-dot {
-  animation-duration: 1.2s;
+/* — 7. Settings：表冠上弦——旋转 90° 过冲咬合 — */
+.gear { transform-box: fill-box; transform-origin: center; }
+.is-active .gear { animation: nav-gear-wind .8s var(--nav-spring) both; }
+@keyframes nav-gear-wind {
+  0% { transform: rotate(0); }
+  55% { transform: rotate(104deg); }
+  100% { transform: rotate(90deg); }
 }
-
-[data-nav="connections"][aria-current="page"] .conn-line-dash {
-  animation-duration: 1.2s;
+.is-leaving .gear { animation: nav-gear-unwind .5s var(--nav-glide) both; }
+@keyframes nav-gear-unwind {
+  from { transform: rotate(90deg); }
+  to { transform: rotate(0); }
 }
 
 /* ============================================
@@ -1014,6 +1092,9 @@ button:focus-visible:not(:disabled, [disabled]),
     /* Disable decorative animations */
   .conn-line-dash,
   .conn-pulse-dot,
+  .nav-btn .icon,
+  .p-draw, .p-shaft, .p-prompt, .p-check, .p-head, .p-fold, .p-book, .p-cursor,
+  .c-node, .gear,
   .scrolling-text,
   #connections-empty svg {
     animation: none !important;

--- a/apps/desktop/src/ui/3d-effect.js
+++ b/apps/desktop/src/ui/3d-effect.js
@@ -8,6 +8,9 @@
  * @module ui/3d-effect
  */
 
+/** Store leave-timeout IDs without polluting DOM element types. */
+const leaveTimeouts = new WeakMap();
+
 /**
  * Apply a 3D perspective hover effect to one or more elements.
  * Each element gets its own RAF-based update loop.
@@ -22,42 +25,51 @@ export function setup3DEffect(input) {
 
         /** @type {number|null} */
         let frameId = null;
+        /** Cached on mouseenter to avoid layout thrashing in RAF. */
+        /** @type {DOMRect | null} */
+        let cachedRect = null;
 
         const handleMouseMove = /** @param {MouseEvent} e */ (e) => {
+            // Capture mouse coords synchronously — accessing `e` inside RAF
+            // can yield stale values in some environments.
+            const clientX = e.clientX;
+            const clientY = e.clientY;
             if (frameId) cancelAnimationFrame(frameId);
             frameId = requestAnimationFrame(() => {
-                const rect = el.getBoundingClientRect();
-                const x = e.clientX - rect.left;
-                const y = e.clientY - rect.top;
+                if (!cachedRect) return;
+                const x = clientX - cachedRect.left - cachedRect.width / 2;
+                const y = clientY - cachedRect.top - cachedRect.height / 2;
 
-                const centerX = rect.width / 2;
-                const centerY = rect.height / 2;
-
-                const angleY = (x - centerX) / 40;
-                const angleX = (centerY - y) / 40;
-
-                el.style.transform = `perspective(1000px) rotateX(${angleX}deg) rotateY(${angleY}deg) translateY(-4px) scale(1.02)`;
-                el.style.zIndex = '10';
+                el.style.transform = `perspective(1000px) rotateX(${-y / 40}deg) rotateY(${x / 40}deg) translateY(-3px)`;
             });
         };
 
         const handleMouseEnter = () => {
+            const t = leaveTimeouts.get(el);
+            if (t) {
+                clearTimeout(t);
+                leaveTimeouts.delete(el);
+            }
+            // Cache rect once on enter — calling getBoundingClientRect()
+            // inside RAF would force synchronous reflow every frame.
+            cachedRect = el.getBoundingClientRect();
             el.style.willChange = 'transform';
-            el.style.transition = 'transform 0.15s ease-out';
-            el.style.transform = 'translateY(-2px) scale(1.01)';
-            el.style.zIndex = '10';
+            el.style.transition = 'transform .15s ease-out';
         };
 
         const handleMouseLeave = () => {
             if (frameId) cancelAnimationFrame(frameId);
-            el.style.transition = 'transform 0.3s ease-out';
-            el.style.transform = 'translateY(0) scale(1)';
-            setTimeout(() => {
-                el.style.zIndex = '1';
+            el.style.transition = 'transform .35s cubic-bezier(.22, 1, .36, 1)';
+            el.style.transform = '';
+            cachedRect = null;
+            const prev = leaveTimeouts.get(el);
+            if (prev) clearTimeout(prev);
+            const t = setTimeout(() => {
                 el.style.transition = '';
-                el.style.transform = '';
                 el.style.willChange = '';
-            }, 300);
+                leaveTimeouts.delete(el);
+            }, 350);
+            leaveTimeouts.set(el, t);
         };
 
         el.addEventListener('mouseenter', handleMouseEnter);

--- a/apps/desktop/src/ui/navigation.js
+++ b/apps/desktop/src/ui/navigation.js
@@ -31,6 +31,9 @@ export function switchPage(pageId) {
     });
 }
 
+/** Store leave-timeout IDs without polluting DOM element types. */
+const leaveTimeouts = new WeakMap();
+
 /**
  * Initialize sidebar navigation.
  * Sets up click handlers on [data-nav] items and applies 3D hover effects.
@@ -70,14 +73,31 @@ export function initNavigation(callbacks = {}) {
                 callbacks.onLeaveProxies();
             }
 
-            // Update nav item active styling
+            // Update nav item active styling — visual (UnoCSS) + animation (is-active/is-leaving)
+            const oldActive = document.querySelector('.nav-btn.is-active');
+            if (oldActive && oldActive !== item) {
+                oldActive.classList.add('is-leaving');
+                oldActive.classList.remove('is-active');
+                const prevTimer = leaveTimeouts.get(oldActive);
+                if (prevTimer) clearTimeout(prevTimer);
+                const timer = setTimeout(() => {
+                    oldActive.classList.remove('is-leaving');
+                    leaveTimeouts.delete(oldActive);
+                }, 500);
+                leaveTimeouts.set(oldActive, timer);
+            }
+            const itemTimer = leaveTimeouts.get(item);
+            if (itemTimer) {
+                clearTimeout(itemTimer);
+                leaveTimeouts.delete(item);
+            }
             navItems.forEach(i => {
                 i.classList.remove('bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
                 i.classList.add('text-[var(--text-muted)]');
                 i.removeAttribute('aria-current');
             });
-            item.classList.add('bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
-            item.classList.remove('text-[var(--text-muted)]');
+            item.classList.add('is-active', 'bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
+            item.classList.remove('text-[var(--text-muted)]', 'is-leaving');
             item.setAttribute('aria-current', 'page');
 
             // Switch page

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -248,10 +248,12 @@ export function showConfirmModal(title, message = '') {
 
          
         contentArea.innerHTML = '';
-        const msgDiv = document.createElement('div');
-        msgDiv.className = 'rounded-lg border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
-        msgDiv.textContent = message;
-        contentArea.appendChild(msgDiv);
+        if (message && message.trim()) {
+            const msgDiv = document.createElement('div');
+            msgDiv.className = 'rounded-lg border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm leading-6 text-[var(--text-primary)]';
+            msgDiv.textContent = message;
+            contentArea.appendChild(msgDiv);
+        }
 
         // Focus trap: Tab cycles inside modal, Escape closes
         const trap = createFocusTrap(bg, { onEscape: () => close(false) });

--- a/packages/tokens/build/css/variables.css
+++ b/packages/tokens/build/css/variables.css
@@ -171,6 +171,10 @@ html:not(.dark) {
   --zephyr-bg-input: rgba(255, 255, 255, 0.8);
   --zephyr-bg-elevated: #ffffff;
   --zephyr-bg-overlay: rgba(0, 0, 0, 0.25);
+  --zephyr-surface-raised: rgba(0, 0, 0, 0.04);
+  --zephyr-surface-elevated: #ffffff;
+  --zephyr-surface-input: rgba(255, 255, 255, 0.8);
+  --zephyr-surface-overlay: rgba(0, 0, 0, 0.25);
   --zephyr-border-primary: rgba(0, 0, 0, 0.15);
   --zephyr-border-subtle: rgba(30, 41, 59, 0.1);
   --zephyr-border-default: rgba(30, 41, 59, 0.14);

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -22,10 +22,10 @@
   },
   "surface": {
     "page":     { "value": "transparent" },
-    "raised":   { "value": "{bg.secondary}" },
-    "elevated": { "value": "{bg.elevated}" },
-    "input":    { "value": "{bg.input}" },
-    "overlay":  { "value": "{bg.overlay}" }
+    "raised":   { "value": "{bg.secondary}", "lightValue": "rgba(0, 0, 0, 0.04)" },
+    "elevated": { "value": "{bg.elevated}", "lightValue": "#ffffff" },
+    "input":    { "value": "{bg.input}", "lightValue": "rgba(255, 255, 255, 0.8)" },
+    "overlay":  { "value": "{bg.overlay}", "lightValue": "rgba(0, 0, 0, 0.25)" }
   },
   "border": {
     "primary": { "value": "hsla(0, 0%, 100%, 0.1)",       "lightValue": "rgba(0, 0, 0, 0.15)" },


### PR DESCRIPTION
## Summary

### 1. Window state persistence (tauri-plugin-window-state)
- Save and restore window size, position, and maximized state across sessions
- State restored while window is invisible to prevent visual flash

### 2. Windows build fix (webview2-com version pin)
- Pinned `webview2-com` and `webview2-com-sys` to `=0.38.2` to resolve COM type incompatibility

### 3. Windows CI check
- Added `windows-build-check` job to CI workflow

### 4. Surface token lightValue
- Added `lightValue` to surface semantic tokens for correct light mode rendering

### 5. Light mode glass-card backdrop-filter fix
- `backdrop-filter: blur(20px) saturate(1.5)` caused dark cards on transparent windows
- Replaced with `backdrop-filter: none` in light mode

### 6. Sidebar micro-animations
- Refined navigation animations, removed notch/glint effects

### 7. Confirm modal empty message block fix
- `showConfirmModal()` no longer renders empty amber block when message is empty

### 8. Race condition fixes (WeakMap-based)
- Navigation `is-leaving` timeout: rapid clicks no longer cut animation short
- 3D hover `mouseleave` timeout: rapid hover no longer causes jitter

### 9. 3D hover layout thrashing fix
- `getBoundingClientRect()` moved from RAF callback to `mouseenter` (cached)
- Mouse coords captured synchronously to avoid stale values in RAF

## Files changed (12)
- `.github/workflows/security.yml`, `Cargo.lock`
- `apps/desktop/src-tauri/Cargo.toml`, `src/lib.rs`, `capabilities/default.json`
- `apps/desktop/src/index.html`, `styles.css`
- `apps/desktop/src/ui/3d-effect.js`, `navigation.js`, `notifications.js`
- `packages/tokens/src/semantic.json`, `build/css/variables.css`