### PR TITLE
fix(proxies): handle empty include-all groups and hide_timeout_nodes over-filtering

### DIFF
--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -255,7 +255,10 @@ async function initApp() {
     onConnections: () => { initConnectionsPage(); },
     onLogs: () => { import('./ui/logs.js').then(m => m.initLogsPage()).catch(() => {}); },
     onLeaveLogs: () => { import('./ui/logs.js').then(m => m.destroyLogsPage()).catch(() => {}); },
-    onLeaveProxies: () => { import('./ui/observed-group.js').then(m => m.stopObservedGroupWatcher()).catch(() => {}); },
+    onLeaveProxies: () => {
+        import('./ui/observed-group.js').then(m => m.stopObservedGroupWatcher()).catch(() => {});
+        import('./ui/proxies.js').then(m => { if (m.stopProviderPoll) m.stopProviderPoll(); }).catch(() => {});
+    },
   });
   initChart();
   initTrayEventListeners();

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -146,6 +146,24 @@ async function populateAndShowWheel(trigger, dropdown, scrollContainer, list, up
         /** @type {string[]} */
         const proxies = [...proxyGroupsResult.proxies];
 
+        // Guard: if the group has no nodes (provider still loading), show
+        // a brief loading hint instead of an empty dropdown.
+        if (proxies.length === 0) {
+            const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
+            const tObj = /** @type {Record<string, string>} */(translations[langKey]);
+            const hint = document.createElement('div');
+            hint.className = 'px-3 py-2 text-xs text-[var(--text-muted)] text-center';
+            hint.textContent = tObj?.loadingNodes || 'Loading nodes...';
+            /** @type {any} */ (list)._virtObserver?.disconnect();
+            list.replaceChildren();
+            list.appendChild(hint);
+            dropdown.classList.remove('opacity-0', 'pointer-events-none');
+            /** @type {HTMLElement} */ (dropdown).style.transform = 'translateY(0) scale(1)';
+            /** @type {HTMLElement} */ (trigger).style.opacity = '0';
+            /** @type {HTMLElement} */ (trigger).style.pointerEvents = 'none';
+            return;
+        }
+
         sortProxiesByLatency(proxies, data);
 
         const fragment = document.createDocumentFragment();

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -6,7 +6,7 @@
  * @module ui/proxies
  */
 
-import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore } from '../api.js';
+import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore, getProxies } from '../api.js';
 import { proxyLogger } from '../utils/logger.js';
 import { escapeHtml } from '../utils/sanitize.js';
 import { getDelayColorClass } from '../utils/format.js';
