### PR TITLE
fix: prevent saving group name as proxy node in switchToConfig

### DIFF
--- a/apps/desktop/src/ui/lifecycle.js
+++ b/apps/desktop/src/ui/lifecycle.js
@@ -38,7 +38,11 @@ export async function switchToConfig(configName, customArgs = []) {
     // 使用短超时 —— 如果 mihomo 繁忙（如延迟测试仍在队列中），
     // 回退到 appStore 状态而不是阻塞数秒
     let timer;
-    const fetchPromise = fetchProxyGroups();
+    // Pass preferredGroupName so the resolver targets the user's chosen group
+    // instead of the effective group.  Without this, `current` may come from
+    // a different group (e.g., "兜底分流") whose `now` is a group name (e.g.,
+    // "手动切换"), which would be incorrectly saved as the proxy node.
+    const fetchPromise = fetchProxyGroups({ preferredGroupName: groupName ?? undefined });
     const timeoutPromise = new Promise(resolve => { timer = setTimeout(() => resolve(null), 500); });
     const currentProxyGroups = await Promise.race([fetchPromise, timeoutPromise]);
     clearTimeout(timer);
@@ -56,9 +60,16 @@ export async function switchToConfig(configName, customArgs = []) {
       const liveSettings = await invoke(COMMANDS.GET_SETTINGS);
       const activeConfig = liveSettings.last_config || 'config.yaml';
       const { saveProxySelection } = await import('./proxy-memory.js');
+      // Use the resolver's uiGroupName when live data was available
+      // (it may normalize or fall back from the raw appStore value).
+      // On timeout fallback, use the raw groupName to keep node and
+      // group sources consistent.
+      const resolvedGroup = (currentProxyGroups && currentProxyGroups.current)
+        ? (currentProxyGroups.uiGroupName || currentProxyGroups.mainGroup || groupName || null)
+        : (groupName || null);
       await saveProxySelection(activeConfig, {
         node: nodeToSave,
-        group: groupName,
+        group: resolvedGroup,
       });
     }
   } catch (e) {

--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -277,6 +277,25 @@ export async function restoreProxySelection(profileName) {
 
         if (!saved.node) return false;
 
+        // Defensive: if saved.node === saved.group, the node was saved
+        // incorrectly by a previous version of switchToConfig (which fetched
+        // from the effective group instead of the preferred group, causing the
+        // group name to be saved as the node).  Clear the stale entry and
+        // skip restoration.  This check is precise: a valid group-as-node
+        // selection always has different group and node names (e.g.,
+        // group="兜底分流", node="手动切换"), so legitimate restorations
+        // are never blocked.
+        if (saved.node === saved.group) {
+            proxyMemoryLogger.warn(
+                `[restoreProxySelection] saved.node "${saved.node}" equals saved.group — stale data from previous bug, clearing and skipping restoration`,
+            );
+            // Clear the stale entry to prevent repeated warnings on every run
+            try {
+                await saveProxySelection(profileName, /** @type {any} */ ({ node: null, group: null }));
+            } catch { /* ignore cleanup errors */ }
+            return false;
+        }
+
         // Resolve preferred group: primary preference > saved group > current UI group
         const primaryGroup = settings.primary_group_preference?.[profileName] || null;
         const preferredGroupName = primaryGroup || saved.group || appStore.get('uiGroupName') || null;


### PR DESCRIPTION
## Problem

When switching configs, switchToConfig called etchProxyGroups() without preferredGroupName, causing the resolver to return the effective group (e.g., "鍏滃簳鍒嗘祦") instead of the user's preferred group (e.g., "鎵嬪姩鍒囨崲"). The effective group's 
ow (a group name) was incorrectly saved as the proxy node, causing the UI to jump to GLOBAL/鍏滃簳鍒嗘祦 on restore.

## Fix (2 files, 32 insertions, 2 deletions)

**1. lifecycle.js:**
- Pass preferredGroupName to etchProxyGroups (using ?? for null-safe handling)
- Use resolver's uiGroupName for saving only when live data was available; on timeout fallback, use raw groupName to keep node and group sources consistent

**2. proxy-memory.js:**
- Check saved.node === saved.group after waitForMihomoReady() (preserving readiness guarantee for callers) but before etchProxyGroups (avoiding unnecessary network calls)
- Clear the stale entry via saveProxySelection(null, null) to prevent repeated warnings
- Precise: a valid group-as-node selection always has different group and node names, so legitimate restorations are never blocked

## Evidence

Reporter's log (2026-07-28 (1).log line 2140):
`
restoreProxySelection: saved.node=馃殌 鎵嬪姩鍒囨崲, saved.group=馃殌 鎵嬪姩鍒囨崲
proxies.includes(saved.node)=false 鈫?fallback to GLOBAL
renderProxies: preferredGroupName=GLOBAL, uiGroupName=馃實 鍏滃簳鍒嗘祦
`

## Files Changed

- pps/desktop/src/ui/lifecycle.js 鈥?pass preferredGroupName + consistent group source
- pps/desktop/src/ui/proxy-memory.js 鈥?stale data check + cleanup

## Summary by Sourcery

Prevent incorrect saving of proxy group names as nodes when switching configurations and ensure stale selections are cleaned up on restore.

Bug Fixes:
- Ensure fetchProxyGroups uses the preferred proxy group when switching configs so group names are not mistakenly saved as nodes.
- Avoid restoring and repeatedly logging stale proxy selections where the saved node and group are identical by clearing them before fetching proxies.

Enhancements:
- Align saved proxy group names with either live resolver output or raw UI state to keep node and group sources consistent during config switches.