### PR TITLE
fix(config): add metadata concurrency lock and atomic write

### DIFF
--- a/apps/desktop/src-tauri/src/core/config_manager.rs
+++ b/apps/desktop/src-tauri/src/core/config_manager.rs
@@ -8,37 +8,12 @@ use tauri_plugin_dialog::DialogExt as _;
 
 use super::core_process::ensure_app_storage;
 use super::crypto::{
-    cleanup_metadata_cache, load_metadata, read_profile_file, save_metadata, write_profile_file,
-    ConfigMetadata, ProfilesMetadata,
+    cleanup_metadata_cache, load_metadata, lock_metadata, read_profile_file, save_metadata,
+    write_profile_file, ConfigMetadata,
 };
 use super::secure_io::write_file_secure;
 use super::ConfigInfo;
 use zephyr_core::config::sanitizer::{sanitize_config_file_name, validate_path_within_dir};
-
-/// Update a field on an existing metadata entry (or create the entry first).
-fn update_metadata_entry<F>(
-    metadata: &mut ProfilesMetadata,
-    safe_name: &str,
-    app: &AppHandle,
-    update: F,
-) where
-    F: FnOnce(&mut ConfigMetadata),
-{
-    let entry = metadata
-        .configs
-        .entry(safe_name.to_owned())
-        .or_insert_with(|| {
-            let url = get_config_url(app, safe_name).ok();
-            ConfigMetadata {
-                url,
-                sub_info: None,
-                last_updated: None,
-                auto_update_interval: None,
-                user_agent: None,
-            }
-        });
-    update(entry);
-}
 
 /// Common validation for config update commands.
 /// Returns sanitized name and app paths if valid.
@@ -182,10 +157,19 @@ pub async fn update_config_url(
         return Err("URL must use http:// or https://".to_owned());
     }
 
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
-    update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
-        entry.url = Some(trimmed_url.to_owned());
-    });
+    let entry = metadata
+        .configs
+        .entry(safe_name)
+        .or_insert_with(|| ConfigMetadata {
+            url: None,
+            sub_info: None,
+            last_updated: None,
+            auto_update_interval: None,
+            user_agent: None,
+        });
+    entry.url = Some(trimmed_url.to_owned());
     save_metadata(&paths, &metadata)?;
 
     Ok(())
@@ -199,11 +183,21 @@ pub async fn update_subscription_interval(
     interval: u64,
 ) -> Result<(), String> {
     let (paths, safe_name) = validate_config_for_update(&app, &name)?;
+    let fallback_url = get_config_url(&app, &safe_name).ok();
 
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
-    update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
-        entry.auto_update_interval = (interval > 0).then_some(interval);
-    });
+    let entry = metadata
+        .configs
+        .entry(safe_name)
+        .or_insert_with(|| ConfigMetadata {
+            url: fallback_url,
+            sub_info: None,
+            last_updated: None,
+            auto_update_interval: None,
+            user_agent: None,
+        });
+    entry.auto_update_interval = (interval > 0).then_some(interval);
     save_metadata(&paths, &metadata)?;
 
     Ok(())
@@ -235,10 +229,21 @@ pub async fn update_subscription_ua(
         }
     }
 
+    let fallback_url = get_config_url(&app, &safe_name).ok();
+
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(&paths);
-    update_metadata_entry(&mut metadata, &safe_name, &app, |entry| {
-        entry.user_agent.clone_from(&normalized);
-    });
+    let entry = metadata
+        .configs
+        .entry(safe_name)
+        .or_insert_with(|| ConfigMetadata {
+            url: fallback_url,
+            sub_info: None,
+            last_updated: None,
+            auto_update_interval: None,
+            user_agent: None,
+        });
+    entry.user_agent.clone_from(&normalized);
     save_metadata(&paths, &metadata)?;
 
     Ok(())
