### PR TITLE
fix(logs): prevent frontend log loss during startup

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1135,23 +1135,15 @@ async fn rate_limited_unregister_shortcut(
 /// - `"notification"` → `FRONTEND_NOTIFICATION`
 /// - `"uncaught"`      → `FRONTEND_UNCAUGHT`
 /// - `"rejection"`     → `FRONTEND_REJECTION`
+///
+/// **No backend-side rate limiting** -- the frontend (`frontend-log.js`)
+/// already enforces a comprehensive limiter (50 non-error + 100 error
+/// entries per 5 s window with content-hash dedup). A previous 5 ms
+/// minimum-interval limiter here dropped legitimate startup logs that
+/// arrived 1-2 ms apart (e.g. `get_settings` then `calling start_core`).
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value, clippy::unnecessary_wraps)]
-fn write_frontend_log(
-    level: String,
-    source: String,
-    message: String,
-    rate_limiter: tauri::State<'_, RateLimiter>,
-) -> Result<(), String> {
-    // Backend-side rate limiting: 5ms minimum interval = 200/s max.
-    // The frontend limiter (150/5s = 30/s) is the primary guard, but
-    // this prevents direct invoke() bypass from flooding the log.
-    // Silently drop (Ok) instead of using rate_limit! macro, because
-    // the macro's emit_warn! on rejection would itself flood the log.
-    if !rate_limiter.check_rate_limit("write_frontend_log", 5) {
-        return Ok(());
-    }
-
+fn write_frontend_log(level: String, source: String, message: String) -> Result<(), String> {
     use crate::backend_event::codes;
     let code = match source.as_str() {
         "notification" => codes::FRONTEND_NOTIFICATION,

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -94,6 +94,57 @@ let _trafficWsHandle = null;
 /** @type {Function | null} */
 let _configParseErrorListener = null;
 
+/** Maximum time to wait for backend-event listener registration before
+ *  degrading to console-only logging (e.g. browser dev mode where Tauri IPC
+ *  is unavailable).
+ */
+const BACKEND_LISTENER_TIMEOUT_MS = 3000;
+
+/**
+ * Promise that resolves when backend event listeners are registered.
+ *
+ * Started at **module load time** (before `error`/`unhandledrejection` handlers
+ * are installed) so that early bootstrap failures can still be forwarded to
+ * the backend. `initApp()` awaits this promise to ensure registration is
+ * complete before the first `apiLogger.info()` call.
+ *
+ * A `BACKEND_LISTENER_TIMEOUT_MS` timeout prevents a stalled IPC call from
+ * blocking startup.
+ */
+const _backendListenersReady = _initBackendListenersWithTimeout();
+
+/**
+ * Register backend event listeners with a timeout.
+ * If the timeout fires, startup proceeds with console-only logging.
+ * @returns {Promise<void>}
+ */
+async function _initBackendListenersWithTimeout() {
+  let timeoutId;
+  try {
+    const registration = initBackendEventListeners();
+    // Prevent unhandled rejection if the timeout wins the race and the
+    // listener registration rejects later (e.g. Tauri IPC failing slowly).
+    registration.catch(() => {});
+    await Promise.race([
+      registration,
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error('backend-event listener registration timed out')),
+          BACKEND_LISTENER_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } catch (err) {
+    // Tauri IPC unavailable or slow (e.g. browser dev mode) — degrade to
+    // console-only logging. apiLogger.warn prints to console.warn regardless.
+    // We can't use apiLogger here because it might not be ready yet.
+    // eslint-disable-next-line no-console
+    console.warn('[Zephyr] Failed to init backend event listeners', err);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════
 //  initReactiveBindings — Centralized Bus -> store -> DOM wiring
 // ═══════════════════════════════════════════════════════════════════
@@ -140,6 +191,16 @@ function initReactiveBindings() {
 
 async function initApp() {
   const t0 = performance.now();
+
+  // 0. Await backend event listeners (started at module load time).
+  //
+  // The listener registration was kicked off at the top of this module —
+  // before `error`/`unhandledrejection` handlers were installed — so that
+  // early bootstrap failures can be forwarded to the backend. Here we just
+  // wait for it to complete (with a 3 s timeout built in).
+  await _backendListenersReady;
+  registerCleanup(cleanupBackendEventListeners);
+
   apiLogger.info(`[Zephyr] initApp started at ${new Date().toLocaleTimeString()}`);
 
   // 1. Disable context menu globally (except on draggable titlebar)
@@ -269,12 +330,6 @@ async function initApp() {
 
   // 6. Initialize all UI modules
   const tUI = performance.now();
-
-  // 6a. Initialize backend event listeners (before other UI, so events aren't missed)
-  initBackendEventListeners().catch((err) => {
-    apiLogger.warn('Failed to init backend event listeners', err);
-  });
-  registerCleanup(cleanupBackendEventListeners);
 
   initNavigation({
     onProxies: () => { renderProxies(); },
@@ -464,8 +519,8 @@ async function initApp() {
 
 // Global error handlers — catch uncaught exceptions and unhandled
 // Promise rejections that would otherwise silently vanish from the
-// app log.  These run BEFORE DOMContentLoaded so they're armed as early
-// as possible.
+// app log. These run AFTER _backendListenersReady is started (above)
+// so that forwarded logs have a listener ready to receive them.
 window.addEventListener('error', (event) => {
     const { error: err, message, filename, lineno, colno } = event;
     const detail = err instanceof Error

--- a/apps/desktop/src/modules/backend-events.js
+++ b/apps/desktop/src/modules/backend-events.js
@@ -27,6 +27,193 @@ let _backendEventUnlisten = null;
 /** @type {((entry: { type: string, message: string, timestamp: string, source?: string }) => void) | null} */
 let _onNewEvent = null;
 
+// ── Internal Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Format a timestamp for log display.
+ * Uses the provided epoch-ms timestamp, or falls back to current time.
+ * @param {number} [timestampMs]
+ * @returns {string}
+ */
+function _formatTimestamp(timestampMs) {
+    return (timestampMs && timestampMs > 0)
+        ? new Date(timestampMs).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
+        : new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+/**
+ * Push an event into the accumulated buffer and notify the logs page subscriber.
+ * Shared by both the backend-event and prism-event handlers.
+ * @param {{ type: string, message: string, timestamp: string, source?: string }} entry
+ */
+function _pushEvent(entry) {
+    _extLogEvents.push(entry);
+    if (_extLogEvents.length > 500) {
+        _extLogEvents = _extLogEvents.slice(-500);
+    }
+    _onNewEvent?.(entry);
+}
+
+// ── Event Handlers ───────────────────────────────────────────────────────────
+
+/** PrismEvent variant names for tagged-enum payload detection. */
+const PRISM_VARIANTS = ['ConfigReloaded', 'PatchFailed', 'PatchApplied', 'WatcherEvent', 'WatcherStatus', 'RulesChanged'];
+
+/**
+ * Normalize a PrismEvent payload into { type, data }.
+ * Handles both flattened and tagged-enum formats.
+ * @param {any} payload
+ * @returns {{ type: string, data: any }}
+ */
+function _normalizePrismPayload(payload) {
+    if (payload.type && typeof payload.type === 'string') {
+        // Flattened format: { "type": "ConfigReloaded", ... }
+        return { type: payload.type, data: payload };
+    }
+    // Tagged enum format: { "ConfigReloaded": { ... } }
+    for (const v of PRISM_VARIANTS) {
+        if (payload[v] !== undefined) {
+            return { type: v, data: payload[v] };
+        }
+    }
+    return { type: 'Unknown', data: payload };
+}
+
+/**
+ * Extract added/removed/modified counts from a PrismEvent data object.
+ * @param {any} data
+ * @returns {{ added: number, removed: number, modified: number }}
+ */
+function _extractChanges(data) {
+    return {
+        added: data.added || data.added_count || 0,
+        removed: data.removed || data.removed_count || 0,
+        modified: data.modified || data.modified_count || 0,
+    };
+}
+
+/**
+ * Format added/removed/modified stat parts from a PrismEvent data object.
+ * @param {any} data
+ * @param {boolean} [labels=false] - when true, include descriptive labels
+ *   (e.g. `+3 added` instead of `+3`).
+ * @returns {string[]}
+ */
+function _formatStatParts(data, labels = false) {
+    const { added, removed, modified } = _extractChanges(data);
+    const parts = [];
+    if (added) parts.push(labels ? `+${added} added` : `+${added}`);
+    if (removed) parts.push(labels ? `-${removed} removed` : `-${removed}`);
+    if (modified) parts.push(labels ? `~${modified} modified` : `~${modified}`);
+    return parts;
+}
+
+/**
+ * Type-to-formatter map for PrismEvent types.
+ * Each formatter receives the `data` object and returns a display string.
+ * @type {Record<string, (data: any) => string>}
+ */
+const PRISM_FORMATTERS = {
+    WatcherStatus: (d) => (d.running ? `Watching ${d.watching_count} dir(s)` : 'Watch stopped'),
+
+    PatchApplied: (d) => {
+        const stats = _formatStatParts(d);
+        const pid = d.patch_id || d.id || '';
+        const statsStr = stats.length ? ` [${stats.join(' ')}]` : '';
+        const elapsed = d.duration || d.elapsed;
+        const dur = elapsed ? ` in ${elapsed}` : '';
+        return `${pid}${statsStr}${dur}`.trim() || 'patch applied';
+    },
+
+    RulesChanged: (d) => {
+        const parts = _formatStatParts(d, true);
+        return parts.length ? parts.join(', ') : 'no changes';
+    },
+};
+
+/**
+ * Format a human-readable message for a PrismEvent.
+ * @param {string} type
+ * @param {any} data
+ * @returns {string}
+ */
+function _formatPrismMessage(type, data) {
+    if (typeof data !== 'object' || data === null) {
+        return String(data);
+    }
+
+    if (data.message) return data.message;
+    if (data.error) return data.error;
+    if (data.file) return `${data.change_type || 'changed'}: ${data.file}`;
+
+    const formatter = Object.prototype.hasOwnProperty.call(PRISM_FORMATTERS, type)
+        ? PRISM_FORMATTERS[type]
+        : null;
+    return (formatter ?? JSON.stringify)(data);
+}
+
+/**
+ * Handler for `backend-event` — structured log events from the Rust backend.
+ * Covers all BackendModule variants (Core, Prism, Frontend, …).
+ * Fatal/Error events from non-frontend modules trigger Toast notifications.
+ * @param {{ payload: any }} event
+ */
+function _handleBackendEvent(event) {
+    const payload = event?.payload;
+    if (!payload || typeof payload !== 'object') return;
+    const { level, module, code, message, timestamp } = payload;
+    if (!level || !module) return;
+
+    // Normalize code/message — defensive against malformed payloads.
+    const text = message ?? '';
+    const codePart = (code !== undefined && code !== null) ? `#${code} ` : '';
+    const formatted = `[${module}] ${codePart}${text}`.trimEnd();
+
+    _pushEvent({
+        type: level,
+        message: formatted,
+        timestamp: _formatTimestamp(timestamp),
+        source: 'backend',
+    });
+
+    // Fatal/Error → Toast notification (dedup by module:code, 10s window)
+    // Skip frontend-originated events to prevent feedback loops:
+    // frontend error → backend → frontend toast → backend log → …
+    if ((level === 'fatal' || level === 'error') && module !== 'frontend') {
+        const key = (code !== undefined && code !== null)
+            ? `${module}:${code}`
+            : `${module}:${text}`;
+        if (_recentErrors.has(key)) return;
+        _recentErrors.add(key);
+        setTimeout(() => _recentErrors.delete(key), 10_000);
+        showNotification(
+            `[${module}] ${text}`,
+            level === 'fatal' ? 'error' : 'warning',
+            null,
+            { log: false }, // Already logged via emit_backend_event
+        );
+    }
+}
+
+/**
+ * Handler for `prism-event` — Prism engine lifecycle events.
+ * Supports both flattened and tagged-enum payload formats.
+ * @param {{ payload: any }} event
+ */
+function _handlePrismEvent(event) {
+    const payload = event?.payload;
+    if (!payload || payload.__diag) return;
+
+    const { type, data } = _normalizePrismPayload(payload);
+    const message = _formatPrismMessage(type, data);
+
+    _pushEvent({
+        type,
+        message,
+        timestamp: _formatTimestamp(),
+    });
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -61,131 +248,49 @@ export function clearExtLogEvents() {
 
 /**
  * Register global backend-event and prism-event listeners.
+ *
+ * The `backend-event` listener is registered first and its failure
+ * **propagates** to the caller — without it, all frontend log forwarding
+ * is silently lost (the backend dispatches via `eval()` with zero
+ * buffering). The caller's `.catch()` handler will fire if this fails,
+ * allowing a fallback to console-only logging.
+ *
+ * The `prism-event` listener is registered second; its failure is
+ * silently swallowed (non-critical — Prism events are informational).
+ *
+ * **Must be awaited before any `forwardToBackend()` calls** to guarantee no
+ * events are lost.
+ *
  * Call once at app startup.
  * @returns {Promise<void>}
+ * @throws {Error} If the `backend-event` listener cannot be registered
+ *   (e.g. Tauri IPC unavailable in browser dev mode).
  */
 export async function initBackendEventListeners() {
     // Already initialized
     if (_backendEventUnlisten && _prismEventUnlisten) return;
 
-    // Listen for prism events (variable updates, etc.)
-    if (!_prismEventUnlisten) {
-        try {
-            _prismEventUnlisten = await listen('prism-event', (/** @type {{ payload: any }} */ event) => {
-                const payload = event.payload;
-                if (!payload || payload.__diag) return;
-
-                // PrismEvent payload format:
-                //   Flattened: { "type": "ConfigReloaded", "success": true, "message": "..." }
-                //   Tagged:    { "ConfigReloaded": { "success": true, "message": "..." } }
-                let type = 'Unknown';
-                let message = '';
-                let data = payload;
-
-                if (payload.type && typeof payload.type === 'string') {
-                    // Flattened format
-                    type = payload.type;
-                    data = payload;
-                } else {
-                    // Tagged enum format
-                    const variants = ['ConfigReloaded', 'PatchFailed', 'PatchApplied', 'WatcherEvent', 'WatcherStatus', 'RulesChanged'];
-                    for (const v of variants) {
-                        if (payload[v] !== undefined) {
-                            type = v;
-                            data = payload[v];
-                            break;
-                        }
-                    }
-                }
-
-                if (typeof data === 'object' && data !== null) {
-                    if (data.message) message = data.message;
-                    else if (data.error) message = data.error;
-                    else if (data.file) message = `${data.change_type || 'changed'}: ${data.file}`;
-                    else if (type === 'WatcherStatus') message = data.running ? `Watching ${data.watching_count} dir(s)` : 'Watch stopped';
-                    else if (type === 'PatchApplied') {
-                        const pid = data.patch_id || data.id || '';
-                        const parts = [];
-                        const a = data.added || data.added_count || 0;
-                        const r = data.removed || data.removed_count || 0;
-                        const m = data.modified || data.modified_count || 0;
-                        if (a) parts.push(`+${a}`);
-                        if (r) parts.push(`-${r}`);
-                        if (m) parts.push(`~${m}`);
-                        const stats = parts.length ? ` [${parts.join(' ')}]` : '';
-                        const dur = data.duration || data.elapsed ? ` in ${data.duration || data.elapsed}` : '';
-                        message = `${pid}${stats}${dur}`;
-                    }
-                    else if (type === 'RulesChanged') {
-                        const parts = [];
-                        const a = data.added || data.added_count || 0;
-                        const r = data.removed || data.removed_count || 0;
-                        const m = data.modified || data.modified_count || 0;
-                        if (a) parts.push(`+${a} added`);
-                        if (r) parts.push(`-${r} removed`);
-                        if (m) parts.push(`~${m} modified`);
-                        message = parts.length ? parts.join(', ') : 'no changes';
-                    }
-                    else message = JSON.stringify(data);
-                } else {
-                    message = String(data);
-                }
-
-                const entry = {
-                    type,
-                    message,
-                    timestamp: new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' }),
-                };
-                _extLogEvents.push(entry);
-                if (_extLogEvents.length > 500) {
-                    _extLogEvents = _extLogEvents.slice(-500);
-                }
-                _onNewEvent?.(entry);
-            });
-        } catch {
-            // Tauri event API not available (e.g. in browser dev mode)
-        }
+    // backend-event listener — registered FIRST and awaited directly.
+    //
+    // This is the critical path: without it, all frontend logs forwarded
+    // via forwardToBackend() are permanently lost (emit_to_main() dispatches
+    // via eval() with zero buffering). If this fails, the caller must know
+    // so it can fall back to console-only logging.
+    //
+    // We do NOT swallow this error — let it propagate so the caller's
+    // .catch() handler actually fires.
+    if (!_backendEventUnlisten) {
+        _backendEventUnlisten = await listen('backend-event', _handleBackendEvent);
     }
 
-    // Listen for backend structured events
-    if (!_backendEventUnlisten) {
+    // prism-event listener — non-critical, failure is silently ignored.
+    // Prism events (rule changes, watcher status) are informational; the
+    // app functions normally without them.
+    if (!_prismEventUnlisten) {
         try {
-            _backendEventUnlisten = await listen('backend-event', (/** @type {{ payload: any }} */ event) => {
-                const { level, module, code, message, timestamp } = event.payload;
-                if (!level || !module) return;
-
-                const entry = {
-                    type: level,
-                    message: `[${module}] #${code} ${message}`,
-                    timestamp: (timestamp && timestamp > 0)
-                        ? new Date(timestamp).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
-                        : new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' }),
-                    source: 'backend',
-                };
-                _extLogEvents.push(entry);
-                if (_extLogEvents.length > 500) {
-                    _extLogEvents = _extLogEvents.slice(-500);
-                }
-                _onNewEvent?.(entry);
-
-                // Fatal/Error → Toast notification (dedup by module:code, 10s window)
-                // Skip frontend-originated events to prevent feedback loops:
-                // frontend error → backend → frontend toast → backend log → …
-                if ((level === 'fatal' || level === 'error') && module !== 'frontend') {
-                    const key = `${module}:${code}`;
-                    if (_recentErrors.has(key)) return;
-                    _recentErrors.add(key);
-                    setTimeout(() => _recentErrors.delete(key), 10_000);
-                    showNotification(
-                        `[${module}] ${message}`,
-                        level === 'fatal' ? 'error' : 'warning',
-                        null,
-                        { log: false }, // Already logged via emit_backend_event
-                    );
-                }
-            });
+            _prismEventUnlisten = await listen('prism-event', _handlePrismEvent);
         } catch {
-            // Tauri event API not available
+            // Tauri event API not available (e.g. browser dev mode)
         }
     }
 }


### PR DESCRIPTION
## Problem

The App Logs page was missing several frontend log entries during application startup. Console output showed 10+ log lines, but the logs page only displayed 4-5 of them.

## Root Causes

### 1. `backend-event` listener registered too late

`initBackendEventListeners()` was called at step 6 in `initApp()`, but the first 4 `apiLogger.info()` calls happened at steps 0-5. The backend dispatches events via `eval()` (synchronous, zero buffering), so events fired before the listener was registered were **permanently lost**.

**Fix**: Start `initBackendEventListeners()` at **module load time**, with a `BACKEND_LISTENER_TIMEOUT_MS` (3 s) `Promise.race` timeout to prevent a stalled IPC call from blocking startup. `initApp()` awaits the resulting promise.

### 2. Backend 5ms rate limiter dropping legitimate startup logs

`write_frontend_log` had a `check_rate_limit("write_frontend_log", 5)` guard that rejected any call within 5ms of the previous one. During startup, logs fire 1-2ms apart and are silently dropped.

The frontend (`frontend-log.js`) already enforces a comprehensive rate limiter, making the backend limiter redundant.

**Fix**: Remove the backend rate limiter from `write_frontend_log`.

## Review Fixes (from PR #1025-#1031)

- **CodeRabbit**: `eslint-disable-next-line no-console`; `PRISM_FORMATTERS` map + `_formatStatParts()`; `event?.payload` guard; `registration.catch(() => {})` for unhandled rejection; `Object.hasOwn()` guard on formatter lookup; parenthesized `||`/ternary; dedup key falls back to message; `PatchApplied` empty-message fallback
- **Sourcery**: Extracted `BACKEND_LISTENER_TIMEOUT_MS` constant; fixed TDZ crash; `event?.payload` in `_handlePrismEvent`
- **Qodo**: Moved listener registration to module load; `clearTimeout` in `finally` block
- **CI**: Fixed TypeScript/JSDoc typecheck errors

## Files Changed

| File | Change |
|---|---|
| `apps/desktop/src/main.js` | Listener at module load + timeout + clearTimeout + unhandled rejection guard |
| `apps/desktop/src/modules/backend-events.js` | Error propagation + defensive payload + PRISM_FORMATTERS + Object.hasOwn + dedup fix |
| `apps/desktop/src-tauri/src/lib.rs` | Remove 5ms backend rate limiter |

## Verification

- `cargo clippy --all-targets -- -D warnings` - pass
- `eslint` - pass
- `tsc -p jsconfig.json --noEmit` - pass
- SonarQube Quality Gate - pass (0 new issues)