### PR TITLE
fix: detect COMPATIBLE-only all[] as provider-loading state

### DIFF
--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -413,15 +413,21 @@ export async function fetchProxyGroups(options = {}) {
     // --- Detect provider-loading state ---
     // Groups with `include-all: true` or `include-all-providers: true` depend
     // on proxy-providers finishing their HTTP download before their `all`
-    // array is populated.  If such a group has an empty `all` array while
-    // the config defines proxy-providers, the nodes are still loading.
+    // array is populated.  If such a group has no real proxy nodes (only
+    // special entries like COMPATIBLE/DIRECT/REJECT/PASS, or is completely
+    // empty), the nodes are still loading.
+    //
+    // mihomo returns `all=[COMPATIBLE]` (length 1) during the download phase,
+    // not `all=[]` (length 0) — so checking `length === 0` misses this state.
     const hasProxyProviders = !!(runConfig && runConfig['proxy-providers']
         && Object.keys(runConfig['proxy-providers']).length > 0);
     const includeAllGroups = buildIncludeAllSet(runConfig);
     const isIncludeAllGroup = uiGroupName
         ? (uiGroupName === 'GLOBAL' || includeAllGroups.has(uiGroupName))
         : false;
-    const providerLoading = hasProxyProviders && isIncludeAllGroup && proxies.length === 0;
+    const hasRealProxies = proxies.length > 0
+        && proxies.some(name => !SPECIAL_GROUPS.has(name));
+    const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
 
     return {
         // Legacy compat fields


### PR DESCRIPTION
## Problem

When mihomo has include-all: true groups with proxy-providers, during the provider download phase mihomo returns ll=[COMPATIBLE] (length 1), not ll=[] (length 0).

The code checked proxies.length === 0 to detect the provider-loading state, which failed because length === 1. As a result:

1. providerLoading was alse even though nodes hadn't arrived
2. The provider poller was never triggered
3. The UI rendered only COMPATIBLE (filtered out in rendering) -> empty node list
4. When nodes arrived later, the UI never re-rendered -> permanent empty list

## Root Cause

proxy-groups.js line 424:
`js
// Before (buggy):
const providerLoading = hasProxyProviders && isIncludeAllGroup && proxies.length === 0;
`

## Fix

Check if ll[] contains only special entries (COMPATIBLE/DIRECT/REJECT/PASS) instead of checking length === 0:

`js
// After (fixed):
const hasRealProxies = proxies.length > 0
    && proxies.some(name => !SPECIAL_GROUPS.has(name));
const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
`

SPECIAL_GROUPS already includes COMPATIBLE (defined at line 22).

## Evidence

Reporter's debug log (2026-07-26.log line 231):
`
RESULT - uiGroup=manual-switch, proxies.length=1, current=COMPATIBLE,
        providerLoading=false, hasProxyProviders=true, isIncludeAllGroup=true
`

After fix: providerLoading would be 	rue, triggering the provider poller, which re-renders once nodes arrive.

## Files Changed

- pps/desktop/src/ui/proxy-groups.js - providerLoading detection logic

## Summary by Sourcery

Bug Fixes:
- Correct provider-loading detection so include-all groups backed by proxy providers are treated as loading when their proxy list contains only special entries such as COMPATIBLE/DIRECT/REJECT/PASS.