### PR TITLE
fix(ci): explicitly install Rust cross-compilation targets via rustup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,8 +197,10 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ (matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin') || (matrix.target == 'aarch64-pc-windows-msvc' && 'aarch64-pc-windows-msvc') || '' }}
+
+      - name: Add Rust cross-compilation target
+        if: matrix.target != ''
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'


### PR DESCRIPTION
## Summary

Fixes cross-compilation target installation failure that broke macOS x64 and Windows arm64 builds in v2.4.1 release.

### Root cause
`dtolnay/rust-toolchain@stable` with comma-separated `targets` parameter no longer reliably installs multiple targets. The `@stable` tag is a floating reference whose internal behavior changed since v2.4.0.

### Fix
Remove the `targets` parameter from `dtolnay/rust-toolchain@stable` and add an explicit `rustup target add ${{ matrix.target }}` step guarded by `if: matrix.target != ''`.

Each matrix job installs only the single target it needs:
- macOS arm64 鈫?`aarch64-apple-darwin`
- macOS x64 鈫?`x86_64-apple-darwin`
- Windows arm64 鈫?`aarch64-pc-windows-msvc`
- Windows x64 / Ubuntu 鈫?skipped (native target)