@@ -1223,6 +1223,16 @@ function renderGroupSelector(groups, currentGroup) {
 /** @type {ReturnType<typeof setTimeout> | null} */
 let _loadingTimeout = null;
 
+/** Provider-loading poller handle (retry when include-all group has empty all[]). */
+/** @type {ReturnType<typeof setTimeout> | null} */
+let _providerPollTimer = null;
+
+/** Maximum provider-loading retries (≈30 s at 1.5 s interval). */
+const PROVIDER_POLL_MAX = 20;
+
+/** Generation token: incremented on stop to cancel in-flight poll callbacks. */
+let _providerPollGeneration = 0;
+
 /**
  * Handle core restart from a button element.
  * @param {HTMLButtonElement} btn - The button that triggered the restart
@@ -1291,6 +1301,73 @@ function clearLoadingTimeout() {
         _loadingTimeout = null;
     }
 }
+
+// ─── Provider-loading poller ───────────────────────────────────────────
+// When a group uses `include-all: true`, its `all[]` array is empty until
+// the proxy-provider finishes its HTTP download.  The poller re-fetches
+// /proxies at a short interval and re-renders once nodes appear.
+
+/**
+ * Start polling for provider-loaded nodes.
+ * @param {string|null} preferredGroupName - The group name to check.
+ * @param {number} [attempt] - Current attempt count (internal).
+ */
+function startProviderPoll(preferredGroupName, attempt = 0) {
+    stopProviderPoll();
+    if (attempt >= PROVIDER_POLL_MAX) return;  // Give up silently
+
+    const gen = _providerPollGeneration;
+    _providerPollTimer = setTimeout(async () => {
+        _providerPollTimer = null;
+        // Cancelled while waiting
+        if (gen !== _providerPollGeneration) return;
+        try {
+            // Use non-cached fetch to avoid invalidating the global cache
+            // (which would force other UI components to re-fetch too).
+            const data = /** @type {any} */ (await getProxies());
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
+            if (!data || !data.proxies) {
+                // Malformed response — treat as retryable
+                startProviderPoll(preferredGroupName, attempt + 1);
+                return;
+            }
+
+            // Pass cached config to avoid an extra /configs HTTP request
+            const cachedConfig = await getConfigCached();
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
+            const result = await fetchProxyGroupsShared({
+                existingData: data,
+                existingConfig: cachedConfig,
+                preferredGroupName: preferredGroupName || undefined,
+            });
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
+            if (result && result.proxies.length > 0) {
+                // Nodes have arrived — invalidate cache + re-render
+                invalidateProxiesCache();
+                renderProxies();
+            } else {
+                // Still empty — keep polling
+                startProviderPoll(preferredGroupName, attempt + 1);
+            }
+        } catch {
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
+            // Network error — keep polling
+            startProviderPoll(preferredGroupName, attempt + 1);
+        }
+    }, 1500);
+}
+
+/** Stop the provider-loading poller if active. */
+function stopProviderPoll() {
+    _providerPollGeneration++;  // Cancel any in-flight callbacks
+    if (_providerPollTimer) {
+        clearTimeout(_providerPollTimer);
+        _providerPollTimer = null;
+    }
+}
+
+// Export for lifecycle cleanup (called when leaving the proxies page)
+export { stopProviderPoll };
 
 /**
  * Update existing proxy wrappers in-place when the proxy list hasn't changed.
@@ -1717,6 +1794,17 @@ export async function renderProxies() {
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
 
+    // --- Provider-loading guard ---
+    // If the uiGroup uses include-all and its all[] is empty, the proxy-provider
+    // hasn't finished downloading nodes yet.  Clear any stale cards from a
+    // previous group, then start a silent poller to re-render once nodes arrive.
+    if (proxyGroupsResult.providerLoading) {
+        renderProxiesLoading(container, t.loadingNodes);
+        startProviderPoll(preferredGroupName);
+        return;
+    }
+    stopProviderPoll();
+
     // Render the group explanation bar (observed/effective vs ui group mismatch indicator)
     const observedGroupName = appStore.get('observedGroupName');
     const observedNodeName = appStore.get('observedNodeName');
@@ -1725,6 +1813,7 @@ export async function renderProxies() {
     // Filter out unavailable (timeout) proxies if setting is enabled
     const settings = await getSettingsCached();
     if (settings?.hide_timeout_nodes) {
+        const preFilterCount = proxies.length;
         proxies = proxies.filter((/** @type {string} */ name) => {
             // Always keep the currently active node, even if it's timed out
             if (name === current) return true;
@@ -1737,6 +1826,12 @@ export async function renderProxies() {
             // Use helper to catch all timeout/invalid states (0, 999999, etc.)
             return !isInvalidDelay(lastDelay);
         });
