### PR TITLE
feat(ci): integrate SignPath release-signing into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -420,6 +421,83 @@ jobs:
           touch portable/.portable
           ARCH_SUFFIX="${{ matrix.arch }}"
           cd portable && tar czf ../dist-artifacts/Zephyr-linux-${ARCH_SUFFIX}-portable.tar.gz . && cd ..
+        shell: bash
+
+      # ── Code signing (SignPath) for Windows artifacts ──
+      # Signs NSIS installers (.exe) and MSI packages (.msi) with the
+      # release-signing policy.  Runs for both x64 and arm64 Windows builds.
+      # Reference: the verified test-signing workflow (.github/workflows/test-signing.yml).
+      - name: Stage unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        run: |
+          mkdir -p unsigned-staging
+          # All four Windows artifacts are expected from the build steps above.
+          # Fail immediately if any is missing or if multiple matches are found.
+          shopt -s nullglob
+          EXPECTED=(
+            "dist-artifacts/*-setup-full.exe"
+            "dist-artifacts/*-setup-lite.exe"
+            "dist-artifacts/*-full.msi"
+            "dist-artifacts/*-lite.msi"
+          )
+          for pattern in "${EXPECTED[@]}"; do
+            files=( $pattern )
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "ERROR: Expected artifact not found: $pattern"
+              exit 1
+            fi
+            if [ ${#files[@]} -gt 1 ]; then
+              echo "ERROR: Multiple files matched pattern: $pattern"
+              printf 'Matches:\n%s\n' "${files[@]}"
+              exit 1
+            fi
+            cp "${files[0]}" unsigned-staging/
+          done
+          echo "Staged $(ls -1 unsigned-staging/ | wc -l) files for code signing:"
+          ls -la unsigned-staging/
+        shell: bash
+
+      - name: Upload unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        id: upload-unsigned-windows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zephyr-unsigned-windows-${{ matrix.arch }}
+          path: unsigned-staging/*
+          if-no-files-found: error
+
+      - name: Sign Windows artifacts with SignPath
+        if: matrix.platform == 'windows-latest'
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
+          project-slug: 'Zephyr'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: './signed-windows'
+
+      - name: Replace unsigned artifacts with signed ones
+        if: matrix.platform == 'windows-latest'
+        run: |
+          echo "Signed artifacts from SignPath:"
+          ls -la ./signed-windows/
+          # Verify every staged file has a signed counterpart, then replace.
+          # This prevents partial signing from leaving unsigned binaries in dist-artifacts.
+          for unsigned in unsigned-staging/*; do
+            name="$(basename "$unsigned")"
+            signed="./signed-windows/$name"
+            if [ ! -f "$signed" ]; then
+              echo "ERROR: Missing signed artifact: $name"
+              exit 1
+            fi
+            cp -f "$signed" "dist-artifacts/$name"
+          done
+          # Clean up staging directories
+          rm -rf unsigned-staging signed-windows
+          echo "Final Windows artifacts in dist-artifacts:"
+          ls -la dist-artifacts/*.exe dist-artifacts/*.msi 2>/dev/null || true
         shell: bash
 
       # ── Minisign: sign all release artifacts ──

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -42,7 +42,7 @@ jobs:
             apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
 
       - name: Sign with SignPath
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'


### PR DESCRIPTION
## Summary

Integrate SignPath's `release-signing` policy into the release workflow for Windows artifacts (both x64 and arm64).

## Changes

### 1. Permissions

``yaml
permissions:
  contents: write   # create GitHub Release
  actions: read     # SignPath downloads artifact
  actions: write    # upload-artifact needs write
``

### 2. SignPath code signing steps (Windows only, x64 + arm64)

Added **after** all Windows artifacts are collected (Full + Lite + Portable) and **before** Minisign:

| Step | Purpose |
|---|---|
| **Stage unsigned** | Copy all 4 expected Windows artifacts into staging. Uses `shopt -s nullglob` + enforces **exactly 1 match per pattern** (fails on 0 or >1). |
| **Upload artifact** | Upload staged files as GitHub artifact for SignPath to download |
| **Sign with SignPath** | Submit signing request with `release-signing` policy, wait for completion |
| **Replace** | **Verify every staged file has a signed counterpart**, then replace. Fails if any signed file is missing. |

### 3. Pin all third-party actions to full commit SHAs

| Action | SHA | Tag |
|---|---|---|
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
| `signpath/github-action-submit-signing-request` | `b9d91eadd323de506c0c81cf0c7fe7438f3360fd` | v2 |

Also pinned in `test-signing.yml` for consistency.

## Design decisions

- **Reuses the verified test-signing implementation**: same action version, org ID, project slug
- **Signing scope per `CODE_SIGNING_POLICY.md`**: only NSIS `.exe` + MSI `.msi` (x64 & arm64)
- **Signing before Minisign**: ensures Minisign generates integrity signatures over the final code-signed binaries
- **Fail-safe staging**: `nullglob` + single-match enforcement 鈥?all 4 expected artifacts must exist, no duplicates
- **Fail-safe replacement**: iterates over staged files, requires signed counterpart for each
- **Both architectures covered**: `if: matrix.platform == 'windows-latest'` matches both x64 and arm64

## Release flow (updated)

`
Build Full -> Collect
Build Lite -> Collect
Build Portable -> Package ZIP
       |
[NEW] Stage (nullglob + single-match) -> Upload -> SignPath sign -> Verify+Replace   <- Windows only
       |
Minisign (signs the code-signed binaries)
       |
Upload to GitHub Release (draft)
`

## Prerequisites

- `SIGNPATH_API_TOKEN` secret already exists (used by test-signing workflow)
- Each release requires **manual approval** on SignPath (1 approval required)

## Review responses (round 2)

Addressed findings from Qodo, CodeRabbit, LlamaPReview:
- **Qodo/CodeRabbit (nullglob)**: Added `shopt -s nullglob` before glob expansion 鈥?without it, unmatched globs become literal strings and the missing-artifact check never fires
- **Qodo/LlamaPReview (single-match)**: Added ` -gt 1` check 鈥?each pattern must match exactly 1 file, prevents duplicate artifacts from being staged
- **LlamaPReview P1 (actions: write)**: Added `actions: write` permission 鈥?`actions/upload-artifact` requires write access; explicit `permissions` block overrides defaults
- **CodeRabbit (Authenticode gate)**: Not implemented 鈥?`Get-AuthenticodeSignature` requires PowerShell and SignPath-returned files are already signed; this would be redundant verification of a trusted service's output