### PR TITLE
perf(ci): reuse Full build binary for portable, add arm64 portable, sign portable exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,8 +290,10 @@ jobs:
           shopt -s nullglob
           if [ -n "${{ matrix.target }}" ]; then
             BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
+            EXE_PATH="target/${{ matrix.target }}/release/Zephyr.exe"
           else
             BUNDLE_DIR="target/release/bundle"
+            EXE_PATH="target/release/Zephyr.exe"
           fi
           for f in $BUNDLE_DIR/nsis/*-setup.exe; do
             cp "$f" "dist-artifacts/$(basename "${f/-setup/-setup-full}")"
@@ -299,6 +301,8 @@ jobs:
           for f in $BUNDLE_DIR/msi/*.msi; do
             cp "$f" "dist-artifacts/$(basename "${f/.msi/-full.msi}")"
           done
+          # Copy raw exe for portable (same binary, avoids a 3rd full compile)
+          cp "$EXE_PATH" "dist-artifacts/Zephyr_${{ steps.get_version.outputs.VERSION }}_${{ matrix.arch }}-portable.exe"
         shell: bash
 
       - name: Collect macOS Full artifacts
@@ -380,50 +384,28 @@ jobs:
           done
         shell: bash
 
-      # ── Portable builds (Windows ZIP + Linux AppImage) ──
-      # Portable uses the same bundled resources as Full, with SHA256 verification
+      # ── Portable builds (Windows ZIP + Linux tar.gz) ──
+      # Portable reuses the Full build binary — no 3rd compile needed.
+      # Windows: uses the Authenticode-signed exe after SignPath verification.
+      # Linux: uses the AppImage already collected from the Full build.
 
-      # ── Restore bundled for portable (reuses unified script) ──
-      - name: Restore bundled for portable
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
+      - name: Package Portable (Linux)
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN" "${{ matrix.arch }}"
-        shell: bash
-
-      - name: Clean bundle directory before portable build
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
-        run: |
-          # Clean previous builds to ensure we get the correct portable artifact
-          rm -rf target/release/bundle
-        shell: bash
-
-      - name: Build Tauri app (Portable)
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
-        run: pnpm --filter @zephyr/desktop tauri build ${{ matrix.args }}
-
-      - name: Package Portable ZIP (Windows)
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
         run: |
           mkdir -p portable/core portable/profiles portable/prism/plugins
-          cp target/release/Zephyr.exe portable/
-          cp apps/desktop/src-tauri/bundled/* portable/core/
-          touch portable/.portable
-          cd portable && 7z a -mx=9 ../dist-artifacts/Zephyr-windows-portable.zip . && cd ..
-        shell: bash
-
-      - name: Package Portable AppImage (Linux)
-        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
-        run: |
-          # Get the freshly built AppImage (should be the only one after clean)
-          APPIMAGE=$(ls -t target/release/bundle/appimage/Zephyr*.AppImage | head -1)
-          if [ -z "$APPIMAGE" ]; then
-            echo "ERROR: No AppImage found!"
+          # Use the Full build AppImage (same binary, avoids a 3rd full compile)
+          shopt -s nullglob
+          matches=(dist-artifacts/*-full.AppImage)
+          if [ ${#matches[@]} -ne 1 ]; then
+            echo "ERROR: Expected exactly 1 full AppImage, found ${#matches[@]}"
+            printf '%s\n' "${matches[@]}"
             exit 1
           fi
-          echo "Using AppImage: $APPIMAGE"
-          mkdir -p portable/core portable/profiles portable/prism/plugins
-          cp "$APPIMAGE" portable/
+          cp -- "${matches[0]}" portable/Zephyr.AppImage
+          # Restore bundled resources (were removed before Lite build)
+          /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN" "${{ matrix.arch }}"
           cp apps/desktop/src-tauri/bundled/* portable/core/
           touch portable/.portable
           ARCH_SUFFIX="${{ matrix.arch }}"
@@ -446,6 +428,7 @@ jobs:
             "dist-artifacts/Zephyr_*_${{ matrix.arch }}-setup-lite.exe"
             "dist-artifacts/Zephyr_*_${{ matrix.arch }}*-full.msi"
             "dist-artifacts/Zephyr_*_${{ matrix.arch }}*-lite.msi"
+            "dist-artifacts/Zephyr_*_${{ matrix.arch }}-portable.exe"
           )
           for pattern in "${EXPECTED[@]}"; do
             mapfile -t files < <(compgen -G "$pattern")
@@ -519,6 +502,23 @@ jobs:
           Remove-Item -Recurse -Force unsigned-staging, signed-windows
           Write-Host "Final Windows artifacts in dist-artifacts:"
           Get-ChildItem dist-artifacts/*.exe, dist-artifacts/*.msi -ErrorAction SilentlyContinue | Format-Table Name, Length
+
+      - name: Package Portable ZIP (Windows) from signed exe
+        if: matrix.platform == 'windows-latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p portable/core portable/profiles portable/prism/plugins
+          # Use the Authenticode-signed exe from dist-artifacts
+          cp dist-artifacts/Zephyr_*_${{ matrix.arch }}-portable.exe portable/Zephyr.exe
+          # Restore bundled resources (were removed before Lite build)
+          /tmp/download-bundled.sh "${{ matrix.platform }}" "${{ steps.mihomo_version.outputs.VERSION }}" "$GITHUB_TOKEN" "${{ matrix.arch }}"
+          cp apps/desktop/src-tauri/bundled/* portable/core/
+          touch portable/.portable
+          cd portable && 7z a -mx=9 ../dist-artifacts/Zephyr_${{ matrix.arch }}-portable.zip . && cd ..
+          # Remove the standalone portable exe (now inside the ZIP)
+          rm -f dist-artifacts/Zephyr_*_${{ matrix.arch }}-portable.exe
+        shell: bash
 
       # ── Minisign: sign all release artifacts ──
       - name: Install minisign

--- a/PORTABLE.md
+++ b/PORTABLE.md
@@ -7,14 +7,14 @@
 ## 下载
 
 从 [Releases](https://github.com/Juwan-Hwang/Zephyr/releases) 下载：
-- **Windows**: `Zephyr-windows-portable.zip`
-- **Linux**: `Zephyr-linux-portable.tar.gz` (包含 AppImage + 数据目录)
+- **Windows**: `Zephyr_x64-portable.zip` / `Zephyr_arm64-portable.zip`
+- **Linux**: `Zephyr-linux-x64-portable.tar.gz` / `Zephyr-linux-arm64-portable.tar.gz` (包含 AppImage + 数据目录)
 
 ## 使用方法
 
 ### Windows
 
-1. 解压 `Zephyr-windows-portable.zip` 到任意目录（如 U 盘、桌面）
+1. 解压 `Zephyr_x64-portable.zip` 或 `Zephyr_arm64-portable.zip` 到任意目录（如 U 盘、桌面）
 2. 确保目录中有 `.portable` 标记文件
 3. 运行 `Zephyr.exe`
 
@@ -32,21 +32,22 @@ Zephyr/
 
 ### Linux (AppImage)
 
-1. 解压 `Zephyr-linux-portable.tar.gz`
+1. 解压 `Zephyr-linux-x64-portable.tar.gz` 或 `Zephyr-linux-arm64-portable.tar.gz`
 2. 确保 `.portable` 文件与 `.AppImage` 在同一目录
-3. 运行 `./Zephyr-*.AppImage`
+3. 运行 `./Zephyr.AppImage`
 
 ```bash
-tar xzf Zephyr-linux-portable.tar.gz
+mkdir Zephyr && tar xzf Zephyr-linux-x64-portable.tar.gz -C Zephyr
 cd Zephyr
-chmod +x Zephyr-*.AppImage
-./Zephyr-*.AppImage
+chmod +x Zephyr.AppImage
+./Zephyr.AppImage
 ```
 
 目录结构：
-```
+
+```text
 Zephyr/
-├── Zephyr-*.AppImage
+├── Zephyr.AppImage
 ├── .portable          ← 便携模式标记
 ├── core/
 ├── profiles/

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Zephyr 采用纵深防御策略：
 
 ### 便携版使用
 
-1. 下载 `Zephyr-windows-portable.zip` 或 `Zephyr-linux-portable.tar.gz`
+1. 下载 `Zephyr_x64-portable.zip` / `Zephyr_arm64-portable.zip` 或 `Zephyr-linux-x64-portable.tar.gz` / `Zephyr-linux-arm64-portable.tar.gz`
 2. 解压至任意目录
 3. 在目录中创建名为 `.portable` 的空文件（首次运行时会自动创建）
 4. 运行可执行文件

--- a/README_en.md
+++ b/README_en.md
@@ -200,7 +200,7 @@ Get the appropriate package from [GitHub Releases](https://github.com/Juwan-Hwan
 
 ### Portable Version Usage
 
-1. Download `Zephyr-windows-portable.zip` or `Zephyr-linux-portable.tar.gz`
+1. Download `Zephyr_x64-portable.zip` / `Zephyr_arm64-portable.zip` or `Zephyr-linux-x64-portable.tar.gz` / `Zephyr-linux-arm64-portable.tar.gz`
 2. Extract to any directory
 3. Create an empty file named `.portable` in the directory (or it will be auto-created on first run)
 4. Run the executable


### PR DESCRIPTION
## Summary

Eliminates the redundant 3rd full Tauri compile for portable builds by reusing the Full build binary. Also adds Windows arm64 portable support and Authenticode-signs the portable exe.

### Changes

1. **Eliminate redundant Portable build compile** — Full build binary reused for both Windows (exe) and Linux (AppImage), saving ~5-8 min per platform
2. **Sign portable exe via SignPath** — raw `Zephyr.exe` staged with installers, signed, then packaged into ZIP
3. **Add Windows arm64 portable** — `Zephyr_x64-portable.zip` / `Zephyr_arm64-portable.zip`
4. **Linux portable: single-match validation** — `*-full.AppImage` glob with exactly-1 check
5. **Update docs** — `PORTABLE.md`, `README.md`, `README_en.md` with new artifact names and fixed extraction instructions

### SignPath artifact configuration (must update on website)

Add to existing config:
```xml
<pe-file path="**/*-portable.exe">
  <authenticode-sign />
</pe-file>
```