### PR TITLE
test: add Golden (snapshot) tests with insta for format-stable outputs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -360,6 +360,21 @@ jobs:
         working-directory: apps/desktop/src-tauri
         run: cargo test --release
 
+      - name: Verify Golden test snapshots are committed
+        working-directory: apps/desktop/src-tauri
+        run: |
+          # Generate any missing snapshots, then check if any .snap files are new/untracked.
+          # If so, they need to be committed to the repo.
+          INSTA_UPDATE=always cargo test --release 2>&1 | tail -5
+          if git diff --exit-code -- '*.snap' || git ls-files --others --exclude-standard -- '*.snap' | grep -q .; then
+            echo "::error::Golden test snapshots are missing or outdated."
+            echo "::error::The following .snap files need to be committed:"
+            git diff --name-only -- '*.snap'
+            git ls-files --others --exclude-standard -- '*.snap'
+            exit 1
+          fi
+          echo "All snapshot files are committed and up to date."
+
       - name: Run frontend tests
         run: pnpm --filter @zephyr/desktop test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "glib 0.22.7",
  "hex",
  "hmac 0.12.1",
+ "insta",
  "libc",
  "minisign",
  "mockall",
@@ -985,6 +986,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1531,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2749,6 +2767,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "regex",
+ "similar",
+ "strip-ansi-escapes",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,7 +3640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4953,6 +4985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,6 +5112,15 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -6425,6 +6472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7648,6 +7704,7 @@ dependencies = [
  "clash-prism-core",
  "clash-prism-smart",
  "dashmap",
+ "insta",
  "rand 0.9.4",
  "regex",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -111,6 +111,7 @@ arboard = { version = "3.3", features = ["wayland-data-control"] }
 [dev-dependencies]
 mockall = "0.15"
 tempfile = "3.14"
+insta = { version = "1", features = ["filters"] }
 
 [lints]
 # rustc native lints

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -2321,4 +2321,38 @@ mod tests {
             get_core_version_with_io(&mock, std::path::Path::new("/usr/bin/mihomo")).unwrap();
         assert_eq!(result, "v1.18.0-alpha.1");
     }
+
+    // -- Snapshot tests for version parsing --------------------------------
+
+    #[test]
+    fn snapshot_parse_version_standard() {
+        insta::assert_snapshot!(parse_version_output("mihomo v1.18.0 linux amd64"));
+    }
+
+    #[test]
+    fn snapshot_parse_version_alpha() {
+        insta::assert_snapshot!(parse_version_output("mihomo v1.18.0-alpha.1 (linux amd64)"));
+    }
+
+    #[test]
+    fn snapshot_parse_version_no_prefix() {
+        insta::assert_snapshot!(parse_version_output("1.18.0"));
+    }
+
+    #[test]
+    fn snapshot_parse_version_empty() {
+        insta::assert_snapshot!(parse_version_output(""));
+    }
+
+    // -- Property test for secret generation -------------------------------
+
+    #[test]
+    fn generate_secret_is_32_alphanumeric() {
+        let secret = generate_secret();
+        assert_eq!(secret.len(), 32, "secret must be exactly 32 characters");
+        assert!(
+            secret.chars().all(|c| c.is_ascii_alphanumeric()),
+            "secret must be alphanumeric: {secret}"
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/core/fetch_util.rs
+++ b/apps/desktop/src-tauri/src/core/fetch_util.rs
@@ -399,4 +399,21 @@ mod tests {
             Err(_) => unreachable!("http://example.com:8080 should be valid"),
         }
     }
+
+    // -- Snapshot tests for host:port formatting ---------------------------
+
+    #[test]
+    fn snapshot_format_host_port_ipv4() {
+        insta::assert_snapshot!(format_host_port("example.com", 443));
+    }
+
+    #[test]
+    fn snapshot_format_host_port_ipv6_loopback() {
+        insta::assert_snapshot!(format_host_port("::1", 80));
+    }
+
+    #[test]
+    fn snapshot_format_host_port_ipv6_full() {
+        insta::assert_snapshot!(format_host_port("2001:db8::1", 443));
+    }
 }

--- a/apps/desktop/src-tauri/src/core/network_optim.rs
+++ b/apps/desktop/src-tauri/src/core/network_optim.rs
@@ -38,7 +38,7 @@ fn get_optim_level() -> OptimLevel {
 
 // -- Linux config --
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 #[derive(Debug, Clone)]
 struct LinuxTcpOptimConfig {
     tcp_fastopen: u32,
@@ -50,7 +50,7 @@ struct LinuxTcpOptimConfig {
     tcp_notsent_lowat: u64,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 impl LinuxTcpOptimConfig {
     const fn conservative() -> Self {
         Self {
@@ -97,6 +97,7 @@ impl LinuxTcpOptimConfig {
     }
 
     /// sysctl key names used for backup / restore validation.
+    #[allow(dead_code)]
     const BACKUP_KEYS: &[&str] = &[
         "net.ipv4.tcp_fastopen",
         "net.ipv4.tcp_ecn",
@@ -312,7 +313,7 @@ pub fn apply_network_optimizations(app: AppHandle) -> Result<(), String> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn generate_linux_optim_script(cfg: &LinuxTcpOptimConfig) -> String {
     format!(
         r#"set -e
@@ -1080,3 +1081,7 @@ pub fn check_network_optimizations_status(_app: AppHandle) -> Result<NetworkOpti
 
     Ok(NetworkOptimStatus { applied, details })
 }
+
+#[cfg(test)]
+#[path = "network_optim_tests.rs"]
+mod network_optim_tests;

--- a/apps/desktop/src-tauri/src/core/network_optim_tests.rs
+++ b/apps/desktop/src-tauri/src/core/network_optim_tests.rs
@@ -1,0 +1,46 @@
+// ===========================================================================
+// network_optim_tests.rs — Golden (snapshot) tests for Linux TCP optimization
+// ===========================================================================
+//
+// Tests `generate_linux_optim_script` which produces a 40+ line bash script
+// for Linux TCP performance tuning via sysctl. The script is executed with
+// root privileges (pkexec) and writes to /etc/sysctl.d/, making correctness
+// critical.
+//
+// Three optimization levels are tested:
+//   - Conservative: minimal buffer increases, TFO=1
+//   - Balanced (default): moderate buffers, TFO=3
+//   - Aggressive: large buffers, TFO=3
+//
+// This file is included from core/network_optim.rs via:
+//   #[cfg(test)]
+//   #[path = "network_optim_tests.rs"]
+//   mod network_optim_tests;
+
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::super::{generate_linux_optim_script, LinuxTcpOptimConfig, OptimLevel};
+
+    #[test]
+    fn conservative_script() {
+        let cfg = LinuxTcpOptimConfig::from_level(OptimLevel::Conservative);
+        insta::assert_snapshot!(generate_linux_optim_script(&cfg));
+    }
+
+    #[test]
+    fn balanced_script() {
+        let cfg = LinuxTcpOptimConfig::from_level(OptimLevel::Balanced);
+        insta::assert_snapshot!(generate_linux_optim_script(&cfg));
+    }
+
+    #[test]
+    fn aggressive_script() {
+        let cfg = LinuxTcpOptimConfig::from_level(OptimLevel::Aggressive);
+        insta::assert_snapshot!(generate_linux_optim_script(&cfg));
+    }
+}

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -231,4 +231,26 @@ mod tests {
         assert_eq!(result.url, "https://example.com/config.yaml");
         assert_eq!(result.name, "test");
     }
+
+    // -- Snapshot tests for name sanitization ------------------------------
+
+    #[test]
+    fn snapshot_sanitize_name_normal() {
+        insta::assert_snapshot!(sanitize_name("My Subscription"));
+    }
+
+    #[test]
+    fn snapshot_sanitize_name_path_traversal() {
+        insta::assert_snapshot!(sanitize_name("../../../etc/passwd"));
+    }
+
+    #[test]
+    fn snapshot_sanitize_name_dangerous_chars() {
+        insta::assert_snapshot!(sanitize_name("test<>:\"|?*\\0"));
+    }
+
+    #[test]
+    fn snapshot_sanitize_name_long_name() {
+        insta::assert_snapshot!(sanitize_name(&"A".repeat(200)));
+    }
 }

--- a/apps/desktop/src-tauri/src/os_notification.rs
+++ b/apps/desktop/src-tauri/src/os_notification.rs
@@ -32,3 +32,7 @@ fn truncate_str(s: &str, max_len: usize) -> String {
         format!("{truncated}...")
     }
 }
+
+#[cfg(test)]
+#[path = "os_notification_tests.rs"]
+mod os_notification_tests;

--- a/apps/desktop/src-tauri/src/os_notification_tests.rs
+++ b/apps/desktop/src-tauri/src/os_notification_tests.rs
@@ -1,0 +1,51 @@
+// ===========================================================================
+// os_notification_tests.rs — Golden (snapshot) tests for notification utils
+// ===========================================================================
+//
+// Tests `truncate_str` which truncates strings to a max character count,
+// appending "..." if truncation occurs.
+//
+// This file is included from os_notification.rs via:
+//   #[cfg(test)]
+//   #[path = "os_notification_tests.rs"]
+//   mod os_notification_tests;
+
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::super::truncate_str;
+
+    #[test]
+    fn no_truncation_needed() {
+        insta::assert_snapshot!(truncate_str("Hello", 10));
+    }
+
+    #[test]
+    fn exact_length() {
+        insta::assert_snapshot!(truncate_str("Hello", 5));
+    }
+
+    #[test]
+    fn truncate_short() {
+        insta::assert_snapshot!(truncate_str("Hello World", 8));
+    }
+
+    #[test]
+    fn truncate_unicode() {
+        insta::assert_snapshot!(truncate_str("你好世界Hello", 6));
+    }
+
+    #[test]
+    fn truncate_to_zero() {
+        insta::assert_snapshot!(truncate_str("Hello", 0));
+    }
+
+    #[test]
+    fn empty_string() {
+        insta::assert_snapshot!(truncate_str("", 10));
+    }
+}

--- a/apps/desktop/src-tauri/src/prism/overrides/overrides_model.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides/overrides_model.rs
@@ -132,3 +132,7 @@ pub struct LogEntry {
     pub level: String,
     pub message: String,
 }
+
+#[cfg(test)]
+#[path = "overrides_model_tests.rs"]
+mod overrides_model_tests;

--- a/apps/desktop/src-tauri/src/prism/overrides/overrides_model_tests.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides/overrides_model_tests.rs
@@ -1,0 +1,56 @@
+// ===========================================================================
+// overrides_model_tests.rs — Golden (snapshot) tests for override filenames
+// ===========================================================================
+//
+// Tests the filename generation methods on `OverrideItem`:
+//   - content_filename:  `{id}.{ext}`
+//   - log_filename:      `{id}.log.json`
+//   - patch_filename:    `override_{id}.prism.yaml`
+//
+// This file is included from prism/overrides/overrides_model.rs via:
+//   #[cfg(test)]
+//   #[path = "overrides_model_tests.rs"]
+//   mod overrides_model_tests;
+
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::super::{OverrideExt, OverrideItem, OverrideType};
+
+    fn make_item(id: &str, ext: OverrideExt) -> OverrideItem {
+        OverrideItem {
+            id: id.to_owned(),
+            name: "test".to_owned(),
+            r#type: OverrideType::Local,
+            ext,
+            enabled: true,
+            global: true,
+            profile_ids: Vec::new(),
+            url: None,
+            order: 0,
+            updated_at: None,
+            created_at: 0,
+            last_success: None,
+        }
+    }
+
+    #[test]
+    fn js_filenames() {
+        let item = make_item("abc123", OverrideExt::Js);
+        insta::assert_snapshot!("js_content", item.content_filename());
+        insta::assert_snapshot!("js_log", item.log_filename());
+        insta::assert_snapshot!("js_patch", item.patch_filename());
+    }
+
+    #[test]
+    fn prism_yaml_filenames() {
+        let item = make_item("xyz789", OverrideExt::PrismYaml);
+        insta::assert_snapshot!("yaml_content", item.content_filename());
+        insta::assert_snapshot!("yaml_log", item.log_filename());
+        insta::assert_snapshot!("yaml_patch", item.patch_filename());
+    }
+}

--- a/apps/desktop/src-tauri/src/prism/overrides_commands.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands.rs
@@ -1107,3 +1107,7 @@ pub fn override_import(state: State<PrismState>, json: String) -> Result<u32, St
     // Batch import: single metadata lock, then best-effort content writes
     overrides_store::import_items_batch(&state, items_to_import)
 }
+
+#[cfg(test)]
+#[path = "overrides_commands_tests.rs"]
+mod overrides_commands_tests;

--- a/apps/desktop/src-tauri/src/prism/overrides_commands_tests.rs
+++ b/apps/desktop/src-tauri/src/prism/overrides_commands_tests.rs
@@ -1,0 +1,32 @@
+// ===========================================================================
+// overrides_commands_tests.rs — Golden (snapshot) tests for override templates
+// ===========================================================================
+//
+// Tests `default_template_content` which returns the default template
+// for JavaScript and PrismYaml override scripts. These templates are
+// shown to users when creating new overrides, so format correctness matters.
+//
+// This file is included from prism/overrides_commands.rs via:
+//   #[cfg(test)]
+//   #[path = "overrides_commands_tests.rs"]
+//   mod overrides_commands_tests;
+
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::super::{default_template_content, OverrideExt};
+
+    #[test]
+    fn js_template() {
+        insta::assert_snapshot!(default_template_content(OverrideExt::Js));
+    }
+
+    #[test]
+    fn prism_yaml_template() {
+        insta::assert_snapshot!(default_template_content(OverrideExt::PrismYaml));
+    }
+}

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -248,6 +248,33 @@ fn show_or_recreate_window(app: &AppHandle) {
     crate::show_or_recreate_main_window(app);
 }
 
+/// Format proxy environment variables for the given shell format and port.
+///
+/// Linux/macOS shells export both lowercase and uppercase proxy variables
+/// for maximum CLI tool compatibility (curl/wget read lowercase, Go reads uppercase).
+/// Windows shells (cmd/powershell/nushell) are case-insensitive, so only one set is needed.
+#[must_use]
+pub(crate) fn format_proxy_env(format: &str, port: u16) -> String {
+    let proxy = format!("http://127.0.0.1:{port}");
+    match format {
+        "fish" => format!(
+            "set -x http_proxy {proxy}; set -x https_proxy {proxy}; set -x all_proxy {proxy}; set -x HTTP_PROXY {proxy}; set -x HTTPS_PROXY {proxy}; set -x ALL_PROXY {proxy}"
+        ),
+        "cmd" => format!(
+            "set http_proxy={proxy}\r\nset https_proxy={proxy}\r\nset all_proxy={proxy}"
+        ),
+        "powershell" => format!(
+            "$env:HTTP_PROXY=\"{proxy}\"; $env:HTTPS_PROXY=\"{proxy}\"; $env:ALL_PROXY=\"{proxy}\""
+        ),
+        "nushell" => format!(
+            "$env.HTTP_PROXY = \"{proxy}\"; $env.HTTPS_PROXY = \"{proxy}\"; $env.ALL_PROXY = \"{proxy}\""
+        ),
+        _ => format!(
+            "export http_proxy={proxy} https_proxy={proxy} all_proxy={proxy} HTTP_PROXY={proxy} HTTPS_PROXY={proxy} ALL_PROXY={proxy}"
+        ),
+    }
+}
+
 /// Copy proxy environment variables to clipboard.
 /// Used by the tray "Copy Proxy Env" menu item.
 /// Handles clipboard write directly in Rust — on Linux, `WebKit2GTK`
@@ -272,24 +299,7 @@ fn copy_proxy_env_to_clipboard(app: &AppHandle) -> Result<(), String> {
         .last_proxy_port()
         .unwrap_or(DEFAULT_MIXED_PORT);
 
-    let proxy = format!("http://127.0.0.1:{port}");
-    let text = match format.as_str() {
-        "fish" => format!(
-            "set -x http_proxy {proxy}; set -x https_proxy {proxy}; set -x all_proxy {proxy}; set -x HTTP_PROXY {proxy}; set -x HTTPS_PROXY {proxy}; set -x ALL_PROXY {proxy}"
-        ),
-        "cmd" => format!(
-            "set http_proxy={proxy}\r\nset https_proxy={proxy}\r\nset all_proxy={proxy}"
-        ),
-        "powershell" => format!(
-            "$env:HTTP_PROXY=\"{proxy}\"; $env:HTTPS_PROXY=\"{proxy}\"; $env:ALL_PROXY=\"{proxy}\""
-        ),
-        "nushell" => format!(
-            "$env.HTTP_PROXY = \"{proxy}\"; $env.HTTPS_PROXY = \"{proxy}\"; $env.ALL_PROXY = \"{proxy}\""
-        ),
-        _ => format!(
-            "export http_proxy={proxy} https_proxy={proxy} all_proxy={proxy} HTTP_PROXY={proxy} HTTPS_PROXY={proxy} ALL_PROXY={proxy}"
-        ),
-    };
+    let text = format_proxy_env(&format, port);
 
     // Write to clipboard using arboard (cross-platform)
     let mut cb = arboard::Clipboard::new().map_err(|e| format!("Clipboard access failed: {e}"))?;
@@ -789,3 +799,7 @@ fn rebuild_tray_menu_from_state(app: &AppHandle) {
         let _ = tray.set_menu(Some(m));
     }
 }
+
+#[cfg(test)]
+#[path = "tray_tests.rs"]
+mod tray_tests;

--- a/apps/desktop/src-tauri/src/tray_tests.rs
+++ b/apps/desktop/src-tauri/src/tray_tests.rs
@@ -1,0 +1,60 @@
+// ===========================================================================
+// tray_tests.rs — Golden (snapshot) tests for tray proxy-env formatting
+// ===========================================================================
+//
+// Tests the pure function `format_proxy_env` which generates shell-specific
+// proxy environment variable export commands for 5 shell formats:
+//   - bash (default, with lowercase + uppercase for Linux/macOS compat)
+//   - fish (with lowercase + uppercase)
+//   - cmd (Windows, case-insensitive — single set only)
+//   - powershell (Windows, case-insensitive — single set only)
+//   - nushell (Windows, case-insensitive — single set only)
+//
+// This file is included from tray.rs via:
+//   #[cfg(test)]
+//   #[path = "tray_tests.rs"]
+//   mod tray_tests;
+
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::super::format_proxy_env;
+
+    // ========================================================================
+    // Shell format snapshot tests
+    // ========================================================================
+
+    #[test]
+    fn format_proxy_env_bash() {
+        insta::assert_snapshot!(format_proxy_env("bash", 7890));
+    }
+
+    #[test]
+    fn format_proxy_env_bash_default_port() {
+        insta::assert_snapshot!(format_proxy_env("unknown", 7890));
+    }
+
+    #[test]
+    fn format_proxy_env_fish() {
+        insta::assert_snapshot!(format_proxy_env("fish", 7890));
+    }
+
+    #[test]
+    fn format_proxy_env_cmd() {
+        insta::assert_snapshot!(format_proxy_env("cmd", 7890));
+    }
+
+    #[test]
+    fn format_proxy_env_powershell() {
+        insta::assert_snapshot!(format_proxy_env("powershell", 7890));
+    }
+
+    #[test]
+    fn format_proxy_env_nushell() {
+        insta::assert_snapshot!(format_proxy_env("nushell", 7890));
+    }
+}

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -2062,4 +2062,22 @@ mod tests {
         let first = digests.first().unwrap();
         assert_eq!(first.0, "mihomo-windows-amd64-v3-v1.19.28.zip");
     }
+
+    // -- Snapshot tests for URL formatting ---------------------------------
+
+    #[test]
+    fn snapshot_build_asset_download_url() {
+        insta::assert_snapshot!(build_asset_download_url(
+            "v1.18.0",
+            "mihomo-linux-amd64-v1.18.0.gz"
+        ));
+    }
+
+    #[test]
+    fn snapshot_build_asset_download_url_windows() {
+        insta::assert_snapshot!(build_asset_download_url(
+            "v1.19.28",
+            "mihomo-windows-amd64-v3-v1.19.28.zip"
+        ));
+    }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,3 +28,6 @@ clash-prism-smart = "0.1.1"
 default = []
 uniffi = ["dep:uniffi"]
 tokio-async = ["tokio"]
+
+[dev-dependencies]
+insta = { version = "1", features = ["filters"] }

--- a/crates/core/src/config/merge.rs
+++ b/crates/core/src/config/merge.rs
@@ -336,4 +336,26 @@ mod tests {
         let result = mask_url("https://example.com/path".to_owned());
         assert!(result.starts_with("https://"));
     }
+
+    // -- Snapshot tests for URL masking -----------------------------------
+
+    #[test]
+    fn snapshot_mask_url_https() {
+        insta::assert_snapshot!(mask_url("https://example.com/path?token=abc".to_owned()));
+    }
+
+    #[test]
+    fn snapshot_mask_url_http_long_host() {
+        insta::assert_snapshot!(mask_url("http://subdomain.example.com/path".to_owned()));
+    }
+
+    #[test]
+    fn snapshot_mask_url_short_host() {
+        insta::assert_snapshot!(mask_url("https://ab.co/path".to_owned()));
+    }
+
+    #[test]
+    fn snapshot_mask_url_invalid() {
+        insta::assert_snapshot!(mask_url("not-a-url".to_owned()));
+    }
 }

