### PR TITLE
fix(ci): increase SignPath signing timeout to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,6 +484,7 @@ jobs:
           signing-policy-slug: 'release-signing'
           github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
           wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: './signed-windows'
 
       - name: Verify and replace unsigned artifacts with signed ones


### PR DESCRIPTION
The default `wait-for-completion-timeout-in-seconds` for the SignPath GitHub Action is 600 seconds (10 minutes). Since release-signing requires manual approval on the SignPath website, 10 minutes is often not enough time to receive the notification and approve the request. This PR increases the timeout to 3600 seconds (60 minutes), giving ample time for manual approval.