+        // Safety valve: if hide_timeout_nodes filtered out EVERY node, keep the
+        // original unfiltered list so the user can still see and interact with
+        // nodes (rather than facing a confusing blank page).
+        if (proxies.length === 0 && preFilterCount > 0) {
+            proxies = [...proxyGroupsResult.proxies];
+        }
     }
 
     if (appStore.get('currentSortMode') === 'name') {
@@ -1839,6 +1934,7 @@ Bus.on(Events.CORE_RESTARTED, () => {
 document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
         stopObservedGroupWatcher();
+        stopProviderPoll();
     } else {
         // Only start if proxies page is visible
         const proxiesPage = document.querySelector('[data-page="proxies"]');

--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -324,6 +324,7 @@ function determineUiPrimaryGroup(ctx) {
  * @property {string|null}  uiGroupName           - Actually used UI group (GLOBAL in global mode, or primary)
  * @property {{source:string, detail:string}} reason - Why this primary group was chosen
  * @property {Record<string, string[]>} graph - Group → children adjacency list
+ * @property {boolean} providerLoading - True when uiGroup uses include-all and all[] is empty
  */
 
 /**
@@ -408,6 +409,19 @@ export async function fetchProxyGroups(options = {}) {
     const proxies = targetGroup?.all || [];
     const current = targetGroup?.now || null;
 
+    // --- Detect provider-loading state ---
+    // Groups with `include-all: true` or `include-all-providers: true` depend
+    // on proxy-providers finishing their HTTP download before their `all`
+    // array is populated.  If such a group has an empty `all` array while
+    // the config defines proxy-providers, the nodes are still loading.
+    const hasProxyProviders = !!(runConfig && runConfig['proxy-providers']
+        && Object.keys(runConfig['proxy-providers']).length > 0);
+    const includeAllGroups = buildIncludeAllSet(runConfig);
+    const isIncludeAllGroup = uiGroupName
+        ? includeAllGroups.has(uiGroupName)
+        : false;
+    const providerLoading = hasProxyProviders && isIncludeAllGroup && proxies.length === 0;
+
     return {
         // Legacy compat fields
         data,
@@ -425,5 +439,27 @@ export async function fetchProxyGroups(options = {}) {
         uiGroupName,
         reason,
         graph,
+
+        // Provider loading state — true when the uiGroup uses include-all
+        // and its all[] is empty (nodes still being downloaded by mihomo)
+        providerLoading,
     };
+}
+
+/**
+ * Build a Set of group names that use `include-all` or `include-all-providers`.
+ * Precomputed once per fetchProxyGroups call to avoid repeated linear scans.
+ *
+ * @param {any} runConfig - The run_config.yaml JSON
+ * @returns {Set<string>}
+ */
+function buildIncludeAllSet(runConfig) {
+    const result = new Set();
+    if (!runConfig || !Array.isArray(runConfig['proxy-groups'])) return result;
+    for (const pg of runConfig['proxy-groups']) {
+        if (pg?.name && (pg['include-all'] || pg['include-all-providers'])) {
+            result.add(pg.name);
+        }
+    }
+    return result;
 }


### PR DESCRIPTION
## Problem

Groups with `include-all: true` have an empty `all[]` array until `proxy-providers` finish their HTTP download. The UI rendered an empty node list, confusing users who saw other groups (which contain sub-group names, not real nodes) display "normally".

## Root Cause

1. **Timing**: `include-all` groups depend on `proxy-providers` downloading nodes via HTTP. The UI fetches `/proxies` and renders before the download completes, resulting in an empty `all[]`.
2. **Over-filtering**: When `hide_timeout_nodes` is enabled and all nodes in a group have timed out, the filter removes every node, leaving a blank list.

## Changes

### `proxy-groups.js`
- Added `providerLoading` flag: detects when a group uses `include-all` and has an empty `all[]` while `proxy-providers` are defined in run_config.
- Added `buildIncludeAllSet()` helper: precomputes a `Set<string>` of include-all group names for O(1) lookup.

### `proxies.js`
- **Provider-loading guard**: When `providerLoading` is true, renders loading spinner and starts a silent poller (`getProxies`, non-cached, every 1.5s, up to 20 retries). Once nodes arrive, invalidates cache + re-renders.
- **Poller lifecycle**: `stopProviderPoll` exported and called from `onLeaveProxies` and `visibilitychange` handler to prevent background polling.
- **Cancellation guard**: Generation token ensures in-flight async callbacks are cancelled when `stopProviderPoll` is called mid-await.
- **Poller optimization**: Passes `getConfigCached()` as `existingConfig` to avoid extra `/configs` HTTP requests during polling.
- **Malformed response handling**: Missing `data.proxies` is treated as retryable, not a silent return.
- **Safety valve for `hide_timeout_nodes`**: If filtering removes every node, falls back to the unfiltered list instead of showing a blank page.

### `node-wheel.js`
- Guard against empty proxies array in wheel dropdown -- shows a loading hint instead of an empty wheel.
- Disconnects `_virtObserver` before replacing list to prevent memory leaks.

### `main.js`
- Added `stopProviderPoll` call to `onLeaveProxies` lifecycle hook alongside `stopObservedGroupWatcher`.