--- a/crates/core/src/config/subscription.rs
+++ b/crates/core/src/config/subscription.rs
@@ -538,4 +538,57 @@ mod tests {
         );
         assert_eq!(parse_content_disposition_filename("no filename here"), None);
     }
+
+    // -- Snapshot tests for subscription content processing ----------------
+
+    #[test]
+    fn snapshot_quote_short_id_simple() {
+        insta::assert_snapshot!(quote_short_id_values("short-id: abc123"));
+    }
+
+    #[test]
+    fn snapshot_quote_short_id_hex_like() {
+        insta::assert_snapshot!(quote_short_id_values("short-id: 34010e92"));
+    }
+
+    #[test]
+    fn snapshot_quote_short_id_multiple() {
+        insta::assert_snapshot!(quote_short_id_values(
+            "proxies:\n  short-id: abc123\n  name: test\n  short-id: def456"
+        ));
+    }
+
+    #[test]
+    fn snapshot_percent_decode_ascii() {
+        insta::assert_snapshot!(percent_decode("hello%20world"));
+    }
+
+    #[test]
+    fn snapshot_percent_decode_utf8() {
+        insta::assert_snapshot!(percent_decode("%E4%B8%AD%E6%96%87"));
+    }
+
+    #[test]
+    fn snapshot_percent_decode_no_encoding() {
+        insta::assert_snapshot!(percent_decode("plain text"));
+    }
+
+    #[test]
+    fn snapshot_redact_url_in_string_single() {
+        insta::assert_snapshot!(redact_url_in_string(
+            "Fetching config from https://example.com/sub?token=secret123".to_owned()
+        ));
+    }
+
+    #[test]
+    fn snapshot_redact_url_in_string_multiple() {
+        insta::assert_snapshot!(redact_url_in_string(
+            "First http://a.com/config then https://b.com/sub2 done".to_owned()
+        ));
+    }
+
+    #[test]
+    fn snapshot_redact_url_in_string_no_url() {
+        insta::assert_snapshot!(redact_url_in_string("Just a plain message".to_owned()));
+    }
 }

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -328,4 +328,48 @@ mod tests {
         assert!(redacted.contains("[CORE_DIR]"));
         assert!(!redacted.contains("/home/user/.config/zephyr/core"));
     }
