### PR TITLE
fix(ci): pin rust-toolchain to SHA and install targets via rustup

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -10,9 +10,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,x86_64-linux-android
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+
+      - name: Add Rust cross-compilation targets
+        run: rustup target add aarch64-linux-android x86_64-linux-android
 
       - name: Install cargo-ndk & uniffi-bindgen
         run: |
@@ -79,9 +80,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+
+      - name: Add Rust cross-compilation targets
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
       - name: Install uniffi-bindgen
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,14 @@ jobs:
           cache: pnpm
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ (matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin') || (matrix.target == 'aarch64-pc-windows-msvc' && 'aarch64-pc-windows-msvc') || '' }}
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+
+      - name: Add Rust cross-compilation target
+        if: matrix.target != ''
+        shell: bash
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+        run: rustup target add "$RUST_TARGET"
 
       - name: Install dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 22
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary

Fixes cross-compilation target installation failure and aligns Rust toolchain pinning across all workflows.

### Changes

**1. Cross-compilation target installation (`release.yml`, `mobile.yml`)**

`dtolnay/rust-toolchain` with comma-separated `targets` parameter is unreliable. Replaced with explicit `rustup target add` steps:
- `release.yml`: guarded by `if: matrix.target != ''`, uses env var + `shell: bash` for cross-platform compatibility (Windows defaults to PowerShell where `$VAR` won't expand)
- `mobile.yml`: Android job installs `aarch64-linux-android x86_64-linux-android`; iOS job installs `aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`

**2. Pin `dtolnay/rust-toolchain` to commit SHA (`release.yml`, `mobile.yml`, `test-signing.yml`)**

Replaced floating `@stable` tag with `@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1`, matching the pin already used in `security.yml`, `codeql.yml`, and `test-badges.yml`. Ensures reproducible builds and reduces supply-chain risk.

### Matrix verification

All matrix entries that need cross-compilation have `target` set:
- `macos-latest` 鈫?`aarch64-apple-darwin`
- `macos-latest` 鈫?`x86_64-apple-darwin`
- `windows-latest` 鈫?`aarch64-pc-windows-msvc`
- `ubuntu-*` and `windows-latest` (x64) 鈫?`target: ""` (correctly skips)