### PR TITLE
fix: prevent saving group name as proxy node in switchToConfig

### DIFF
--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -38,7 +38,11 @@ export async function switchToConfig(configName, customArgs = []) {
     // 使用短超时 —— 如果 mihomo 繁忙（如延迟测试仍在队列中），
     // 回退到 appStore 状态而不是阻塞数秒
     let timer;
-    const fetchPromise = fetchProxyGroups();
+    // Pass preferredGroupName so the resolver targets the user's chosen group
+    // instead of the effective group.  Without this, `current` may come from
+    // a different group (e.g., "兜底分流") whose `now` is a group name (e.g.,
+    // "手动切换"), which would be incorrectly saved as the proxy node.
+    const fetchPromise = fetchProxyGroups({ preferredGroupName: groupName ?? undefined });
     const timeoutPromise = new Promise(resolve => { timer = setTimeout(() => resolve(null), 500); });
     const currentProxyGroups = await Promise.race([fetchPromise, timeoutPromise]);
     clearTimeout(timer);
@@ -56,9 +60,16 @@ export async function switchToConfig(configName, customArgs = []) {
       const liveSettings = await invoke(COMMANDS.GET_SETTINGS);
       const activeConfig = liveSettings.last_config || 'config.yaml';
       const { saveProxySelection } = await import('./proxy-memory.js');
+      // Use the resolver's uiGroupName when available (it may normalize
+      // or fall back from the raw appStore value), falling back to the
+      // raw groupName only on timeout.
+      const resolvedGroup = currentProxyGroups?.uiGroupName
+        || currentProxyGroups?.mainGroup
+        || groupName
+        || null;
       await saveProxySelection(activeConfig, {
         node: nodeToSave,
-        group: groupName,
+        group: resolvedGroup,
       });
     }
   } catch (e) {

--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -266,6 +266,26 @@ export async function restoreProxySelection(profileName) {
         const raw = settings.last_proxy_selection?.[profileName];
         const saved = parseSelection(raw);
 
+        // Defensive: if saved.node === saved.group, the node was saved
+        // incorrectly by a previous version of switchToConfig (which fetched
+        // from the effective group instead of the preferred group, causing the
+        // group name to be saved as the node).  Clear the stale entry and
+        // skip restoration early — before any network calls — to avoid
+        // waiting for mihomo readiness and jumping to GLOBAL.
+        // This check is precise: a valid group-as-node selection always has
+        // different group and node names (e.g., group="兜底分流",
+        // node="手动切换"), so legitimate restorations are never blocked.
+        if (saved.node && saved.node === saved.group) {
+            proxyMemoryLogger.warn(
+                `[restoreProxySelection] saved.node "${saved.node}" equals saved.group — stale data from previous bug, clearing and skipping restoration`,
+            );
+            // Clear the stale entry to prevent repeated warnings on every run
+            try {
+                await saveProxySelection(profileName, /** @type {any} */ ({ node: null, group: null }));
+            } catch { /* ignore cleanup errors */ }
+            return false;
+        }
+
         // Always wait for mihomo to be ready, even if no saved node exists.
         // Callers removed their hardcoded delays and rely on this function
         // to ensure the core is ready before proceeding.


### PR DESCRIPTION
## Problem

When switching configs, switchToConfig in lifecycle.js called etchProxyGroups() **without** preferredGroupName, causing the resolver to return the effective group (e.g., "鍏滃簳鍒嗘祦") instead of the user's preferred group (e.g., "鎵嬪姩鍒囨崲").

The effective group's 
ow can be a **group name** (e.g., "鍏滃簳鍒嗘祦" has 
ow=鎵嬪姩鍒囨崲). This group name was incorrectly saved as the proxy node:
`
saved = {"node":"鎵嬪姩鍒囨崲","group":"鎵嬪姩鍒囨崲"}  // node is a GROUP NAME
`

On restore, proxies.includes("鎵嬪姩鍒囨崲") = false 鈫?fallback to GLOBAL 鈫?UI jumps from "鎵嬪姩鍒囨崲" to "鍏滃簳鍒嗘祦".

## Fix (2 files, 33 insertions, 2 deletions)

**1. lifecycle.js 鈥?two fixes:**

- Pass preferredGroupName to etchProxyGroups (using ?? for null-safe handling)
- Use resolver's uiGroupName when saving (not raw ppStore value), so the saved group matches the actual resolved group

**2. proxy-memory.js 鈥?early defensive check for stale saved data:**

- Check saved.node === saved.group immediately after parseSelection(raw), before any network calls (waitForMihomoReady, etchProxyGroups, waitForProvidersLoaded)
- Clear the stale entry via saveProxySelection(null, null) to prevent repeated warnings
- Precise: a valid group-as-node selection always has different group and node names, so legitimate restorations are never blocked

## Evidence

Reporter's log (2026-07-28 (1).log line 2140):
`
restoreProxySelection: saved.node=馃殌 鎵嬪姩鍒囨崲, saved.group=馃殌 鎵嬪姩鍒囨崲
proxies.includes(saved.node)=false
fallback search 鈥?fallbackGroup=GLOBAL
renderProxies: preferredGroupName=GLOBAL, uiGroupName=馃實 鍏滃簳鍒嗘祦
`

## Files Changed

- pps/desktop/src/ui/lifecycle.js 鈥?pass preferredGroupName + use resolved group name
- pps/desktop/src/ui/proxy-memory.js 鈥?early saved.node === saved.group check + stale data cleanup

## Summary by Sourcery

Fix incorrect persistence and restoration of proxy group selections when switching configurations.

Bug Fixes:
- Ensure proxy groups are fetched using the preferred group name so the saved proxy node corresponds to the user-selected group instead of the effective group.
- Use the resolved UI group name when saving proxy selections to align stored group data with the actual resolved group.
- Add an early defensive check that detects and clears stale proxy selection entries where the saved node equals the group name, preventing invalid restorations and UI jumps to the GLOBAL group.