### PR TITLE
fix: use empty string instead of null for stale proxy selection cleanup

### DIFF
--- a/apps/desktop/src/ui/proxy-memory.js
+++ b/apps/desktop/src/ui/proxy-memory.js
@@ -289,9 +289,12 @@ export async function restoreProxySelection(profileName) {
             proxyMemoryLogger.warn(
                 `[restoreProxySelection] saved.node "${saved.node}" equals saved.group — stale data from previous bug, clearing and skipping restoration`,
             );
-            // Clear the stale entry to prevent repeated warnings on every run
+            // Clear the stale entry to prevent repeated warnings on every run.
+            // Use empty strings because the Rust backend's update_proxy_selection
+            // requires node_name as String (not Option<String>).
+            // parseSelection() treats "" as null via the `|| null` check.
             try {
-                await saveProxySelection(profileName, /** @type {any} */ ({ node: null, group: null }));
+                await saveProxySelection(profileName, { node: '', group: '' });
             } catch { /* ignore cleanup errors */ }
             return false;
         }


### PR DESCRIPTION
## Problem

PR #1055 added stale data cleanup in estoreProxySelection() 鈥?when saved.node === saved.group, it calls saveProxySelection(profileName, { node: null, group: null }) to clear the stale entry.

However, the Rust backend's update_proxy_selection command requires 
ode_name: String (not Option<String>). Passing 
ull from JS causes a Tauri deserialization error, so the stale entry is **never actually cleared** 鈥?it persists and triggers the warning on every run.

Found by Qodo review on PR #1054 (posted after PR was closed).

## Fix

Use empty strings '' instead of 
ull. The backend accepts "" as a valid String, and parseSelection() already treats "" as null via the parsed.node || null check (line 108).

`js
// Before (broken 鈥?null causes Tauri deserialization error):
await saveProxySelection(profileName, /** @type {any} */ ({ node: null, group: null }));

// After (works 鈥?"" is a valid String, treated as null by parseSelection):
await saveProxySelection(profileName, { node: '', group: '' });
`

## Files Changed

- pps/desktop/src/ui/proxy-memory.js 鈥?use '' instead of 
ull for stale data cleanup

## Summary by Sourcery

Bug Fixes:
- Replace null proxy selection values with empty strings so the Rust backend accepts cleanup requests and stale entries are actually removed.