### PR TITLE
fix: detect COMPATIBLE-only all[] as provider-loading state

### DIFF
--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1449,12 +1449,12 @@ function startProviderPoll(preferredGroupName, exhaustionKey, attempt = 0) {
                 preferredGroupName: preferredGroupName || undefined,
             });
             if (gen !== _providerPollGeneration) return;  // Cancelled during await
-            if (result && result.proxies.length > 0) {
+            if (result && !result.providerLoading) {
                 // Nodes have arrived — invalidate cache + re-render
                 invalidateProxiesCache();
                 renderProxies().catch(() => {});
             } else {
-                // Still empty — keep polling
+                // Still loading — keep polling
                 startProviderPoll(preferredGroupName, exhaustionKey, attempt + 1);
             }
         } catch (err) {
@@ -1917,10 +1917,12 @@ export async function renderProxies() {
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
 
-    // --- Provider-loading guard ---
-    // If the uiGroup uses include-all and its all[] is empty, the proxy-provider
-    // hasn't finished downloading nodes yet.  Clear any stale cards from a
-    // previous group, then start a silent poller to re-render once nodes arrive.
+// --- Provider-loading guard ---
+// If the uiGroup uses include-all/include-all-providers and its all[] has
+// no real proxy nodes (empty or only special entries like COMPATIBLE),
+// the proxy-provider hasn't finished downloading nodes yet.  Clear any
+// stale cards from a previous group, then start a silent poller to
+// re-render once nodes arrive.
     if (proxyGroupsResult.providerLoading) {
         // If polling was already exhausted for this group, show a terminal state
         // with a retry button instead of restarting the poll loop.

--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -324,7 +324,7 @@ function determineUiPrimaryGroup(ctx) {
  * @property {string|null}  uiGroupName           - Actually used UI group (GLOBAL in global mode, or primary)
  * @property {{source:string, detail:string}} reason - Why this primary group was chosen
  * @property {Record<string, string[]>} graph - Group → children adjacency list
- * @property {boolean} providerLoading - True when uiGroup uses include-all and all[] is empty
+ * @property {boolean} providerLoading - True when uiGroup uses include-all or include-all-providers and all[] has no real proxy nodes (empty or special-only)
  * @property {boolean} hasProxyProviders - True when the config defines proxy-providers (regardless of loading state)
  */
 
@@ -413,15 +413,21 @@ export async function fetchProxyGroups(options = {}) {
     // --- Detect provider-loading state ---
     // Groups with `include-all: true` or `include-all-providers: true` depend
     // on proxy-providers finishing their HTTP download before their `all`
-    // array is populated.  If such a group has an empty `all` array while
-    // the config defines proxy-providers, the nodes are still loading.
+    // array is populated.  If such a group has no real proxy nodes (only
+    // special entries like COMPATIBLE/DIRECT/REJECT/PASS, or is completely
+    // empty), the nodes are still loading.
+    //
+    // mihomo returns `all=[COMPATIBLE]` (length 1) during the download phase,
+    // not `all=[]` (length 0) — so checking `length === 0` misses this state.
     const hasProxyProviders = !!(runConfig && runConfig['proxy-providers']
         && Object.keys(runConfig['proxy-providers']).length > 0);
     const includeAllGroups = buildIncludeAllSet(runConfig);
     const isIncludeAllGroup = uiGroupName
         ? (uiGroupName === 'GLOBAL' || includeAllGroups.has(uiGroupName))
         : false;
-    const providerLoading = hasProxyProviders && isIncludeAllGroup && proxies.length === 0;
+    const hasRealProxies = Array.isArray(proxies)
+        && proxies.some(name => typeof name === 'string' && !SPECIAL_GROUPS.has(name.toUpperCase()));
+    const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
 
     return {
         // Legacy compat fields
@@ -442,7 +448,9 @@ export async function fetchProxyGroups(options = {}) {
         graph,
 
         // Provider loading state — true when the uiGroup uses include-all
-        // and its all[] is empty (nodes still being downloaded by mihomo)
+        // or include-all-providers and its all[] has no real proxy nodes
+        // (empty or only special entries like COMPATIBLE/DIRECT/REJECT/PASS
+        // — nodes still being downloaded by mihomo)
         providerLoading,
 
         // Whether the config defines proxy-providers (regardless of loading

--- a/apps/desktop/src/ui/proxy-groups.test.js
+++ b/apps/desktop/src/ui/proxy-groups.test.js
@@ -163,6 +163,49 @@ describe('fetchProxyGroups providerLoading', () => {
         expect(result.providerLoading).toBe(false);
     });
 
+    it('providerLoading=true when all[] has only COMPATIBLE (the reported bug)', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['COMPATIBLE'], now: 'COMPATIBLE' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(true);
+    });
+
+    it('providerLoading=true when all[] has only lowercase special entries', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['compatible', 'reject'], now: 'compatible' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(true);
+    });
+
+    it('providerLoading=false when all[] has special entries mixed with real nodes', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['COMPATIBLE', 'real-node'], now: 'real-node' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(false);
+        expect(result.proxies).toEqual(['COMPATIBLE', 'real-node']);
+    });
+
     it('GLOBAL group treated as include-all in global mode', async () => {
         const result = await setup({
             proxies: {


### PR DESCRIPTION
## Problem

When mihomo has include-all: true groups with proxy-providers, during the provider download phase mihomo returns ll=[COMPATIBLE] (length 1), not ll=[] (length 0).

The code checked proxies.length === 0 to detect the provider-loading state, which failed because length === 1. As a result:

1. providerLoading was alse even though nodes hadn't arrived
2. The provider poller was never triggered
3. The UI rendered only COMPATIBLE (filtered out in rendering) -> empty node list
4. When nodes arrived later, the UI never re-rendered -> permanent empty list

## Root Cause

proxy-groups.js:
`js
// Before (buggy):
const providerLoading = hasProxyProviders && isIncludeAllGroup && proxies.length === 0;
`

## Fix (3 files, 64 insertions, 11 deletions)

**1. proxy-groups.js 鈥?providerLoading detection**

Check if ll[] contains only special entries (COMPATIBLE/DIRECT/REJECT/PASS) instead of checking length === 0:
`js
const hasRealProxies = Array.isArray(proxies)
    && proxies.some(name =>
        typeof name === 'string' && !SPECIAL_GROUPS.has(name.toUpperCase()));
const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
`

**2. proxies.js 鈥?provider poller guard**

The poller checked esult.proxies.length > 0 to decide if nodes arrived. With ['COMPATIBLE'] (length 1), it would falsely stop polling. Changed to !result.providerLoading:
`js
if (result && !result.providerLoading) {
    // Nodes have arrived
} else {
    // Still loading 鈥?keep polling
}
`

**3. Tests + docs**

- 3 regression tests: COMPATIBLE-only, lowercase special, mixed special+real
- Updated JSDoc, return-object comment, and proxies.js guard comment

## Evidence

Reporter's debug log (2026-07-26.log line 231):
`
RESULT - uiGroup=manual-switch, proxies.length=1, current=COMPATIBLE,
        providerLoading=false, hasProxyProviders=true, isIncludeAllGroup=true
`

After fix: providerLoading would be 	rue, triggering the provider poller, which re-renders once nodes arrive.

## Files Changed

- pps/desktop/src/ui/proxy-groups.js 鈥?providerLoading detection + guards + docs
- pps/desktop/src/ui/proxies.js 鈥?poller guard: length > 0 -> !providerLoading
- pps/desktop/src/ui/proxy-groups.test.js 鈥?3 new regression tests

## Summary by Sourcery

Detect provider-loading state based on absence of real proxy nodes rather than empty all[] and ensure the UI repolls and re-renders once providers finish loading.

Bug Fixes:
- Fix providerLoading detection for include-all groups when all[] contains only special entries like COMPATIBLE, so provider-backed groups are correctly treated as loading until real nodes arrive.
- Fix provider poller termination condition so it waits for providerLoading=false instead of any non-empty proxies list, preventing premature stop when only special entries are present.

Tests:
- Add regression tests covering COMPATIBLE-only groups, lowercase special entries, and mixed special+real nodes to validate providerLoading behavior.