### PR TITLE
fix: prevent saving group name as proxy node in switchToConfig

### DIFF
--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -38,7 +38,11 @@ export async function switchToConfig(configName, customArgs = []) {
     // 使用短超时 —— 如果 mihomo 繁忙（如延迟测试仍在队列中），
     // 回退到 appStore 状态而不是阻塞数秒
     let timer;
-    const fetchPromise = fetchProxyGroups();
+    // Pass preferredGroupName so the resolver targets the user's chosen group
+    // instead of the effective group.  Without this, `current` may come from
+    // a different group (e.g., "兜底分流") whose `now` is a group name (e.g.,
+    // "手动切换"), which would be incorrectly saved as the proxy node.
+    const fetchPromise = fetchProxyGroups({ preferredGroupName: groupName || undefined });
     const timeoutPromise = new Promise(resolve => { timer = setTimeout(() => resolve(null), 500); });
     const currentProxyGroups = await Promise.race([fetchPromise, timeoutPromise]);
     clearTimeout(timer);

--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -337,6 +337,21 @@ export async function restoreProxySelection(profileName) {
         // After profile/core switches, the saved node may belong to a different
         // selector group than the resolved primary.
         const proxyMap = /** @type {any} */ (proxyGroupsResult.data)?.proxies;
+
+        // Defensive: if saved.node is actually a group name (e.g., "手动切换"
+        // saved as node when it's a Selector group), skip restoration —
+        // switching to a group-as-node in GLOBAL causes the UI to jump to
+        // the effective group instead of the user's preferred group.
+        if (proxyMap && saved.node && proxyMap[saved.node]) {
+            const nodeType = (proxyMap[saved.node]?.type || '').toLowerCase();
+            if (['selector', 'urltest', 'fallback', 'loadbalance', 'relay'].includes(nodeType)) {
+                proxyMemoryLogger.warn(
+                    `${_dbgTag}: saved.node "${saved.node}" is a group (type=${nodeType}), not a proxy node — skipping restoration`,
+                );
+                return false;
+            }
+        }
+
         const fallbackGroup = findWritableGroupWithNode(proxyMap, saved.node);
         if (fallbackGroup) {
             const success = await switchProxy(fallbackGroup, saved.node);


### PR DESCRIPTION
## Problem

When switching configs, the app saves the current proxy selection to restore later. However, switchToConfig in lifecycle.js called etchProxyGroups() **without** preferredGroupName, causing the resolver to return the effective group (e.g., "鍏滃簳鍒嗘祦") instead of the user's preferred group (e.g., "鎵嬪姩鍒囨崲").

The effective group's 
ow can be a **group name** (e.g., "鍏滃簳鍒嗘祦" has 
ow=鎵嬪姩鍒囨崲 because "鎵嬪姩鍒囨崲" is one of its Selector options). This group name was incorrectly saved as the proxy node:
`
saved = {"node":"鎵嬪姩鍒囨崲","group":"鎵嬪姩鍒囨崲"}  // 鈫?node is a GROUP NAME, not a proxy node
`

On restore, proxies.includes("鎵嬪姩鍒囨崲") = false (because "鎵嬪姩鍒囨崲" is the group, not a node within it) 鈫?fallback search finds it in GLOBAL 鈫?switches to GLOBAL 鈫?UI jumps from "鎵嬪姩鍒囨崲" to "鍏滃簳鍒嗘祦" (effective group).

## Evidence

Reporter's log (2026-07-28 (1).log line 2140):
`
restoreProxySelection: saved.node=馃殌 鎵嬪姩鍒囨崲, saved.group=馃殌 鎵嬪姩鍒囨崲
proxies.includes(saved.node)=false
fallback search 鈥?fallbackGroup=GLOBAL
fallback switchProxy success, group=GLOBAL
renderProxies: preferredGroupName=GLOBAL, uiGroupName=馃實 鍏滃簳鍒嗘祦
`

## Fix (2 files)

**1. lifecycle.js 鈥?pass preferredGroupName to etchProxyGroups**
`js
// Before (buggy):
const fetchPromise = fetchProxyGroups();

// After (fixed):
const fetchPromise = fetchProxyGroups({ preferredGroupName: groupName || undefined });
`
This ensures current comes from the user's preferred group (a real proxy node), not the effective group (which may have a group name as 
ow).

**2. proxy-memory.js 鈥?defensive check for stale saved data**

For users who already have incorrect saved data from the previous bug, add a check: if saved.node exists in the proxy map as a group (type Selector/URLTest/Fallback/LoadBalance/Relay), skip restoration instead of falling back to GLOBAL.
`js
if (proxyMap[saved.node]) {
    const nodeType = proxyMap[saved.node]?.type?.toLowerCase();
    if (['selector', 'urltest', 'fallback', 'loadbalance', 'relay'].includes(nodeType)) {
        // saved.node is a group, not a proxy 鈥?skip restoration
        return false;
    }
}
`

## Files Changed

- pps/desktop/src/ui/lifecycle.js 鈥?pass preferredGroupName to etchProxyGroups
- pps/desktop/src/ui/proxy-memory.js 鈥?defensive check for group-name-as-node

## Summary by Sourcery

Prevent saving proxy group names as proxy nodes when switching configurations and make restoration robust against previously corrupted proxy selections.

Bug Fixes:
- Ensure proxy groups are fetched using the user's preferred group when switching configs to avoid saving an effective group's name as the selected proxy node.
- Skip restoring saved proxy selections when the saved node is actually a proxy group (Selector/URLTest/Fallback/LoadBalance/Relay) to avoid incorrect fallbacks and UI jumps.