### PR TITLE
fix: backup metadata path + frontend log forwarding to app log

### DIFF
--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -154,6 +154,7 @@ pub enum BackendModule {
     Override,
     Rule,
     Smart,
+    Frontend,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -338,6 +339,16 @@ pub mod codes {
     pub const SMART_WAL_APPEND_FAILED: u16 = 10003;
     /// Smart WAL remove operation failed.
     pub const SMART_WAL_REMOVE_FAILED: u16 = 10004;
+
+    // Frontend: 11000-11999
+    /// Console `console.error()` / `console.warn()` forwarded from frontend.
+    pub const FRONTEND_CONSOLE: u16 = 11001;
+    /// Toast notification shown via `showNotification()`.
+    pub const FRONTEND_NOTIFICATION: u16 = 11002;
+    /// Uncaught exception caught by `window.onerror`.
+    pub const FRONTEND_UNCAUGHT: u16 = 11003;
+    /// Unhandled Promise rejection caught by `unhandledrejection`.
+    pub const FRONTEND_REJECTION: u16 = 11004;
 }
 
 // ── Global Emitter ──────────────────────────────────────────────────────────
@@ -439,6 +450,7 @@ pub fn emit_backend_event(event: &BackendEvent) {
                 BackendModule::Override => "override",
                 BackendModule::Rule => "rule",
                 BackendModule::Smart => "smart",
+                BackendModule::Frontend => "frontend",
             };
             let line = format!(
                 "[{}] [{}] [{}] (#{}) {}",
@@ -453,6 +465,37 @@ pub fn emit_backend_event(event: &BackendEvent) {
             }
         }
     }
+}
+
+// ── Frontend Log Forwarding ────────────────────────────────────────────────
+
+/// Write a log entry originating from the frontend (console errors, toast
+/// notifications, uncaught exceptions, unhandled Promise rejections).
+///
+/// This goes through the standard `emit_backend_event` pipeline so the event
+/// reaches stderr, the frontend event listener (for the logs page), and the
+/// app log file (if `log_app_enabled` is active).
+///
+/// To prevent feedback loops (frontend error → backend → frontend toast →
+/// backend log → …), `backend-events.js` skips toast notifications for
+/// events from the `Frontend` module.
+///
+/// # Arguments
+/// * `level` - One of `"error"`, `"warn"`, `"info"` (case-insensitive).
+/// * `code`  - Error code from the `codes::FRONTEND_*` constants.
+/// * `message` - The log message text.
+pub fn write_frontend_log(level: &str, code: u16, message: &str) {
+    let backend_level = match level.to_ascii_lowercase().as_str() {
+        "error" | "fatal" => BackendLevel::Error,
+        "warn" => BackendLevel::Warn,
+        _ => BackendLevel::Info,
+    };
+    emit_backend_event(&BackendEvent::new(
+        backend_level,
+        BackendModule::Frontend,
+        code,
+        message,
+    ));
 }
 
 // ── Convenience Macros ──────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/backup.rs
+++ b/apps/desktop/src-tauri/src/backup.rs
@@ -106,7 +106,9 @@ fn collect_backup_files(paths: &AppPaths) -> Vec<(String, PathBuf)> {
     }
 
     // 4. Metadata file (subscription info, intervals, etc.)
-    let metadata = paths.app_data_dir.join("metadata.json");
+    //    Lives in profiles_dir — same directory as the profile YAMLs,
+    //    not in app_data_dir (see crypto.rs load_metadata/save_metadata).
+    let metadata = paths.profiles_dir.join("metadata.json");
     if metadata.exists() {
         files.push(("metadata.json".to_owned(), metadata));
     }
