### PR TITLE
fix(config): add metadata concurrency lock and atomic write

### DIFF
--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -8,8 +8,8 @@ use tauri_plugin_dialog::DialogExt as _;
 
 use super::core_process::ensure_app_storage;
 use super::crypto::{
-    cleanup_metadata_cache, load_metadata, read_profile_file, save_metadata, write_profile_file,
-    ConfigMetadata, ProfilesMetadata,
+    cleanup_metadata_cache, load_metadata, lock_metadata, read_profile_file, save_metadata,
+    write_profile_file, ConfigMetadata, ProfilesMetadata,
 };
 use super::secure_io::write_file_secure;
 use super::ConfigInfo;
@@ -182,6 +182,7 @@ pub async fn update_config_url(
         return Err("URL must use http:// or https://".to_owned());
     }
 
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
     update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
         entry.url = Some(trimmed_url.to_owned());
@@ -200,6 +201,7 @@ pub async fn update_subscription_interval(
 ) -> Result<(), String> {
     let (paths, safe_name) = validate_config_for_update(&app, &name)?;
 
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
     update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
         entry.auto_update_interval = (interval > 0).then_some(interval);
@@ -235,6 +237,7 @@ pub async fn update_subscription_ua(
         }
     }
 
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
     update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
         entry.user_agent.clone_from(&normalized);
