### PR TITLE
fix(ci): resolve typecheck errors + document declined review suggestions

### DIFF
--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -7,6 +7,18 @@
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Polyfill: Element.replaceChildren() for older WebViews (pre-Safari 14 / macOS 10.15)
+//
+// Design note (ES5 compatibility):
+//
+// This polyfill deliberately uses `var`, index-based `for` loops, and
+// `this.removeChild(this.firstChild)` instead of `let`/`const`, `for...of`, and
+// `Node.remove()`.  The polyfill exists precisely because the target WebView
+// lacks `replaceChildren()` — such old engines may also lack ES6 features
+// (`Symbol.iterator` for `for...of`) and DOM4 (`Node.remove()`).
+//
+// SonarCloud may flag `var` and the `for` loop as style violations.  Do NOT
+// "fix" them to `let`/`for...of` — that would break the polyfill on the very
+// old WebViews it was created for.
 if (typeof Element.prototype.replaceChildren !== 'function') {
     Element.prototype.replaceChildren = function (/* ...nodes */) {
         while (this.firstChild) this.removeChild(this.firstChild);

--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -807,6 +807,11 @@ function showConnDetail(conn, mode) {
     }
 
     // Network info
+    // NOTE: These values use String() coercion (NOT _esc()) because they are
+    // only ever rendered through renderDetailRow(), which already calls _esc()
+    // on both label and value.  Pre-escaping here would cause double-escaping
+    // (e.g., "&" → "&amp;" → "&amp;amp;").  String() only ensures type safety
+    // so that undefined/null become '-' instead of "undefined".
     const networkVal = String(meta.network || meta.interface || '-');
     const typeVal = String(meta.type || conn.type || '-');
     const srcIp = String(meta.sourceIP || '-');

--- a/apps/desktop/src/ui/advanced.js
+++ b/apps/desktop/src/ui/advanced.js
@@ -190,6 +190,26 @@ async function handleConfigUpdate(path, value) {
  */
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+/*
+ * Design note (prototype-pollution guard):
+ *
+ * When an unsafe key is encountered, buildNestedPayload() returns the (possibly
+ * partially-built) result object instead of throwing.  This is intentional:
+ *
+ *   1. `__proto__`, `constructor`, and `prototype` are NOT valid mihomo config
+ *      keys — no legitimate user path will ever contain them.
+ *   2. Throwing would abort the entire multi-key batch update, silently dropping
+ *      other valid keys the user intended to set.
+ *   3. Returning an empty/partial payload turns the operation into a no-op:
+ *      patchConfig receives an object with no harmful keys, so the config is not
+ *      polluted and no data is lost.
+ *
+ * Reviewers have repeatedly suggested throwing instead of returning.  That
+ * approach was rejected for the reasons above.  Do NOT change `return result`
+ * to `throw` without understanding the multi-key update flow in
+ * handleConfigUpdate().
+ */
+
 /**
  * @param {string} path
  * @param {*} value
@@ -217,7 +237,7 @@ function buildNestedPayload(path, value) {
         const nextSeg = segments[i + 1];
 
         if (seg.type === 'key') {
-            if (UNSAFE_KEYS.has(seg.value)) return result; // nosemgrep: prototype-pollution — guarded
+            if (UNSAFE_KEYS.has(String(seg.value))) return result; // nosemgrep: prototype-pollution — guarded
             current[seg.value] = nextSeg.type === 'index' ? [] : Object.create(null);
             current = current[seg.value];
         } else {
@@ -230,7 +250,7 @@ function buildNestedPayload(path, value) {
 
     const lastSeg = segments[segments.length - 1];
     if (lastSeg.type === 'key') {
-        if (UNSAFE_KEYS.has(lastSeg.value)) return result; // nosemgrep: prototype-pollution — guarded
+        if (UNSAFE_KEYS.has(String(lastSeg.value))) return result; // nosemgrep: prototype-pollution — guarded
         current[lastSeg.value] = value;
     } else {
         while (current.length <= lastSeg.value) {

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -2148,6 +2148,11 @@ appStore.set('isNetworkUpdating', false);
             const modal = document.createElement('div');
             modal.id = 'smart-config-modal';
             modal.className = 'fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-[var(--zephyr-bg-overlay)] backdrop-blur-md';
+            // NOTE: config.* values (latency_weight, success_weight, etc.) come from
+            // prism.smartConfig() which calls a Tauri command backed by Rust f64 types.
+            // They are NOT user-controlled strings and cannot contain HTML — they are
+            // guaranteed to be numbers by the Rust type system.  Do not add HTML escaping
+            // here; it would produce visible "&amp;" artifacts in the number inputs.
             // eslint-disable-next-line no-unsanitized/property -- i18n translation keys // nosemgrep: js-innerhtml-assignment — verified safe, see eslint-disable above
             modal.innerHTML = `
                 <div class="glass-card w-[440px] p-6 space-y-5">


### PR DESCRIPTION
## Summary

Fixes the CI failure (TypeScript typecheck) from PR #990 and adds inline design notes documenting why certain reviewer suggestions were intentionally declined.

## Changes

### CI fix: TypeScript typecheck errors

UNSAFE_KEYS.has(seg.value) was called with string | number 鈥?TypeScript couldn't narrow the type via seg.type === 'key'. Fixed by wrapping in String().

### Design notes (inline code comments)

| File | Declined suggestion | Reason documented |
|------|---------------------|-------------------|
| dvanced.js | eturn result -> 	hrow | Unsafe keys are not valid config keys; throwing aborts entire batch; no-op is safe |
| connections.js | String() -> _esc() | enderDetailRow() already calls _esc(); pre-escaping causes double-escaping |
| settings.js | escape config.* values | Values are Rust f64 types, not user-controlled strings |
| main.js | ar -> let, or -> or...of, emoveChild -> emove() | Polyfill targets old WebViews lacking ES6/DOM4 |

## Testing

- pnpm typecheck pass
- pnpm lint clean (0 errors, 0 warnings)
- 405 JS tests pass