+
+    // -- Snapshot tests for error redaction --------------------------------
+
+    #[test]
+    fn snapshot_redact_core_dir() {
+        let _ = REDACT_PATHS.set((
+            "/home/user/.config/zephyr/core".to_owned(),
+            "/home/user/.config/zephyr/profiles".to_owned(),
+        ));
+        insta::assert_snapshot!(redact_error_message(
+            "Failed to read /home/user/.config/zephyr/core/run_config.yaml"
+        ));
+    }
+
+    #[test]
+    fn snapshot_redact_profiles_dir() {
+        let _ = REDACT_PATHS.set((
+            "/home/user/.config/zephyr/core".to_owned(),
+            "/home/user/.config/zephyr/profiles".to_owned(),
+        ));
+        insta::assert_snapshot!(redact_error_message(
+            "Error loading /home/user/.config/zephyr/profiles/default.yaml: permission denied"
+        ));
+    }
+
+    #[test]
+    fn snapshot_redact_both_dirs() {
+        let _ = REDACT_PATHS.set((
+            "/home/user/.config/zephyr/core".to_owned(),
+            "/home/user/.config/zephyr/profiles".to_owned(),
+        ));
+        insta::assert_snapshot!(redact_error_message(
+            "Core at /home/user/.config/zephyr/core failed; profiles at /home/user/.config/zephyr/profiles also failed"
+        ));
+    }
+
+    #[test]
+    fn snapshot_redact_no_match() {
+        let _ = REDACT_PATHS.set((
+            "/home/user/.config/zephyr/core".to_owned(),
+            "/home/user/.config/zephyr/profiles".to_owned(),
+        ));
+        insta::assert_snapshot!(redact_error_message("An unrelated error occurred"));
+    }
 }

