### PR TITLE
feat(ci): integrate SignPath release-signing into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -420,6 +421,83 @@ jobs:
           touch portable/.portable
           ARCH_SUFFIX="${{ matrix.arch }}"
           cd portable && tar czf ../dist-artifacts/Zephyr-linux-${ARCH_SUFFIX}-portable.tar.gz . && cd ..
+        shell: bash
+
+      # ── Code signing (SignPath) for Windows artifacts ──
+      # Signs NSIS installers (.exe) and MSI packages (.msi) with the
+      # release-signing policy.  Runs for both x64 and arm64 Windows builds.
+      # Reference: the verified test-signing workflow (.github/workflows/test-signing.yml).
+      - name: Stage unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        run: |
+          mkdir -p unsigned-staging
+          # All four Windows artifacts are expected from the build steps above.
+          # Fail immediately if any is missing or if multiple matches are found.
+          shopt -s nullglob
+          EXPECTED=(
+            "dist-artifacts/*-setup-full.exe"
+            "dist-artifacts/*-setup-lite.exe"
+            "dist-artifacts/*-full.msi"
+            "dist-artifacts/*-lite.msi"
+          )
+          for pattern in "${EXPECTED[@]}"; do
+            files=( $pattern )
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "ERROR: Expected artifact not found: $pattern"
+              exit 1
+            fi
+            if [ ${#files[@]} -gt 1 ]; then
+              echo "ERROR: Multiple files matched pattern: $pattern"
+              printf 'Matches:\n%s\n' "${files[@]}"
+              exit 1
+            fi
+            cp "${files[0]}" unsigned-staging/
+          done
+          echo "Staged $(ls -1 unsigned-staging/ | wc -l) files for code signing:"
+          ls -la unsigned-staging/
+        shell: bash
+
+      - name: Upload unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        id: upload-unsigned-windows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zephyr-unsigned-windows-${{ matrix.arch }}
+          path: unsigned-staging/*
+          if-no-files-found: error
+
+      - name: Sign Windows artifacts with SignPath
+        if: matrix.platform == 'windows-latest'
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
+          project-slug: 'Zephyr'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: './signed-windows'
+
+      - name: Replace unsigned artifacts with signed ones
+        if: matrix.platform == 'windows-latest'
+        run: |
+          echo "Signed artifacts from SignPath:"
+          ls -la ./signed-windows/
+          # Verify every staged file has a signed counterpart, then replace.
+          # This prevents partial signing from leaving unsigned binaries in dist-artifacts.
+          for unsigned in unsigned-staging/*; do
+            name="$(basename "$unsigned")"
+            signed="./signed-windows/$name"
+            if [ ! -f "$signed" ]; then
+              echo "ERROR: Missing signed artifact: $name"
+              exit 1
+            fi
+            cp -f "$signed" "dist-artifacts/$name"
+          done
+          # Clean up staging directories
+          rm -rf unsigned-staging signed-windows
+          echo "Final Windows artifacts in dist-artifacts:"
+          ls -la dist-artifacts/*.exe dist-artifacts/*.msi 2>/dev/null || true
         shell: bash
 
       # ── Minisign: sign all release artifacts ──

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload unsigned artifact
         id: upload-unsigned
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: zephyr-unsigned
           path: |
@@ -42,7 +42,7 @@ jobs:
             apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
 
       - name: Sign with SignPath
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
@@ -53,7 +53,7 @@ jobs:
           output-artifact-directory: './signed'
 
       - name: Upload signed artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: zephyr-signed
           path: ./signed/*

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -12,8 +12,8 @@ Zephyr is maintained by [Juwan Hwang](https://github.com/Juwan-Hwang), who acts 
 
 Only the official Windows release artifacts are signed:
 
-- NSIS installer (`Zephyr_*_x64-setup.exe`, `Zephyr_*_arm64-setup.exe`)
-- MSI package (`Zephyr_*_x64_*.msi`, `Zephyr_*_arm64_*.msi`)
+- NSIS installer (`Zephyr_*_x64-setup-full.exe`, `Zephyr_*_arm64-setup-full.exe`, `Zephyr_*_x64-setup-lite.exe`, `Zephyr_*_arm64-setup-lite.exe`)
+- MSI package (`Zephyr_*_x64-full.msi`, `Zephyr_*_arm64-full.msi`, `Zephyr_*_x64-lite.msi`, `Zephyr_*_arm64-lite.msi`)
 
 Artifacts are built by GitHub Actions directly from the source in this repository and submitted to SignPath from that workflow only.
 
@@ -26,7 +26,7 @@ This program will not transfer any information to other networked systems unless
 On Windows, check the signature with PowerShell:
 
 ```powershell
-Get-AuthenticodeSignature .\Zephyr_*_setup.exe
+Get-AuthenticodeSignature .\Zephyr_*_setup-*.exe
 ```
 
 The status must be **Valid** and the signer **SignPath Foundation**. You can also right-click the file → Properties → Digital Signatures.


### PR DESCRIPTION
## Summary

Integrate SignPath's `release-signing` policy into the release workflow for Windows artifacts (both x64 and arm64).

## Changes

### 1. Permissions

``yaml
permissions:
  contents: write   # create GitHub Release + upload-artifact
  actions: write    # SignPath downloads artifact + upload-artifact needs write
``

`actions: write` subsumes `actions: read`, so only one entry is needed.

### 2. SignPath code signing steps (Windows only, x64 + arm64)

Added **after** all Windows artifacts are collected (Full + Lite + Portable) and **before** Minisign:

| Step | Purpose |
|---|---|
| **Stage unsigned** | Copy all 4 expected Windows artifacts into staging. Uses `shopt -s nullglob` + enforces **exactly 1 match per pattern** (fails on 0 or >1). |
| **Upload artifact** | Upload staged files as GitHub artifact for SignPath to download |
| **Sign with SignPath** | Submit signing request with `release-signing` policy, wait for completion |
| **Replace** | **Verify every staged file has a signed counterpart**, then replace. Fails if any signed file is missing. |

### 3. Pin all third-party actions to full commit SHAs

| Action | SHA | Tag |
|---|---|---|
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
| `signpath/github-action-submit-signing-request` | `b9d91eadd323de506c0c81cf0c7fe7438f3360fd` | v2 |

Also pinned in `test-signing.yml` for consistency.

## Design decisions

- **Reuses the verified test-signing implementation**: same action version, org ID, project slug
- **Signing scope per `CODE_SIGNING_POLICY.md`**: only NSIS `.exe` + MSI `.msi` (x64 & arm64)
- **Signing before Minisign**: ensures Minisign generates integrity signatures over the final code-signed binaries
- **Fail-safe staging**: `nullglob` + single-match enforcement
- **Fail-safe replacement**: iterates over staged files, requires signed counterpart for each
- **Both architectures covered**: `if: matrix.platform == 'windows-latest'` matches both x64 and arm64

## Prerequisites

- `SIGNPATH_API_TOKEN` secret already exists (used by test-signing workflow)
- Each release requires **manual approval** on SignPath (1 approval required)

## Review responses (round 3)

- **CodeRabbit/Qodo (duplicate actions key)**: Removed duplicate `actions: read` 鈥?`actions: write` subsumes read access. actionlint/YAMLlint confirmed duplicate key was invalid.