@@ -706,7 +708,7 @@ fn build_dest_map(paths: &AppPaths, manifest: &BackupManifest) -> Vec<(String, P
             } else if entry.path == "run_config.yaml" {
                 paths.core_dir.join("run_config.yaml")
             } else if entry.path == "metadata.json" {
-                paths.app_data_dir.join("metadata.json")
+                paths.profiles_dir.join("metadata.json")
             } else {
                 // Reject unknown paths to prevent crafted archives from
                 // overwriting arbitrary application directories.
@@ -796,7 +798,7 @@ fn map_rel_to_dest(rel: &Path, paths: &AppPaths) -> Option<PathBuf> {
     } else if rel == Path::new("run_config.yaml") {
         Some(paths.core_dir.join("run_config.yaml"))
     } else if rel == Path::new("metadata.json") {
-        Some(paths.app_data_dir.join("metadata.json"))
+        Some(paths.profiles_dir.join("metadata.json"))
     } else {
         None
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1124,7 +1124,41 @@ async fn rate_limited_unregister_shortcut(
     global_shortcut::unregister_shortcut(app, shortcut_state, action)
 }
 
+/// Frontend log forwarding command.
+///
+/// Receives log entries from the frontend (console errors, toast
+/// notifications, uncaught exceptions, unhandled Promise rejections) and
+/// writes them to the app log via `emit_backend_event`.
+///
+/// The `source` parameter determines the error code:
+/// - `"console"`       → `FRONTEND_CONSOLE`      (default)
+/// - `"notification"` → `FRONTEND_NOTIFICATION`
+/// - `"uncaught"`      → `FRONTEND_UNCAUGHT`
+/// - `"rejection"`     → `FRONTEND_REJECTION`
 #[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn write_frontend_log(level: String, source: String, message: String) {
+    use crate::backend_event::codes;
+    let code = match source.as_str() {
+        "notification" => codes::FRONTEND_NOTIFICATION,
+        "uncaught" => codes::FRONTEND_UNCAUGHT,
+        "rejection" => codes::FRONTEND_REJECTION,
+        _ => codes::FRONTEND_CONSOLE,
+    };
+    // Cap message length to prevent unbounded disk writes from oversized
+    // stack traces or stringified circular objects. 16 KiB is generous
+    // for any realistic log entry while protecting the log file.
+    const MAX_MESSAGE_LEN: usize = 16 * 1024;
+    let message = if message.len() > MAX_MESSAGE_LEN {
+        message[..MAX_MESSAGE_LEN].to_owned() + "… [truncated]"
+    } else {
+        message
+    };
+    crate::backend_event::write_frontend_log(&level, code, &message);
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
 fn get_app_version() -> String {
     env!("CARGO_PKG_VERSION").to_owned()
 }
@@ -1597,6 +1631,7 @@ invalidate_heartbeat(window.app_handle());
             rate_limited_send_notification,
             get_app_version,
             heartbeat,
+write_frontend_log,
             // Prism Engine commands
             prism::prism_apply,
             prism::prism_status,

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -53,6 +53,7 @@ import { initChart, updateTrafficData, cleanupChart } from './modules/traffic-ch
 import { initConnectionsPage } from './modules/connections.js';
 import { initBackendEventListeners, cleanupBackendEventListeners } from './modules/backend-events.js';
 import { apiLogger } from './utils/logger.js';
+import { forwardToBackend } from './utils/frontend-log.js';
 import { registerCleanup, runCleanup } from './utils/cleanup-registry.js';
 import { COMMANDS } from '@zephyr/shared';
 import * as prism from './ui/prism.js';
@@ -460,6 +461,26 @@ async function initApp() {
 // ═══════════════════════════════════════════════════════════════════
 //  Bootstrap
 // ═══════════════════════════════════════════════════════════════════
+
+// Global error handlers — catch uncaught exceptions and unhandled
+// Promise rejections that would otherwise silently vanish from the
+// app log.  These run BEFORE DOMContentLoaded so they're armed as early
+// as possible.
+window.addEventListener('error', (event) => {
+    const { error: err, message, filename, lineno, colno } = event;
+    const detail = err instanceof Error
+        ? `${err.name}: ${err.message}\n${err.stack || ''}`
+        : `${message} at ${filename}:${lineno}:${colno}`;
+    forwardToBackend('error', 'uncaught', `[Uncaught] ${detail}`);
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const detail = reason instanceof Error
+        ? `${reason.name}: ${reason.message}\n${reason.stack || ''}`
+        : String(reason);
+    forwardToBackend('error', 'rejection', `[Unhandled Rejection] ${detail}`);
+});
 
 window.addEventListener('DOMContentLoaded', () => {
   initApp().catch((err) => {

--- a/apps/desktop/src/modules/backend-events.js
+++ b/apps/desktop/src/modules/backend-events.js
@@ -169,7 +169,9 @@ export async function initBackendEventListeners() {
                 _onNewEvent?.(entry);
 
                 // Fatal/Error → Toast notification (dedup by module:code, 10s window)
-                if (level === 'fatal' || level === 'error') {
+                // Skip frontend-originated events to prevent feedback loops:
+                // frontend error → backend → frontend toast → backend log → …
+                if ((level === 'fatal' || level === 'error') && module !== 'frontend') {
                     const key = `${module}:${code}`;
                     if (_recentErrors.has(key)) return;
                     _recentErrors.add(key);
@@ -177,6 +179,8 @@ export async function initBackendEventListeners() {
                     showNotification(
                         `[${module}] ${message}`,
                         level === 'fatal' ? 'error' : 'warning',
+                        null,
+                        { log: false }, // Already logged via emit_backend_event
                     );
                 }
             });

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -9,6 +9,7 @@ import { markdownToHtml } from '../utils/markdown.js';
 import { sanitizeHtml } from '../utils/sanitize.js';
 import { translations } from '../i18n.js';
 import { appStore } from './state.js';
+import { forwardToBackend } from '../utils/frontend-log.js';
 
 /**
  * Show a toast notification.
@@ -31,8 +32,10 @@ const MAX_NOTIFICATIONS = 5;
  * @param {string} message
  * @param {'info'|'success'|'warning'|'error'} [type]
  * @param {string|null} [title]
+ * @param {{ log?: boolean }} [opts] - `log: false` skips app-log forwarding
+ *        (use when the toast is triggered by a backend event that's already logged).
  */
-export function showNotification(message, type = 'info', title = null) {
+export function showNotification(message, type = 'info', title = null, { log = true } = {}) {
     const container = document.getElementById('notif-container');
     if (!container) return;
 
@@ -89,6 +92,24 @@ export function showNotification(message, type = 'info', title = null) {
         notif.classList.add('translate-x-full', 'opacity-0');
         setTimeout(() => notif.remove(), 500);
     }, title ? 4000 : 3000);
+
+    if (log) _forwardNotification(type, title, message);
+}
+
+/**
+ * Map notification type to log level and forward to backend app log.
+ * Extracted from showNotification to keep its cognitive complexity
+ * below the SonarCloud threshold (15).
+ * @param {string} type
+ * @param {string|null} title
+ * @param {string} message
+ */
+function _forwardNotification(type, title, message) {
+    const level = type === 'error' ? 'error'
+                : type === 'warning' ? 'warn'
+                : 'info';
+    const msg = title ? `[${title}] ${message}` : message;
+    forwardToBackend(level, 'notification', msg);
 }
 
 /**

--- a/apps/desktop/src/utils/frontend-log.js
+++ b/apps/desktop/src/utils/frontend-log.js
@@ -1,0 +1,102 @@
+// @ts-check
+/**
+ * Frontend log forwarding — sends log entries to the backend app log.
+ *
+ * Architecture:
+ *   - Fire-and-forget: never blocks UI, never throws
+ *   - Rate-limited: max 50 entries per 5 s window, deduped by content hash
+ *   - Zero circular deps: accesses __TAURI_INTERNALS__ directly,
+ *     bypassing api.js (which imports logger.js → would be circular)
+ *
+ * @module frontend-log
+ */
+
+import { COMMANDS } from '@zephyr/shared';
+
+// ── Tauri IPC (raw — avoids circular dependency with api.js) ─────────────
+
+/**
+ * The raw Tauri internals object, injected into `window` by the runtime
+ * regardless of `withGlobalTauri` config.  Same technique as `api.js`.
+ * @type {{ invoke?: (cmd: string, args?: Record<string, unknown>) => Promise<unknown> } | undefined}
+ */
+const _tauri =
+    typeof window !== 'undefined'
+        ? /** @type {any} */ (window).__TAURI_INTERNALS__
+        : undefined;
+
+// ── Rate Limiting ───────────────────────────────────────────────────────
+
+/** @type {number} Dedup window in milliseconds */
+const DEDUPE_WINDOW_MS = 5000;
+
+/** @type {number} Maximum log entries forwarded per dedup window */
+const MAX_PER_WINDOW = 50;
+
+/** @type {Map<string, number>} message-hash → last-sent timestamp */
+const _dedupe = new Map();
+
+/** @type {number} Entries forwarded in the current window */
+let _windowCount = 0;
+
+/** @type {number} Current window start timestamp */
+let _windowStart = Date.now();
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Forward a log entry to the backend app log file.
+ *
+ * The entry goes through `emit_backend_event` on the Rust side, so it
+ * appears in stderr, the frontend logs page, and the app log file
+ * (if `log_app_enabled` is active).
+ *
+ * This function is fire-and-forget — it never throws, never blocks,
+ * and silently drops entries when the rate limit is exceeded.
+ *
+ * @param {'error'|'warn'|'info'|'debug'} level   - Log severity (debug maps to Info on the backend)
+ * @param {'console'|'notification'|'uncaught'|'rejection'} source - Origin
+ * @param {string} message               - Log message text
+ * @returns {void}
+ */
+export function forwardToBackend(level, source, message) {
+    // — Rate limit: reset window if expired —
+    const now = Date.now();
+    if (now - _windowStart > DEDUPE_WINDOW_MS) {
+        _windowCount = 0;
+        _windowStart = now;
+        _dedupe.clear();
+    }
+
+    // — Rate limit: drop if window capacity exhausted —
+    // Error-level entries always pass through, even when the window is full,
+    // so critical frontend failures are never silently dropped by a burst
+    // of lower-severity (debug/info) chatter.
+    const isError = level === 'error';
+    if (!isError && _windowCount >= MAX_PER_WINDOW) return;
+
+    // — Dedup: skip identical messages within the window —
+    // Use the full message (not truncated) to avoid false dedup of
+    // long stack traces that share a prefix but differ in the tail.
+    const hash = `${level}:${source}:${message}`;
+    const last = _dedupe.get(hash);
+    if (last !== undefined && now - last < DEDUPE_WINDOW_MS) return;
+    _dedupe.set(hash, now);
+    _windowCount++;
+
+    // — Fire-and-forget: swallow both sync throws and async rejections —
+    try {
+        const promise = _tauri?.invoke?.(COMMANDS.WRITE_FRONTEND_LOG, {
+            level,
+            source,
+            message,
+        });
+        // Catch the Promise rejection to prevent unhandledrejection
+        // (which would itself trigger forwardToBackend → loop).
+        if (promise && typeof promise.catch === 'function') {
+            promise.catch(() => {});
+        }
+    } catch {
+        // Silently ignore — logging must never throw
+    }
+}

--- a/apps/desktop/src/utils/logger.js
+++ b/apps/desktop/src/utils/logger.js
@@ -1,10 +1,14 @@
 // @ts-check
+import { forwardToBackend } from './frontend-log.js';
 /**
  * Logging system with colored console output.
  *
  * Architecture:
  *   Logger (abstract base)  <-  ConsoleLogger
  *   Registry (Map)          <-  factory + global level control
+ *
+ * ConsoleLogger forwards `warn`/`error` entries to the backend app log
+ * via `frontend-log.js` (fire-and-forget, rate-limited).
  *
  * @module logger
  */
@@ -99,6 +103,24 @@ class Logger {
 // Console logger — colored prefix output
 // ---------------------------------------------------------------------------
 
+/**
+ * Format a single argument for log forwarding.
+ * Handles Error objects (with stack), strings, and objects.
+ * @param {*} arg
+ * @returns {string}
+ */
+function _formatArg(arg) {
+    if (arg instanceof Error) {
+        return arg.stack || `${arg.name}: ${arg.message}`;
+    }
+    if (typeof arg === 'string') return arg;
+    try {
+        return JSON.stringify(arg) ?? String(arg);
+    } catch {
+        return String(arg);
+    }
+}
+
 /** @type {Record<string, string>} */
 const CONSOLE_STYLES = {
     debug: 'color:#6b7280;font-weight:bold',
@@ -120,6 +142,12 @@ class ConsoleLogger extends Logger {
         if (typeof console[method] === 'function') {
             console[method](`%c${prefix}`, style, ...args);
         }
+
+        // Forward all levels to the backend app log (fire-and-forget, rate-limited).
+        // debug is included because it only reaches _write when the user has
+        // explicitly lowered the log level — in that case they want full visibility.
+        const msg = args.map(_formatArg).join(' ');
+        forwardToBackend(level, 'console', `${prefix} ${msg}`);
     }
 }
 

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -142,6 +142,7 @@ export const MISC = Object.freeze({
     SEND_NOTIFICATION: "rate_limited_send_notification",
     EXEMPT_UWP_APPS: "exempt_uwp_apps",
     HEARTBEAT: "heartbeat",
+    WRITE_FRONTEND_LOG: "write_frontend_log",
     EXPORT_BACKUP: "export_backup",
     IMPORT_BACKUP: "import_backup",
 });


### PR DESCRIPTION
## Backup metadata.json path fix

Fixed metadata.json path in collect_backup_files, build_dest_map, and map_rel_to_dest in backup.rs: changed from app_data_dir to profiles_dir, matching crypto.rs load_metadata/save_metadata.

Previously, metadata.json was never included in backups because the backup code looked in the wrong directory (app_data_dir/metadata.json instead of app_data_dir/profiles/metadata.json).

## Frontend log forwarding to app log

### Problem
The app log file only captured backend events emitted via emit_*! macros. Frontend console errors, toast notifications, and uncaught exceptions were invisible in the app log.

### Solution

**Backend (Rust):**
- Added Frontend variant to BackendModule enum
- Added 4 error codes (11001-11004): FRONTEND_CONSOLE, FRONTEND_NOTIFICATION, FRONTEND_UNCAUGHT, FRONTEND_REJECTION
- Added write_frontend_log() function in backend_event.rs
- Added write_frontend_log Tauri command in lib.rs (maps source param to error code)

**Frontend (JavaScript):**
- Created frontend-log.js: rate-limited (5s/50 max/dedup) fire-and-forget forwarding module. Uses raw __TAURI_INTERNALS__.invoke to avoid circular dependency.
- Enhanced ConsoleLogger to forward all levels (debug/info/warn/error) to backend
- Enhanced showNotification() to forward to app log, with log:false option for backend-event-triggered toasts
- Added global window.onerror + unhandledrejection handlers in main.js
- Skip toast for frontend module events in backend-events.js to prevent feedback loops

### Feedback loop prevention

Frontend error -> forwardToBackend -> Rust emit_backend_event -> frontend backend-event listener -> showNotification -> forwardToBackend -> ...

Broken at two points:
1. backend-events.js: skip toast for frontend module events
2. notifications.js: log:false when called from backend-events.js (original event already logged)