@@ -388,6 +391,7 @@ pub async fn delete_config(
 
         if yml_path.exists() {
             fs::remove_file(&yml_path).map_err(|e| format!("Failed to delete file: {e}"))?;
+            let _guard = lock_metadata();
             let mut metadata = load_metadata(&paths);
             metadata.configs.remove(&yml_name);
             save_metadata(&paths, &metadata)?;
@@ -413,13 +417,16 @@ pub async fn delete_config(
 
     // File deleted successfully — now update metadata
     // Use clean_name for metadata removal (matches the actual file key stored)
-    let mut metadata = load_metadata(&paths);
-    metadata.configs.remove(&clean_name);
-    // Also try the original name in case metadata was stored with a different key
-    if name != clean_name {
-        metadata.configs.remove(&name);
+    {
+        let _guard = lock_metadata();
+        let mut metadata = load_metadata(&paths);
+        metadata.configs.remove(&clean_name);
+        // Also try the original name in case metadata was stored with a different key
+        if name != clean_name {
+            metadata.configs.remove(&name);
+        }
+        save_metadata(&paths, &metadata)?;
     }
-    save_metadata(&paths, &metadata)?;
 
     // 如果被删除的配置恰好是 last_config 指向的配置，重置为第一个可用配置，
     // 避免悬空指针导致下次冷启动加载到错误的配置。
@@ -600,17 +607,20 @@ pub fn rename_config(app: AppHandle, old_name: String, new_name: String) -> Resu
     std::fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename config: {e}"))?;
 
     // Update metadata
-    let mut metadata = load_metadata(&paths);
-    if let Some(meta) = metadata.configs.remove(&clean_old) {
-        metadata.configs.insert(clean_new.clone(), meta);
-    }
-    // Also try original name in case metadata was stored differently
-    if old_name != clean_old {
-        if let Some(meta) = metadata.configs.remove(&old_name) {
+    {
+        let _guard = lock_metadata();
+        let mut metadata = load_metadata(&paths);
+        if let Some(meta) = metadata.configs.remove(&clean_old) {
             metadata.configs.insert(clean_new.clone(), meta);
         }
+        // Also try original name in case metadata was stored differently
+        if old_name != clean_old {
+            if let Some(meta) = metadata.configs.remove(&old_name) {
+                metadata.configs.insert(clean_new.clone(), meta);
+            }
+        }
+        save_metadata(&paths, &metadata)?;
     }
-    save_metadata(&paths, &metadata)?;
 
     // Update last_config setting if it references the old name
     // Also migrate last_proxy_selection key from old name to new name

--- a/apps/desktop/src-tauri/src/core/crypto.rs
+++ b/apps/desktop/src-tauri/src/core/crypto.rs
@@ -3,7 +3,7 @@ use rand::RngExt as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use super::secure_io::write_file_secure;
 use super::AppPaths;
@@ -502,6 +502,35 @@ pub fn decrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
     }
 }
 
+// ── Metadata concurrency ────────────────────────────────────────────────
+
+/// Coarse-grained lock serializing all metadata read-modify-write sequences.
+///
+/// Prevents Lost Update races between user-initiated Tauri commands
+/// (`update_config_url`, `delete_config`, `rename_config`, …) and the
+/// background subscription scheduler (`download_sub_inner`).
+///
+/// The lock is held **only** for the brief JSON load-modify-save sequence —
+/// never across non-metadata file I/O (config writes, directory scans) or
+/// `.await` points — so contention is negligible.
+///
+/// # Poison safety
+/// Recovers from poison via [`PoisonError::into_inner`], consistent with
+/// the rest of the codebase — a panic in one command does not permanently
+/// disable configuration management.
+static METADATA_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the global metadata lock.
+///
+/// The returned guard is dropped automatically at the end of the enclosing
+/// scope. **Never hold it across `.await` points** — `std::sync::MutexGuard`
+/// is `!Send`, so the compiler will reject that.
+pub(super) fn lock_metadata() -> std::sync::MutexGuard<'static, ()> {
+    METADATA_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 pub(super) fn load_metadata(paths: &AppPaths) -> ProfilesMetadata {
     let meta_path = paths.profiles_dir.join("metadata.json");
     match fs::read_to_string(&meta_path) {
@@ -564,12 +593,36 @@ pub(super) fn save_metadata(paths: &AppPaths, meta: &ProfilesMetadata) -> Result
     let meta_path = paths.profiles_dir.join("metadata.json");
     let data = serde_json::to_string_pretty(&obf_meta)
         .map_err(|e| format!("Failed to serialize metadata: {e}"))?;
-    write_file_secure(&meta_path, &data)?;
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // `rename` is atomic on the same filesystem — readers see either the old
+    // or the new file, never a partial write. If the process crashes between
+    // the temp write and the rename, the old metadata.json is untouched.
+    let temp_path = paths.profiles_dir.join("metadata.json.tmp");
+    write_file_secure(&temp_path, &data)?;
+
+    if let Err(e) = std::fs::rename(&temp_path, &meta_path) {
+        // Rename can fail on Windows if an external process (e.g. antivirus)
+        // has the file open. Clean up the temp file and fall back to direct
+        // write — not atomic, but strictly better than losing the data.
+        let _ = std::fs::remove_file(&temp_path);
+        write_file_secure(&meta_path, &data)?;
+        emit_warn!(
+            Core,
+            CORE_CRASHED,
+            "Atomic rename of metadata.json failed, used direct write: {e}"
+        );
+    }
+
     Ok(())
 }
 
-/// Clean up metadata entries for configs that no longer exist on disk
+/// Clean up metadata entries for configs that no longer exist on disk.
+///
+/// Acquires the metadata lock to ensure the load-modify-save sequence is
+/// atomic with respect to concurrent metadata writers.
 pub(super) fn cleanup_metadata_cache(paths: &AppPaths) {
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(paths);
     let mut changed = false;
 

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -10,7 +10,7 @@ use zephyr_core::config::subscription::{
 };
 
 use super::core_process::ensure_app_storage;
-use super::crypto::{load_metadata, save_metadata, write_profile_file};
+use super::crypto::{load_metadata, lock_metadata, save_metadata, write_profile_file};
 use super::{MihomoState, MAX_RESPONSE_SIZE};
 #[allow(unused_imports)]
 use crate::emit_warn;
@@ -586,33 +586,6 @@ async fn download_sub_inner_raw(
     zephyr_core::config::sanitizer::validate_path_within_dir(&target_path, &paths.profiles_dir)
         .map_err(|e| e.to_string())?;
 
-    let mut metadata = load_metadata(&paths);
-    // Preserve existing auto_update_interval and per-subscription user_agent
-    // to avoid silently resetting user-configured settings
-    let (preserved_interval, preserved_ua) = metadata
-        .configs
-        .get(&clean_name)
-        .map(|m| (m.auto_update_interval, m.user_agent.clone()))
-        .unwrap_or((None, None));
-    metadata.configs.insert(
-        clean_name.clone(),
-        super::crypto::ConfigMetadata {
-            url: Some(final_url),
-            sub_info: if sub_info_header.is_empty() {
-                None
-            } else {
-                Some(sub_info_header)
-            },
-            last_updated: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0),
-            ),
-            auto_update_interval: preserved_interval,
-            user_agent: preserved_ua,
-        },
-    );
     let final_content = content;
 
     // Best-effort atomic config + metadata update (compensating transactions, not ACID):
@@ -657,8 +630,43 @@ async fn download_sub_inner_raw(
         return Err(format!("Failed to apply config file: {e}"));
     }
 
-    // Save metadata — last step so failure can be cleanly rolled back
-    if let Err(e) = save_metadata(&paths, &metadata) {
+    // Save metadata — last step so failure can be cleanly rolled back.
+    // Load *after* file I/O and under the metadata lock to avoid Lost Update:
+    // a concurrent command's metadata change would otherwise be overwritten
+    // by this save (which was based on a pre-download snapshot).
+    let metadata_result = {
+        let _guard = lock_metadata();
+        let mut metadata = load_metadata(&paths);
+        // Preserve existing auto_update_interval and per-subscription user_agent
+        // to avoid silently resetting user-configured settings
+        let (preserved_interval, preserved_ua) = metadata
+            .configs
+            .get(&clean_name)
+            .map(|m| (m.auto_update_interval, m.user_agent.clone()))
+            .unwrap_or((None, None));
+        metadata.configs.insert(
+            clean_name.clone(),
+            super::crypto::ConfigMetadata {
+                url: Some(final_url),
+                sub_info: if sub_info_header.is_empty() {
+                    None
+                } else {
+                    Some(sub_info_header)
+                },
+                last_updated: Some(
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                ),
+                auto_update_interval: preserved_interval,
+                user_agent: preserved_ua,
+            },
+        );
+        save_metadata(&paths, &metadata)
+    };
+
+    if let Err(e) = metadata_result {
         // Rollback config to previous state
         let _ = std::fs::remove_file(&target_path);
         if let Some(bp) = backup_path.as_ref() {


### PR DESCRIPTION
## Problem

All metadata read-modify-write operations on `metadata.json` (`load_metadata` -> modify -> `save_metadata`) lacked concurrency control. The background subscription scheduler (`download_sub_inner`) and user-initiated Tauri commands (`update_config_url`, `delete_config`, `rename_config`, etc.) could execute concurrently, causing **Lost Update** races where one writer's changes were silently overwritten by another.

The race window was especially significant in `download_sub_inner`, which loaded metadata *before* file I/O (write temp + rename) and saved it *after* — a ~100ms-1s gap during which any concurrent user command's metadata change would be overwritten by the pre-download snapshot.

## Solution

### 1. Coarse-grained `Mutex` gate lock (`METADATA_LOCK`)

Added a `static METADATA_LOCK: Mutex<()>` in `crypto.rs` with a `lock_metadata()` helper. Every metadata RMW site now acquires this lock before `load_metadata` and releases it after `save_metadata`. The lock is held **only** for the brief JSON read-modify-write — never across file I/O or `.await` points — so contention is negligible.

Poison recovery uses `PoisonError::into_inner`, consistent with the rest of the codebase (`cleanup_dangling_last_config`, `rename_config`, `write_config_file_inner`).

### 2. Restructured `download_sub_inner`

Moved the `load_metadata` + metadata modification to **after** the file I/O (write temp + rename) and wrapped it in the lock. This ensures the metadata being saved reflects the latest state, not a pre-download snapshot. The rollback logic (remove target + restore backup on `save_metadata` failure) is preserved.

### 3. Atomic `save_metadata` write

Replaced `write_file_secure` (which uses `fs::write` = truncate + write, not atomic) with a **temp file + rename** pattern:
- Write to `metadata.json.tmp` in the same directory
- `std::fs::rename` (atomic on the same filesystem)
- **Fallback**: if rename fails (Windows AV edge case), clean up temp and fall back to direct write — strictly better than the old behavior

This prevents partial-write corruption if the process crashes during `save_metadata`.

## Files Changed

| File | Changes |
|---|---|
| `crypto.rs` | `METADATA_LOCK` static, `lock_metadata()` helper, atomic `save_metadata`, lock in `cleanup_metadata_cache` |
| `config_manager.rs` | Lock added to `update_config_url`, `update_subscription_interval`, `update_subscription_ua`, `delete_config` (both paths), `rename_config` |
| `subscription.rs` | `download_sub_inner` restructured: metadata RMW moved after file I/O and wrapped in lock |

## Verification

- `cargo fmt`: pass
- `cargo clippy --all-targets -- -D warnings`: pass (0 warnings)
- `cargo test -p zephyr-core`: 149 passed, 0 failed
- Tauri app test binary has a pre-existing Windows DLL issue (`STATUS_ENTRYPOINT_NOT_FOUND`), unrelated to these changes