### PR TITLE
feat(ci): integrate SignPath release-signing into release workflow for Windows x64+arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -421,6 +422,94 @@ jobs:
           ARCH_SUFFIX="${{ matrix.arch }}"
           cd portable && tar czf ../dist-artifacts/Zephyr-linux-${ARCH_SUFFIX}-portable.tar.gz . && cd ..
         shell: bash
+
+      # ── Code signing (SignPath) for Windows artifacts ──
+      # Signs NSIS installers (.exe) and MSI packages (.msi) with the
+      # release-signing policy.  Runs for both x64 and arm64 Windows builds.
+      # Reference: the verified test-signing workflow (.github/workflows/test-signing.yml).
+      - name: Stage unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        run: |
+          mkdir -p unsigned-staging
+          # All four Windows artifacts are expected from the build steps above.
+          # Fail immediately if any is missing or if multiple matches are found.
+          shopt -s nullglob
+          EXPECTED=(
+            "dist-artifacts/*-setup-full.exe"
+            "dist-artifacts/*-setup-lite.exe"
+            "dist-artifacts/*-full.msi"
+            "dist-artifacts/*-lite.msi"
+          )
+          for pattern in "${EXPECTED[@]}"; do
+            files=( $pattern )
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "ERROR: Expected artifact not found: $pattern"
+              exit 1
+            fi
+            if [ ${#files[@]} -gt 1 ]; then
+              echo "ERROR: Multiple files matched pattern: $pattern"
+              printf 'Matches:\n%s\n' "${files[@]}"
+              exit 1
+            fi
+            cp "${files[0]}" unsigned-staging/
+          done
+          echo "Staged $(ls -1 unsigned-staging/ | wc -l) files for code signing:"
+          ls -la unsigned-staging/
+        shell: bash
+
+      - name: Upload unsigned Windows artifacts for signing
+        if: matrix.platform == 'windows-latest'
+        id: upload-unsigned-windows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zephyr-unsigned-windows-${{ matrix.arch }}
+          path: unsigned-staging/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Sign Windows artifacts with SignPath
+        if: matrix.platform == 'windows-latest'
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
+          project-slug: 'Zephyr'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: './signed-windows'
+
+      - name: Verify and replace unsigned artifacts with signed ones
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          Write-Host "Signed artifacts from SignPath:"
+          Get-ChildItem ./signed-windows/ | Format-Table Name, Length
+          # Verify every staged file has a signed counterpart with a valid
+          # Authenticode signature from SignPath Foundation, then replace.
+          # This prevents partial/failed signing from leaving unsigned binaries.
+          foreach ($unsigned in (Get-ChildItem unsigned-staging)) {
+            $signed = Join-Path ./signed-windows $unsigned.Name
+            if (-not (Test-Path $signed)) {
+              Write-Error "Missing signed artifact: $($unsigned.Name)"
+              exit 1
+            }
+            $sig = Get-AuthenticodeSignature $signed
+            if ($sig.Status -ne 'Valid') {
+              Write-Error "Invalid signature for $($unsigned.Name): $($sig.Status)"
+              exit 1
+            }
+            if ($sig.SignerCertificate.Subject -notmatch 'CN=SignPath Foundation(,|$)') {
+              Write-Error "Unexpected signer for $($unsigned.Name): $($sig.SignerCertificate.Subject)"
+              exit 1
+            }
+            Write-Host "[OK] $($unsigned.Name): Valid signature by SignPath Foundation"
+            Copy-Item -Force $signed "dist-artifacts/$($unsigned.Name)"
+          }
+          # Clean up staging directories
+          Remove-Item -Recurse -Force unsigned-staging, signed-windows
+          Write-Host "Final Windows artifacts in dist-artifacts:"
+          Get-ChildItem dist-artifacts/*.exe, dist-artifacts/*.msi -ErrorAction SilentlyContinue | Format-Table Name, Length
 
       # ── Minisign: sign all release artifacts ──
       - name: Install minisign

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload unsigned artifact
         id: upload-unsigned
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: zephyr-unsigned
           path: |
@@ -42,7 +42,7 @@ jobs:
             apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
 
       - name: Sign with SignPath
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: '480cc228-d09e-4d18-b654-4917b96a0611'
@@ -53,7 +53,7 @@ jobs:
           output-artifact-directory: './signed'
 
       - name: Upload signed artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: zephyr-signed
           path: ./signed/*

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -12,8 +12,8 @@ Zephyr is maintained by [Juwan Hwang](https://github.com/Juwan-Hwang), who acts 
 
 Only the official Windows release artifacts are signed:
 
-- NSIS installer (`Zephyr_*_x64-setup.exe`, `Zephyr_*_arm64-setup.exe`)
-- MSI package (`Zephyr_*_x64_*.msi`, `Zephyr_*_arm64_*.msi`)
+- NSIS installer (`Zephyr_*_x64-setup-full.exe`, `Zephyr_*_arm64-setup-full.exe`, `Zephyr_*_x64-setup-lite.exe`, `Zephyr_*_arm64-setup-lite.exe`)
+- MSI package (`Zephyr_*_x64-full.msi`, `Zephyr_*_arm64-full.msi`, `Zephyr_*_x64-lite.msi`, `Zephyr_*_arm64-lite.msi`)
 
 Artifacts are built by GitHub Actions directly from the source in this repository and submitted to SignPath from that workflow only.
 
@@ -26,7 +26,7 @@ This program will not transfer any information to other networked systems unless
 On Windows, check the signature with PowerShell:
 
 ```powershell
-Get-AuthenticodeSignature .\Zephyr_*_setup.exe
+Get-ChildItem .\Zephyr_*.exe, .\Zephyr_*.msi -ErrorAction SilentlyContinue | Get-AuthenticodeSignature
 ```
 
 The status must be **Valid** and the signer **SignPath Foundation**. You can also right-click the file → Properties → Digital Signatures.


### PR DESCRIPTION
## Summary

Integrates formal SignPath code signing into the release build workflow for all Windows artifacts (x64 + arm64).

### Changes
- **`.github/workflows/release.yml`**: Added staging, upload, SignPath signing, and signed-artifact replacement steps. Unsigned artifacts are staged with fail-safe single-match enforcement (`shopt -s nullglob`). Pinned `actions/upload-artifact` and `signpath/github-action-submit-signing-request` to full commit SHAs.
- **`.github/workflows/test-signing.yml`**: Pinned `actions/upload-artifact` to full commit SHA for supply-chain consistency.
- **`CODE_SIGNING_POLICY.md`**: Updated signed artifact patterns to reflect Full/Lite naming.

### Artifacts signed
- NSIS: `*-setup-full.exe`, `*-setup-lite.exe`
- MSI: `*-full.msi`, `*-lite.msi`

Both x64 and arm64 architectures.