--- a/crates/core/src/process.rs
+++ b/crates/core/src/process.rs
@@ -645,4 +645,30 @@ mod tests {
         assert!(port >= 59090);
         assert!(port < 59190);
     }
+
+    // -- Snapshot tests for version parsing --------------------------------
+
+    #[test]
+    fn snapshot_parse_version_standard() {
+        insta::assert_snapshot!(parse_version_output(
+            "Mihomo v1.18.0 abc123 linux/amd64".to_owned()
+        ));
+    }
+
+    #[test]
+    fn snapshot_parse_version_alpha() {
+        insta::assert_snapshot!(parse_version_output(
+            "mihomo v1.18.0-alpha.1 (linux amd64)".to_owned()
+        ));
+    }
+
+    #[test]
+    fn snapshot_parse_version_no_v_prefix() {
+        insta::assert_snapshot!(parse_version_output("1.18.0".to_owned()));
+    }
+
+    #[test]
+    fn snapshot_parse_version_empty() {
+        insta::assert_snapshot!(parse_version_output("".to_owned()));
+    }
 }

--- a/crates/core/src/updater.rs
+++ b/crates/core/src/updater.rs
@@ -381,4 +381,30 @@ mod tests {
             "https://github.com/MetaCubeX/mihomo/releases/download/v1.18.0/mihomo-linux-amd64.gz"
         );
     }
