### PR TITLE
feat(ci): integrate SignPath release-signing into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -420,6 +421,77 @@ jobs:
           touch portable/.portable
           ARCH_SUFFIX="${{ matrix.arch }}"
           cd portable && tar czf ../dist-artifacts/Zephyr-linux-${ARCH_SUFFIX}-portable.tar.gz . && cd ..
+        shell: bash
+
+      # ── Code signing (SignPath) for Windows artifacts ──
+      # Signs NSIS installers (.exe) and MSI packages (.msi) with the
+      # release-signing policy.  Runs for both x64 and arm64 Windows builds.
+      # Reference: the verified test-signing workflow (.github/workflows/test-signing.yml).
+      - name: Stage unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        run: |
+          mkdir -p unsigned-staging
+          # All four Windows artifacts are expected from the build steps above.
+          # Fail immediately if any is missing rather than silently staging a subset.
+          EXPECTED=(
+            "dist-artifacts/*-setup-full.exe"
+            "dist-artifacts/*-setup-lite.exe"
+            "dist-artifacts/*-full.msi"
+            "dist-artifacts/*-lite.msi"
+          )
+          for pattern in "${EXPECTED[@]}"; do
+            files=( $pattern )
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "ERROR: Expected artifact not found: $pattern"
+              exit 1
+            fi
+            cp "${files[@]}" unsigned-staging/
+          done
+          echo "Staged $(ls -1 unsigned-staging/ | wc -l) files for code signing:"
+          ls -la unsigned-staging/
+        shell: bash
+
+      - name: Upload unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        id: upload-unsigned-windows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zephyr-unsigned-windows-${{ matrix.arch }}
+          path: unsigned-staging/*
+          if-no-files-found: error
+
+      - name: Sign Windows artifacts with SignPath
+        if: matrix.platform == 'windows-latest'
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
+          project-slug: 'Zephyr'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: './signed-windows'
+
+      - name: Replace unsigned artifacts with signed ones
+        if: matrix.platform == 'windows-latest'
+        run: |
+          echo "Signed artifacts from SignPath:"
+          ls -la ./signed-windows/
+          # Verify every staged file has a signed counterpart, then replace.
+          # This prevents partial signing from leaving unsigned binaries in dist-artifacts.
+          for unsigned in unsigned-staging/*; do
+            name="$(basename "$unsigned")"
+            signed="./signed-windows/$name"
+            if [ ! -f "$signed" ]; then
+              echo "ERROR: Missing signed artifact: $name"
+              exit 1
+            fi
+            cp -f "$signed" "dist-artifacts/$name"
+          done
+          # Clean up staging directories
+          rm -rf unsigned-staging signed-windows
+          echo "Final Windows artifacts in dist-artifacts:"
+          ls -la dist-artifacts/*.exe dist-artifacts/*.msi 2>/dev/null || true
         shell: bash
 
       # ── Minisign: sign all release artifacts ──

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -42,7 +42,7 @@ jobs:
             apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
 
       - name: Sign with SignPath
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'


### PR DESCRIPTION
## Summary

Integrate SignPath's `release-signing` policy into the release workflow for Windows artifacts (both x64 and arm64).

## Changes

Add 4 steps to `.github/workflows/release.yml` that run **after all Windows artifacts are collected** and **before Minisign signing**:

| Step | Purpose |
|---|---|
| **Stage unsigned** | Copy NSIS installers (`.exe`) and MSI packages (`.msi`) 鈥?Full + Lite 鈥?into a staging directory; fail if none found |
| **Upload artifact** | Upload staged files as a GitHub artifact (`zephyr-unsigned-windows-${{ matrix.arch }}`) |
| **Sign with SignPath** | Submit signing request via `signpath/github-action-submit-signing-request@v2` with the `release-signing` policy, wait for completion |
| **Replace** | Overwrite unsigned files in `dist-artifacts/` with signed ones; clean up staging dirs |

Also adds `actions: read` permission (required by SignPath to download the uploaded artifact).

## Design decisions

- **Reuses the verified test-signing implementation**: same action version (`@v2`), org ID, project slug as `.github/workflows/test-signing.yml` 鈥?only the policy slug changes from `test-signing` 鈫?`release-signing`.
- **Signing scope per `CODE_SIGNING_POLICY.md`**: only NSIS `.exe` + MSI `.msi` (x64 & arm64). Portable ZIP is excluded.
- **Signing before Minisign**: ensures Minisign generates integrity signatures over the final code-signed binaries.
- **Both architectures covered**: `if: matrix.platform == 'windows-latest'` matches both x64 and arm64 matrix entries automatically.
- **Fail-safe**: no artifacts 鈫?`exit 1`; signing failure 鈫?workflow aborts; unsigned binaries never reach the release.

## Release flow (updated)

`
Build Full -> Collect
Build Lite -> Collect
Build Portable -> Package ZIP
       |
[NEW] Stage -> Upload -> SignPath sign -> Replace   <- Windows only
       |
Minisign (signs the code-signed binaries)
       |
Upload to GitHub Release (draft)
`

## Prerequisites

- `SIGNPATH_API_TOKEN` secret already exists (used by test-signing workflow).
- Each release requires **manual approval** on SignPath (1 approval required). The CI will wait at `wait-for-completion: true` until approved.

## Test plan

- [ ] Merge to `main`, tag a prerelease, verify:
  - [ ] SignPath receives the signing request for both x64 and arm64
  - [ ] After approval, signed `.exe`/`.msi` appear in the GitHub Release
  - [ ] `Get-AuthenticodeSignature` shows **Valid** / **SignPath Foundation**
  - [ ] Minisign `.minisig` files are also present