### PR TITLE
fix(ci): explicitly install Rust cross-compilation targets via rustup

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -11,8 +11,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Add Rust cross-compilation targets
+        run: rustup target add aarch64-linux-android x86_64-linux-android
 
       - name: Install cargo-ndk & uniffi-bindgen
         run: |
@@ -80,8 +81,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Add Rust cross-compilation targets
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
       - name: Install uniffi-bindgen
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,8 +197,13 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ (matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin') || (matrix.target == 'aarch64-pc-windows-msvc' && 'aarch64-pc-windows-msvc') || '' }}
+
+      - name: Add Rust cross-compilation target
+        if: matrix.target != ''
+        shell: bash
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+        run: rustup target add "$RUST_TARGET"
 
       - name: Install dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'


### PR DESCRIPTION
## Summary

Fixes cross-compilation target installation failure that broke macOS x64 and Windows arm64 builds in v2.4.1 release.

### Root cause
`dtolnay/rust-toolchain@stable` with comma-separated `targets` parameter no longer reliably installs multiple targets. The `@stable` tag is a floating reference whose internal behavior changed since v2.4.0.

### Fix
Remove the `targets` parameter from `dtolnay/rust-toolchain@stable` and add explicit `rustup target add` steps in:
- **`release.yml`**: guarded by `if: matrix.target != ''`, uses env var to avoid template injection
- **`mobile.yml`**: Android job installs `aarch64-linux-android x86_64-linux-android`, iOS job installs `aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`

`security.yml` and `test-badges.yml` use a commit-SHA-pinned version of the action (`@e97e2d8cc...`), which is not affected by the floating tag issue.