+
+    // -- Snapshot tests ----------------------------------------------------
+
+    #[test]
+    fn snapshot_build_asset_url_linux() {
+        insta::assert_snapshot!(build_asset_download_url(
+            "v1.18.0",
+            "mihomo-linux-amd64-v1.18.0.gz"
+        ));
+    }
+
+    #[test]
+    fn snapshot_build_asset_url_windows() {
+        insta::assert_snapshot!(build_asset_download_url(
+            "v1.19.28",
+            "mihomo-windows-amd64-v3-v1.19.28.zip"
+        ));
+    }
+
+    #[test]
+    fn snapshot_build_asset_url_arm64() {
+        insta::assert_snapshot!(build_asset_download_url(
+            "v1.20.1",
+            "mihomo-darwin-arm64-v1.20.1.gz"
+        ));
+    }
 }


### PR DESCRIPTION
## Overview

Adds Golden (snapshot) tests using the [insta](https://insta.rs) crate to lock down all format-stable string outputs across the codebase. This prevents silent regressions in generated scripts, URLs, filenames, and redaction logic.

## What is Golden Testing?

Golden tests (aka snapshot tests) capture a function's output as a "golden master" file (.snap). On every CI run, the output is compared byte-for-byte against the master. Any change 鈥?intentional or not 鈥?causes a test failure, forcing the developer to review and accept the diff via cargo insta review.

## Changes

### Dependencies
- Added insta = { version = "1", features = ["filters"] } as a dev-dependency to both pps/desktop/src-tauri/Cargo.toml and crates/core/Cargo.toml.

### Desktop crate (pps/desktop/src-tauri)
| File | Function | Why |
|------|----------|-----|
| 	ray_tests.rs (new) | ormat_proxy_env | 5 shell formats (bash/fish/cmd/powershell/nushell) 鈥?refactored into a pure function for testability |
| 
etwork_optim_tests.rs (new) | generate_linux_optim_script | 40+ line root-executed sysctl script 鈥?#[cfg(any(target_os = "linux", test))] to enable cross-platform testing |
| os_notification_tests.rs (new) | 	runcate_str | String truncation with Unicode edge cases |
| overrides_commands_tests.rs (new) | default_template_content | JS/PrismYaml override templates shown to users |
| overrides_model_tests.rs (new) | content_filename / log_filename / patch_filename | Override file naming convention |
| updater.rs (inline) | uild_asset_download_url | mihomo release URL construction |
| core_process.rs (inline) | parse_version_output + generate_secret property test | Version string parsing + secret format validation |
| deep_link.rs (inline) | sanitize_name | Path traversal / dangerous char sanitization |
| etch_util.rs (inline) | ormat_host_port | IPv4/IPv6 host:port formatting |

### Core crate (crates/core)
| File | Function | Why |
|------|----------|-----|
| config/merge.rs (inline) | mask_url | URL masking for safe display (token redaction) |
| config/subscription.rs (inline) | quote_short_id_values, percent_decode, edact_url_in_string | YAML sanitization, URL decoding, URL redaction in log strings |
| event.rs (inline) | edact_error_message | Sensitive path redaction (CORE_DIR / PROFILES_DIR) |
| updater.rs (inline) | uild_asset_download_url | Core-level URL construction |
| process.rs (inline) | parse_version_output | Version string parsing |

### Refactoring
- 	ray.rs: Extracted ormat_proxy_env() as a pure pub(crate) function from copy_proxy_env_to_clipboard() for testability.
- 
etwork_optim.rs: Changed #[cfg(target_os = "linux")] to #[cfg(any(target_os = "linux", test))] for LinuxTcpOptimConfig and generate_linux_optim_script to enable testing on non-Linux platforms.

### CI Integration
- security.yml uild-verification job: Added "Verify Golden test snapshots are committed" step that:
  1. Runs INSTA_UPDATE=always cargo test --release to generate any missing .snap files
  2. Checks git diff and git ls-files --others for uncommitted .snap files
  3. Fails with a clear error message if snapshots are missing or outdated

## Testing Convention

This PR follows the existing project convention:
- New test files use the #[cfg(test)] #[path = "..."] mod xxx_tests; pattern (consistent with prism_tests.rs, smart_state_tests.rs)
- Inline snapshot tests are added to existing mod tests blocks where the function already has tests
- All test files use #[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing, clippy::panic)] consistent with prism_tests.rs

## Note

Snapshot .snap files will be auto-generated on the first CI run. The "Verify Golden test snapshots are committed" step will fail on the first run, indicating which .snap files need to be committed. These files will then be added in a follow-up commit.