### PR TITLE
fix: detect local-proxy-only all[] as provider-loading state

### DIFF
--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -413,21 +413,47 @@ export async function fetchProxyGroups(options = {}) {
     // --- Detect provider-loading state ---
     // Groups with `include-all: true` or `include-all-providers: true` depend
     // on proxy-providers finishing their HTTP download before their `all`
-    // array is populated.  If such a group has no real proxy nodes (only
-    // special entries like COMPATIBLE/DIRECT/REJECT/PASS, or is completely
-    // empty), the nodes are still loading.
+    // array is fully populated.
     //
-    // mihomo returns `all=[COMPATIBLE]` (length 1) during the download phase,
-    // not `all=[]` (length 0) — so checking `length === 0` misses this state.
+    // To detect the loading state, we check whether `all[]` contains any
+    // proxy that came from a provider.  Every entry in `all[]` falls into
+    // exactly one of four categories:
+    //   1. mihomo built-in: COMPATIBLE, DIRECT, REJECT, PASS
+    //   2. Local proxy: defined in config's `proxies:` section
+    //   3. Group reference: defined in config's `proxy-groups:` section
+    //   4. Provider proxy: injected by proxy-providers after download
+    //
+    // If no category-4 entry exists, providers haven't finished downloading.
+    // This approach correctly handles any local proxy name (🟢 直连, 🔴 拒绝,
+    // etc.) without needing to enumerate them.
     const hasProxyProviders = !!(runConfig && runConfig['proxy-providers']
         && Object.keys(runConfig['proxy-providers']).length > 0);
     const includeAllGroups = buildIncludeAllSet(runConfig);
     const isIncludeAllGroup = uiGroupName
         ? (uiGroupName === 'GLOBAL' || includeAllGroups.has(uiGroupName))
         : false;
-    const hasRealProxies = Array.isArray(proxies)
-        && proxies.some(name => typeof name === 'string' && !SPECIAL_GROUPS.has(name.toUpperCase()));
-    const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
+
+    // Build sets of local proxy names and group names from run_config
+    const localProxyNames = new Set(
+        Array.isArray(runConfig?.proxies)
+            ? runConfig.proxies.map(/** @param {any} p */ p => p?.name).filter(Boolean)
+            : []
+    );
+    const groupNames = new Set(
+        Array.isArray(runConfig?.['proxy-groups'])
+            ? runConfig['proxy-groups'].map(/** @param {any} g */ g => g?.name).filter(Boolean)
+            : []
+    );
+
+    // A "provider proxy" is one that is not built-in, not local, and not a group
+    const hasProviderProxies = Array.isArray(proxies)
+        && proxies.some(name =>
+            typeof name === 'string'
+            && !SPECIAL_GROUPS.has(name.toUpperCase())
+            && !localProxyNames.has(name)
+            && !groupNames.has(name)
+        );
+    const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasProviderProxies;
 
     return {
         // Legacy compat fields

--- a/apps/desktop/src/ui/proxy-groups.test.js
+++ b/apps/desktop/src/ui/proxy-groups.test.js
@@ -206,6 +206,66 @@ describe('fetchProxyGroups providerLoading', () => {
         expect(result.proxies).toEqual(['COMPATIBLE', 'real-node']);
     });
 
+    it('providerLoading=true when all[] has only local proxies (not from providers)', async () => {
+        // This is the exact bug from the 2026-07-28 log:
+        // all=['🟢 直连'] where 🟢 直连 is a local proxy, not from a provider.
+        // The old code treated it as "loaded" because 🟢 直连 was not in
+        // SPECIAL_GROUPS.  The new code checks runConfig.proxies to identify
+        // local proxies and correctly detects the loading state.
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['🟢 直连'], now: '🟢 直连' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(true);
+    });
+
+    it('providerLoading=true when all[] has local proxies + group refs but no provider proxies', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['🟢 直连', '♻️ 自动选择'], now: '🟢 直连' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [
+                    { name: 'MyGroup', 'include-all': true },
+                    { name: '♻️ 自动选择', type: 'url-test', 'include-all': true },
+                ],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(true);
+    });
+
+    it('providerLoading=false when local proxies mixed with provider proxies', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['🟢 直连', 'provider-node-1'], now: 'provider-node-1' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(false);
+        expect(result.proxies).toEqual(['🟢 直连', 'provider-node-1']);
+    });
+
     it('GLOBAL group treated as include-all in global mode', async () => {
         const result = await setup({
             proxies: {


### PR DESCRIPTION
## Problem

The previous fix (PR #1048) used SPECIAL_GROUPS to detect provider-loading state. But SPECIAL_GROUPS only contains mihomo's 4 built-in entries (DIRECT/REJECT/PASS/COMPATIBLE). Configs can define **local proxies** (e.g., 馃煝 鐩磋繛, 馃敶 鎷掔粷, custom local nodes) that appear in ll[] during the provider download phase.

When ll=['馃煝 鐩磋繛'], hasRealProxies=true (because 馃煝 鐩磋繛 is not in SPECIAL_GROUPS), so providerLoading=false and the poller never starts 鈥?the UI shows an incomplete list permanently.

## Root Cause

SPECIAL_GROUPS is a **whitelist of known non-provider entries**. This approach is fundamentally flawed because local proxy names are config-specific and cannot be enumerated.

## Fix

Replace the whitelist approach with a **precise classification** based on unConfig:

Every entry in ll[] falls into exactly one of 4 categories:
1. **mihomo built-in**: COMPATIBLE/DIRECT/REJECT/PASS (checked via SPECIAL_GROUPS)
2. **Local proxy**: defined in config's proxies: section (checked via unConfig.proxies)
3. **Group reference**: defined in config's proxy-groups: section (checked via unConfig['proxy-groups'])
4. **Provider proxy**: injected by proxy-providers after download

providerLoading = true when the group uses include-all and ll[] has **no category-4 entries**.

This correctly handles any local proxy name without needing to enumerate them.

## Evidence

Reporter's log (2026-07-28.log line 63):
`
RESULT 鈥?uiGroup=馃殌 鎵嬪姩鍒囨崲, proxies.length=1, current=馃煝 鐩磋繛,
         providerLoading=false, hasProxyProviders=true, isIncludeAllGroup=true
`
馃煝 鐩磋繛 is a local proxy defined in proxies: section. After fix: providerLoading=true 鈫?poller starts 鈫?nodes arrive 鈫?UI re-renders.

## Files Changed

- pps/desktop/src/ui/proxy-groups.js 鈥?replace hasRealProxies heuristic with hasProviderProxies classification
- pps/desktop/src/ui/proxy-groups.test.js 鈥?3 new regression tests (local-only, local+group-refs, local+provider mixed)

## Summary by Sourcery

Detect provider-loading state in include-all proxy groups by distinguishing provider-injected proxies from built-ins, local proxies, and group references.

Bug Fixes:
- Fix incorrect provider-loading detection when all[] contains only local proxies or local proxies plus group references by classifying entries using runConfig instead of a SPECIAL_GROUPS whitelist.

Tests:
- Add regression tests covering local-only, local+group-reference, and mixed local+provider proxy scenarios for provider-loading detection in include-all groups.