### PR TITLE
fix: detect local-proxy-only all[] as provider-loading state

### DIFF
--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -413,21 +413,51 @@ export async function fetchProxyGroups(options = {}) {
     // --- Detect provider-loading state ---
     // Groups with `include-all: true` or `include-all-providers: true` depend
     // on proxy-providers finishing their HTTP download before their `all`
-    // array is populated.  If such a group has no real proxy nodes (only
-    // special entries like COMPATIBLE/DIRECT/REJECT/PASS, or is completely
-    // empty), the nodes are still loading.
+    // array is fully populated.
     //
-    // mihomo returns `all=[COMPATIBLE]` (length 1) during the download phase,
-    // not `all=[]` (length 0) — so checking `length === 0` misses this state.
+    // To detect the loading state, we check whether `all[]` contains any
+    // proxy that came from a provider.  Every entry in `all[]` falls into
+    // exactly one of four categories:
+    //   1. mihomo built-in: COMPATIBLE, DIRECT, REJECT, PASS
+    //   2. Local proxy: defined in config's `proxies:` section
+    //   3. Group reference: defined in config's `proxy-groups:` section
+    //   4. Provider proxy: injected by proxy-providers after download
+    //
+    // If no category-4 entry exists, providers haven't finished downloading.
+    // This approach correctly handles any local proxy name (🟢 直连, 🔴 拒绝,
+    // etc.) without needing to enumerate them.
     const hasProxyProviders = !!(runConfig && runConfig['proxy-providers']
         && Object.keys(runConfig['proxy-providers']).length > 0);
     const includeAllGroups = buildIncludeAllSet(runConfig);
     const isIncludeAllGroup = uiGroupName
         ? (uiGroupName === 'GLOBAL' || includeAllGroups.has(uiGroupName))
         : false;
-    const hasRealProxies = Array.isArray(proxies)
-        && proxies.some(name => typeof name === 'string' && !SPECIAL_GROUPS.has(name.toUpperCase()));
-    const providerLoading = hasProxyProviders && isIncludeAllGroup && !hasRealProxies;
+
+    // Build sets of local proxy names and group names from run_config
+    const localProxyNames = new Set(
+        Array.isArray(runConfig?.proxies)
+            ? runConfig.proxies.map(/** @param {any} p */ p => p?.name).filter(Boolean)
+            : []
+    );
+    const groupNames = new Set(
+        Array.isArray(runConfig?.['proxy-groups'])
+            ? runConfig['proxy-groups'].map(/** @param {any} g */ g => g?.name).filter(Boolean)
+            : []
+    );
+
+    // A "provider proxy" is one that is not built-in, not local, and not a group.
+    // Note: GLOBAL group's all[] contains group references (not direct provider
+    // proxies), so providerLoading is never true for GLOBAL — it's handled by
+    // the include-all groups it references.
+    const isGlobalGroup = uiGroupName === 'GLOBAL';
+    const hasProviderProxies = Array.isArray(proxies)
+        && proxies.some(name =>
+            typeof name === 'string'
+            && !SPECIAL_GROUPS.has(name.toUpperCase())
+            && !localProxyNames.has(name)
+            && !groupNames.has(name)
+        );
+    const providerLoading = hasProxyProviders && isIncludeAllGroup && !isGlobalGroup && !hasProviderProxies;
 
     return {
         // Legacy compat fields

--- a/apps/desktop/src/ui/proxy-groups.test.js
+++ b/apps/desktop/src/ui/proxy-groups.test.js
@@ -206,20 +206,83 @@ describe('fetchProxyGroups providerLoading', () => {
         expect(result.proxies).toEqual(['COMPATIBLE', 'real-node']);
     });
 
-    it('GLOBAL group treated as include-all in global mode', async () => {
+    it('providerLoading=true when all[] has only local proxies (not from providers)', async () => {
+        // This is the exact bug from the 2026-07-28 log:
+        // all=['🟢 直连'] where 🟢 直连 is a local proxy, not from a provider.
+        // The old code treated it as "loaded" because 🟢 直连 was not in
+        // SPECIAL_GROUPS.  The new code checks runConfig.proxies to identify
+        // local proxies and correctly detects the loading state.
         const result = await setup({
             proxies: {
-                GLOBAL: { type: 'Selector', all: [], now: null },
+                MyGroup: { type: 'Selector', all: ['🟢 直连'], now: '🟢 直连' },
             },
-            mode: 'global',
             runConfig: {
                 'proxy-providers': { 'prov1': { type: 'http' } },
-                'proxy-groups': [],
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
             },
+            preferredGroupName: 'MyGroup',
         });
-        expect(result.uiGroupName).toBe('GLOBAL');
         expect(result.providerLoading).toBe(true);
     });
+
+    it('providerLoading=true when all[] has local proxies + group refs but no provider proxies', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['🟢 直连', '♻️ 自动选择'], now: '🟢 直连' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [
+                    { name: 'MyGroup', 'include-all': true },
+                    { name: '♻️ 自动选择', type: 'url-test', 'include-all': true },
+                ],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(true);
+    });
+
+    it('providerLoading=false when local proxies mixed with provider proxies', async () => {
+        const result = await setup({
+            proxies: {
+                MyGroup: { type: 'Selector', all: ['🟢 直连', 'provider-node-1'], now: 'provider-node-1' },
+            },
+            runConfig: {
+                'proxy-providers': { 'prov1': { type: 'http' } },
+                'proxies': [
+                    { name: '🟢 直连', type: 'direct' },
+                ],
+                'proxy-groups': [{ name: 'MyGroup', 'include-all': true }],
+            },
+            preferredGroupName: 'MyGroup',
+        });
+        expect(result.providerLoading).toBe(false);
+        expect(result.proxies).toEqual(['🟢 直连', 'provider-node-1']);
+    });
+
+it('GLOBAL group treated as include-all in global mode', async () => {
+const result = await setup({
+proxies: {
+GLOBAL: { type: 'Selector', all: [], now: null },
+},
+mode: 'global',
+runConfig: {
+'proxy-providers': { 'prov1': { type: 'http' } },
+'proxy-groups': [],
+},
+});
+expect(result.uiGroupName).toBe('GLOBAL');
+// GLOBAL's all[] contains group references, not direct provider proxies,
+// so providerLoading is never true for GLOBAL — it's handled by the
+// include-all groups it references.
+expect(result.providerLoading).toBe(false);
+});
 
     it('providerLoading=false when proxy-providers object is empty', async () => {
         const result = await setup({


### PR DESCRIPTION
## Problem

The previous fix (PR #1048) used SPECIAL_GROUPS (DIRECT/REJECT/PASS/COMPATIBLE) to detect provider-loading. But configs define **local proxies** (e.g., 馃煝 鐩磋繛, 馃敶 鎷掔粷) that appear in ll[] during download. Since these aren't in SPECIAL_GROUPS, providerLoading=false and the poller never starts.

## Fix

Replace the whitelist with **precise classification** from unConfig:

Every ll[] entry is one of:
1. **mihomo built-in**: COMPATIBLE/DIRECT/REJECT/PASS
2. **Local proxy**: defined in proxies: section
3. **Group reference**: defined in proxy-groups: section
4. **Provider proxy**: injected by proxy-providers after download

providerLoading = true when include-all group has no category-4 entries.

GLOBAL group is excluded 鈥?its ll[] contains group references, not direct provider proxies.

## Files Changed

- pps/desktop/src/ui/proxy-groups.js 鈥?hasProviderProxies classification + GLOBAL exclusion
- pps/desktop/src/ui/proxy-groups.test.js 鈥?3 new regression tests + updated GLOBAL test

## Summary by Sourcery

Improve detection of provider-loading state for include-all proxy groups based on precise classification of proxy entries.

Bug Fixes:
- Ensure include-all groups with only local proxies or group references are correctly treated as still loading provider proxies.
- Avoid treating the GLOBAL group as provider-loading since its members are group references rather than direct provider proxies.

Tests:
- Add regression tests covering include-all groups with only local proxies, with local proxies plus group references, and with mixed local/provider proxies, and update the GLOBAL group test to reflect the new loading behavior.