### PR TITLE
fix: prevent saving group name as proxy node in switchToConfig

### DIFF
--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -38,7 +38,11 @@ export async function switchToConfig(configName, customArgs = []) {
     // 使用短超时 —— 如果 mihomo 繁忙（如延迟测试仍在队列中），
     // 回退到 appStore 状态而不是阻塞数秒
     let timer;
-    const fetchPromise = fetchProxyGroups();
+    // Pass preferredGroupName so the resolver targets the user's chosen group
+    // instead of the effective group.  Without this, `current` may come from
+    // a different group (e.g., "兜底分流") whose `now` is a group name (e.g.,
+    // "手动切换"), which would be incorrectly saved as the proxy node.
+    const fetchPromise = fetchProxyGroups({ preferredGroupName: groupName || undefined });
     const timeoutPromise = new Promise(resolve => { timer = setTimeout(() => resolve(null), 500); });
     const currentProxyGroups = await Promise.race([fetchPromise, timeoutPromise]);
     clearTimeout(timer);

--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -277,6 +277,21 @@ export async function restoreProxySelection(profileName) {
 
         if (!saved.node) return false;
 
+        // Defensive: if saved.node === saved.group, the node was saved
+        // incorrectly by a previous version of switchToConfig (which fetched
+        // from the effective group instead of the preferred group, causing the
+        // group name to be saved as the node).  Skip restoration early to
+        // avoid waiting for provider downloads and jumping to GLOBAL.  This
+        // check is precise: a valid group-as-node selection always has
+        // different group and node names (e.g., group="兜底分流",
+        // node="手动切换"), so legitimate restorations are never blocked.
+        if (saved.node === saved.group) {
+            proxyMemoryLogger.warn(
+                `[restoreProxySelection] saved.node "${saved.node}" equals saved.group — stale data from previous bug, skipping restoration`,
+            );
+            return false;
+        }
+
         // Resolve preferred group: primary preference > saved group > current UI group
         const primaryGroup = settings.primary_group_preference?.[profileName] || null;
         const preferredGroupName = primaryGroup || saved.group || appStore.get('uiGroupName') || null;


### PR DESCRIPTION
## Problem

When switching configs, switchToConfig in lifecycle.js called etchProxyGroups() **without** preferredGroupName, causing the resolver to return the effective group (e.g., "鍏滃簳鍒嗘祦") instead of the user's preferred group (e.g., "鎵嬪姩鍒囨崲").

The effective group's 
ow can be a **group name** (e.g., "鍏滃簳鍒嗘祦" has 
ow=鎵嬪姩鍒囨崲). This group name was incorrectly saved as the proxy node:
`
saved = {"node":"鎵嬪姩鍒囨崲","group":"鎵嬪姩鍒囨崲"}  // node is a GROUP NAME
`

On restore, proxies.includes("鎵嬪姩鍒囨崲") = false 鈫?fallback to GLOBAL 鈫?UI jumps from "鎵嬪姩鍒囨崲" to "鍏滃簳鍒嗘祦".

## Fix (2 files)

**1. lifecycle.js 鈥?pass preferredGroupName to etchProxyGroups**

Ensures current comes from the user's preferred group (a real proxy node), not the effective group (which may have a group name as 
ow).

**2. proxy-memory.js 鈥?early defensive check for stale saved data**

For users with existing incorrect saved data (saved.node === saved.group), skip restoration **immediately** after the !saved.node guard 鈥?before any network calls 鈥?to avoid waiting for provider downloads and jumping to GLOBAL.

This check is precise: a valid group-as-node selection always has different group and node names (e.g., group="鍏滃簳鍒嗘祦", node="鎵嬪姩鍒囨崲"), so legitimate restorations are never blocked.

## Evidence

Reporter's log (2026-07-28 (1).log line 2140):
`
restoreProxySelection: saved.node=馃殌 鎵嬪姩鍒囨崲, saved.group=馃殌 鎵嬪姩鍒囨崲
proxies.includes(saved.node)=false
fallback search 鈥?fallbackGroup=GLOBAL
renderProxies: preferredGroupName=GLOBAL, uiGroupName=馃實 鍏滃簳鍒嗘祦
`

## Files Changed

- pps/desktop/src/ui/lifecycle.js 鈥?pass preferredGroupName to etchProxyGroups
- pps/desktop/src/ui/proxy-memory.js 鈥?early saved.node === saved.group check

## Summary by Sourcery

Fix incorrect restoration of proxy selections when switching configurations by ensuring the preferred group is respected and stale saved selections are ignored.

Bug Fixes:
- Ensure proxy group resolution during config switching uses the preferred group so a group name is not incorrectly saved as the proxy node.
- Add an early guard in proxy selection restore logic to skip entries where the saved node equals the saved group, avoiding use of stale, invalid state.