@@ -388,9 +393,12 @@ pub async fn delete_config(
 
         if yml_path.exists() {
             fs::remove_file(&yml_path).map_err(|e| format!("Failed to delete file: {e}"))?;
-            let mut metadata = load_metadata(&paths);
-            metadata.configs.remove(&yml_name);
-            save_metadata(&paths, &metadata)?;
+            {
+                let _guard = lock_metadata();
+                let mut metadata = load_metadata(&paths);
+                metadata.configs.remove(&yml_name);
+                save_metadata(&paths, &metadata)?;
+            }
             cleanup_dangling_last_config(&app, &state, &paths, &yml_name);
             return Ok(format!("Config {yml_name} deleted"));
         }
@@ -413,13 +421,16 @@ pub async fn delete_config(
 
     // File deleted successfully — now update metadata
     // Use clean_name for metadata removal (matches the actual file key stored)
-    let mut metadata = load_metadata(&paths);
-    metadata.configs.remove(&clean_name);
-    // Also try the original name in case metadata was stored with a different key
-    if name != clean_name {
-        metadata.configs.remove(&name);
+    {
+        let _guard = lock_metadata();
+        let mut metadata = load_metadata(&paths);
+        metadata.configs.remove(&clean_name);
+        // Also try the original name in case metadata was stored with a different key
+        if name != clean_name {
+            metadata.configs.remove(&name);
+        }
+        save_metadata(&paths, &metadata)?;
     }
-    save_metadata(&paths, &metadata)?;
 
     // 如果被删除的配置恰好是 last_config 指向的配置，重置为第一个可用配置，
     // 避免悬空指针导致下次冷启动加载到错误的配置。
@@ -596,21 +607,28 @@ pub fn rename_config(app: AppHandle, old_name: String, new_name: String) -> Resu
         return Err(format!("A config named '{clean_new}' already exists"));
     }
 
-    // Rename file
-    std::fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename config: {e}"))?;
-
-    // Update metadata
-    let mut metadata = load_metadata(&paths);
-    if let Some(meta) = metadata.configs.remove(&clean_old) {
-        metadata.configs.insert(clean_new.clone(), meta);
-    }
-    // Also try original name in case metadata was stored differently
-    if old_name != clean_old {
-        if let Some(meta) = metadata.configs.remove(&old_name) {
+    // Rename file + update metadata under lock to prevent cleanup_metadata_cache
+    // from removing the metadata entry while the file is temporarily absent.
+    {
+        let _guard = lock_metadata();
+        std::fs::rename(&old_path, &new_path)
+            .map_err(|e| format!("Failed to rename config: {e}"))?;
+        let mut metadata = load_metadata(&paths);
+        if let Some(meta) = metadata.configs.remove(&clean_old) {
             metadata.configs.insert(clean_new.clone(), meta);
         }
+        // Also try original name in case metadata was stored differently
+        if old_name != clean_old {
+            if let Some(meta) = metadata.configs.remove(&old_name) {
+                metadata.configs.insert(clean_new.clone(), meta);
+            }
+        }
+        if let Err(e) = save_metadata(&paths, &metadata) {
+            // Rollback: rename file back to old path
+            let _ = std::fs::rename(&new_path, &old_path);
+            return Err(format!("Failed to save metadata: {e}"));
+        }
     }
-    save_metadata(&paths, &metadata)?;
 
     // Update last_config setting if it references the old name
     // Also migrate last_proxy_selection key from old name to new name

--- a/apps/desktop/src-tauri/src/core/crypto.rs
+++ b/apps/desktop/src-tauri/src/core/crypto.rs
@@ -3,7 +3,7 @@ use rand::RngExt as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use super::secure_io::write_file_secure;
 use super::AppPaths;
@@ -13,7 +13,7 @@ pub(super) struct ProfilesMetadata {
     pub configs: std::collections::HashMap<String, ConfigMetadata>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
 pub(super) struct ConfigMetadata {
     pub url: Option<String>,
     pub sub_info: Option<String>,
@@ -502,6 +502,42 @@ pub fn decrypt_all_profiles(profiles_dir: &Path) -> Result<(), String> {
     }
 }
 
+// ── Metadata concurrency ────────────────────────────────────────────────
+
+/// Coarse-grained lock serializing all metadata read-modify-write sequences.
+///
+/// Prevents Lost Update races between user-initiated Tauri commands
+/// (`update_config_url`, `delete_config`, `rename_config`, …) and the
+/// background subscription scheduler (`download_sub_inner`).
+///
+/// The lock serializes metadata load-modify-save sequences and may be held
+/// across synchronous file operations that are part of the transaction
+/// (e.g., `save_metadata`, directory scans in `cleanup_metadata_cache`,
+/// file renames in `rename_config` and `download_sub_inner`). It must
+/// **never** be held across `.await` points.
+///
+/// # Poison safety
+/// Recovers from poison via [`PoisonError::into_inner`], consistent with
+/// the rest of the codebase — a panic in one command does not permanently
+/// disable configuration management.
+static METADATA_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the global metadata lock.
+///
+/// The returned guard is dropped automatically at the end of the enclosing
+/// scope. **Never hold it across `.await` points** — `std::sync::MutexGuard`
+/// is `!Send`, so the compiler will reject that.
+pub(super) fn lock_metadata() -> std::sync::MutexGuard<'static, ()> {
+    METADATA_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// # Concurrency
+///
+/// Safe to call without [`lock_metadata`] for read-only access (atomic
+/// write ensures no torn reads). Must hold [`lock_metadata`] if the loaded
+/// data will be modified and saved back via [`save_metadata`].
 pub(super) fn load_metadata(paths: &AppPaths) -> ProfilesMetadata {
     let meta_path = paths.profiles_dir.join("metadata.json");
     match fs::read_to_string(&meta_path) {
@@ -544,6 +580,10 @@ pub(super) fn load_metadata(paths: &AppPaths) -> ProfilesMetadata {
     }
 }
 
+/// # Concurrency
+///
+/// Callers must hold [`lock_metadata`] before calling this function
+/// to prevent Lost Update races.
 pub(super) fn save_metadata(paths: &AppPaths, meta: &ProfilesMetadata) -> Result<(), String> {
     let mut obf_meta = ProfilesMetadata::default();
     #[allow(clippy::iter_over_hash_type)]
@@ -564,12 +604,59 @@ pub(super) fn save_metadata(paths: &AppPaths, meta: &ProfilesMetadata) -> Result
     let meta_path = paths.profiles_dir.join("metadata.json");
     let data = serde_json::to_string_pretty(&obf_meta)
         .map_err(|e| format!("Failed to serialize metadata: {e}"))?;
-    write_file_secure(&meta_path, &data)?;
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // `rename` is atomic on the same filesystem — readers see either the old
+    // or the new file, never a partial write. If the process crashes between
+    // the temp write and the rename, the old metadata.json is untouched.
+    let temp_path = paths.profiles_dir.join("metadata.json.tmp");
+    write_file_secure(&temp_path, &data)?;
+
+    // Rename can fail on Windows if an external process (e.g. antivirus)
+    // has the file open. Such handles are transient — retry before falling
+    // back to a non-atomic direct write.
+    let mut rename_err = None;
+    for attempt in 0..3 {
+        match std::fs::rename(&temp_path, &meta_path) {
+            Ok(()) => {
+                rename_err = None;
+                break;
+            }
+            Err(e) => {
+                rename_err = Some(e);
+                if attempt < 2 {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+            }
+        }
+    }
+
+    if let Some(e) = rename_err {
+        let _ = std::fs::remove_file(&temp_path);
+        // Keep a recoverable copy: an interrupted direct write truncates
+        // metadata.json, and load_metadata would then silently degrade to
+        // an empty default that the next save persists.
+        let _ = std::fs::copy(&meta_path, paths.profiles_dir.join("metadata.json.bak"));
+        write_file_secure(&meta_path, &data)?;
+        emit_warn!(
+            Core,
+            CORE_CRASHED,
+            "Atomic rename of metadata.json failed, used direct write: {e}"
+        );
+    }
+
     Ok(())
 }
 
-/// Clean up metadata entries for configs that no longer exist on disk
+/// Clean up metadata entries for configs that no longer exist on disk.
+///
+/// Acquires the metadata lock for the entire scan-modify-save sequence.
+/// The directory scan is performed under the lock to prevent TOCTOU races:
+/// if the scan were outside the lock, a concurrent writer could create a file
+/// between the scan and the metadata modification, causing its entry to be
+/// erroneously removed.
 pub(super) fn cleanup_metadata_cache(paths: &AppPaths) {
+    let _guard = lock_metadata();
     let mut metadata = load_metadata(paths);
     let mut changed = false;
 

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -10,7 +10,7 @@ use zephyr_core::config::subscription::{
 };
 
 use super::core_process::ensure_app_storage;
-use super::crypto::{load_metadata, save_metadata, write_profile_file};
+use super::crypto::{load_metadata, lock_metadata, save_metadata, write_profile_file};
 use super::{MihomoState, MAX_RESPONSE_SIZE};
 #[allow(unused_imports)]
 use crate::emit_warn;
@@ -586,45 +586,19 @@ async fn download_sub_inner_raw(
     zephyr_core::config::sanitizer::validate_path_within_dir(&target_path, &paths.profiles_dir)
         .map_err(|e| e.to_string())?;
 
-    let mut metadata = load_metadata(&paths);
-    // Preserve existing auto_update_interval and per-subscription user_agent
-    // to avoid silently resetting user-configured settings
-    let (preserved_interval, preserved_ua) = metadata
-        .configs
-        .get(&clean_name)
-        .map(|m| (m.auto_update_interval, m.user_agent.clone()))
-        .unwrap_or((None, None));
-    metadata.configs.insert(
-        clean_name.clone(),
-        super::crypto::ConfigMetadata {
-            url: Some(final_url),
-            sub_info: if sub_info_header.is_empty() {
-                None
-            } else {
-                Some(sub_info_header)
-            },
-            last_updated: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0),
-            ),
-            auto_update_interval: preserved_interval,
-            user_agent: preserved_ua,
-        },
-    );
     let final_content = content;
 
     // Best-effort atomic config + metadata update (compensating transactions, not ACID):
     //   Overwrite: target -> backup, temp -> target, save_metadata, cleanup backup
     //   New:      temp -> target, save_metadata, remove target on failure
     // Crash between steps may leave .bak.<uuid> residuals — cleaned up at startup.
-    let is_overwrite = target_path.exists();
+    //
+    // The overwrite decision is made *under* the lock to prevent TOCTOU:
+    // a concurrent delete/create between the pre-lock probe and the swap
+    // would either abort the update or clobber a new file with no backup.
 
     // Use UUID suffix to avoid conflicts from concurrent updates or crash residuals
     let unique_id = uuid::Uuid::new_v4().to_string()[..8].to_owned();
-    let backup_path =
-        is_overwrite.then(|| target_path.with_extension(format!("yaml.bak.{unique_id}")));
     let temp_path = target_path.with_extension(format!("yaml.tmp.{unique_id}"));
 
     // Write new config to temp file (encrypt if setting is enabled)
@@ -638,40 +612,117 @@ async fn download_sub_inner_raw(
     };
     write_profile_file(&temp_path, &final_content, encrypt)?;
 
-    // Overwrite: move old config to backup first
-    if let Some(bp) = backup_path.as_ref() {
-        std::fs::rename(&target_path, bp).map_err(|e| {
+    // File swap + metadata RMW under lock to prevent cleanup_metadata_cache
+    // from removing the metadata entry while the file is temporarily absent
+    // (e.g. during overwrite, the target is briefly moved to a backup).
+    let metadata_result = {
+        let _guard = lock_metadata();
+
+        // Decide overwrite-vs-new *under the lock*: the pre-lock probe can
+        // be invalidated by a concurrent delete or create.
+        let backup_path = if target_path.exists() {
+            let bp = target_path.with_extension(format!("yaml.bak.{unique_id}"));
+            std::fs::rename(&target_path, &bp).map_err(|e| {
+                let _ = std::fs::remove_file(&temp_path);
+                format!("Failed to backup existing config (update aborted): {e}")
+            })?;
+            Some(bp)
+        } else {
+            None
+        };
+
+        // Move temp to final path (same directory — rename is always atomic, no copy fallback)
+        if let Err(e) = std::fs::rename(&temp_path, &target_path) {
             let _ = std::fs::remove_file(&temp_path);
-            format!("Failed to backup existing config (update aborted): {e}")
-        })?;
-    }
+            if let Some(bp) = backup_path.as_ref() {
+                if bp.exists() {
+                    let _ = std::fs::rename(bp, &target_path);
+                }
+            }
+            return Err(format!("Failed to apply config file: {e}"));
+        }
 
-    // Move temp to final path (same directory — rename is always atomic, no copy fallback)
-    if let Err(e) = std::fs::rename(&temp_path, &target_path) {
-        let _ = std::fs::remove_file(&temp_path);
-        if let Some(bp) = backup_path.as_ref() {
-            if bp.exists() {
-                let _ = std::fs::rename(bp, &target_path);
+        let mut metadata = load_metadata(&paths);
+        // Preserve existing auto_update_interval, per-subscription user_agent, and
+        // URL only when updating an existing subscription — avoids silently
+        // resetting user-configured settings if the URL changed mid-download.
+        // For new subscriptions, any pre-existing entry under `clean_name` is
+        // stale (e.g. an orphaned entry left by a failed delete) and must not
+        // leak into the new subscription's metadata.
+        let (preserved_interval, preserved_ua, preserved_url, preserved_sub_info) = if overwrite {
+            metadata
+                .configs
+                .get(&clean_name)
+                .map(|m| {
+                    (
+                        m.auto_update_interval,
+                        m.user_agent.clone(),
+                        m.url.clone(),
+                        m.sub_info.clone(),
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            (None, None, None, None)
+        };
+        metadata.configs.insert(
+            clean_name.clone(),
+            super::crypto::ConfigMetadata {
+                url: preserved_url.or(Some(final_url)),
+                sub_info: if sub_info_header.is_empty() {
+                    preserved_sub_info
+                } else {
+                    Some(sub_info_header)
+                },
+                last_updated: Some(
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                ),
+                auto_update_interval: preserved_interval,
+                user_agent: preserved_ua,
+            },
+        );
+        match save_metadata(&paths, &metadata) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Rollback under lock to prevent cleanup_metadata_cache
+                // from removing the metadata entry while the file is
+                // temporarily absent during rollback.
+                if let Err(rm_err) = std::fs::remove_file(&target_path) {
+                    emit_warn!(
+                        Subscription,
+                        SUB_UPDATE_FAILED,
+                        "Rollback: failed to remove {clean_name}: {rm_err}"
+                    );
+                }
+                if let Some(bp) = backup_path.as_ref() {
+                    if bp.exists() {
+                        if let Err(rn_err) = std::fs::rename(bp, &target_path) {
+                            emit_warn!(
+                                Subscription,
+                                SUB_UPDATE_FAILED,
+                                "Rollback: failed to restore {clean_name} from {:?}: {rn_err}",
+                                bp
+                            );
+                        }
+                    }
+                }
+                Err(e)
             }
         }
-        return Err(format!("Failed to apply config file: {e}"));
-    }
+    };
 
-    // Save metadata — last step so failure can be cleanly rolled back
-    if let Err(e) = save_metadata(&paths, &metadata) {
-        // Rollback config to previous state
-        let _ = std::fs::remove_file(&target_path);
-        if let Some(bp) = backup_path.as_ref() {
-            if bp.exists() {
-                let _ = std::fs::rename(bp, &target_path);
-            }
-        }
+    if let Err(e) = metadata_result {
         return Err(format!("Metadata save failed (config rolled back): {e}"));
     }
 
     // Success — clean up backup
-    if let Some(bp) = backup_path.as_ref() {
-        let _ = std::fs::remove_file(bp);
+    // (backup_path is derived from unique_id, so we can reconstruct it)
+    let backup_path = target_path.with_extension(format!("yaml.bak.{unique_id}"));
+    if backup_path.exists() {
+        let _ = std::fs::remove_file(&backup_path);
     }
 
     Ok(DownloadSubResult {


### PR DESCRIPTION
## Problem

All metadata read-modify-write operations on `metadata.json` lacked concurrency control, causing Lost Update races between the background subscription scheduler and user-initiated Tauri commands.

## Solution

1. **`METADATA_LOCK: Mutex<()>`** — serializes all metadata RMW operations
2. **Restructured `download_sub_inner`** — metadata RMW after file I/O, under lock, URL preserved with `overwrite` guard
3. **Atomic `save_metadata`** — temp file + rename with Windows AV fallback
4. **Inlined `update_metadata_entry`** — `get_config_url` called before lock
5. **File swap under lock** — `rename_config` and `download_sub_inner` hold `METADATA_LOCK` during file renames + rollback to prevent `cleanup_metadata_cache` from removing entries while files are temporarily absent
6. **Rollback on save failure** — both `rename_config` and `download_sub_inner` now rollback file operations under lock if `save_metadata` fails
7. **Documented lock preconditions** — `save_metadata`/`load_metadata` doc comments state the locking requirement; `METADATA_LOCK` doc accurately reflects that the lock may be held across file operations

## Verification

- `cargo fmt`: pass
- `cargo clippy --all-targets -- -D warnings`: pass (0 warnings)
- LlamaPReview: No review blocker found
- SonarQube: Quality Gate passed, 0 new issues