### PR TITLE
fix: re-fetch stale cached proxies when nodes missing from data.proxies

### DIFF
--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1917,6 +1917,33 @@ export async function renderProxies() {
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
 
+    // --- Stale-cache recovery ---
+    // `data` was fetched via getProxiesCached() at the top of this function.
+    // When proxy-providers finish downloading, mihomo updates group.all[] with
+    // new node names before the node details appear in the /proxies response.
+    // If the cached data is in this "half-updated" state, the proxies array
+    // (from group.all[]) will contain names that don't exist in data.proxies.
+    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
+    // return), resulting in an empty container — the user sees no nodes.
+    //
+    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
+    // and re-fetch. If still missing (mihomo not fully updated), retry once
+    // after a short delay.
+    if (data?.proxies) {
+        const hasMissing = proxies.some(name => !data.proxies[name]);
+        if (hasMissing) {
+            invalidateProxiesCache();
+            let freshData = /** @type {any} */ (await getProxies());
+            if (freshData?.proxies && proxies.some(name => !freshData.proxies[name])) {
+                await new Promise(r => setTimeout(r, 500));
+                freshData = /** @type {any} */ (await getProxies());
+            }
+            if (freshData?.proxies) {
+                data.proxies = freshData.proxies;
+            }
+        }
+    }
+
 // --- Provider-loading guard ---
 // If the uiGroup uses include-all/include-all-providers and its all[] has
 // no real proxy nodes (empty or only special entries like COMPATIBLE),


### PR DESCRIPTION
## Root Cause

When proxy-providers finish downloading nodes, mihomo updates the group's ll[] array with new node names **before** the node details appear in the /proxies API response.

enderProxies() fetches data via getProxiesCached() at the top of the function. If the cache is in this "half-updated" state:
- etchProxyGroupsShared() reads group.all[] 鈫?gets 94 node names
- uildProxyWrappers() looks up data.proxies[name] 鈫?**all 94 nodes missing** (only 63 keys in cache)
- if (!proxy) return skips every node
- **Container becomes empty 鈥?user sees no nodes**

This is the real reason users report "鎵嬪姩鍒囨崲鍒嗙粍涓棤娉曞嚭鐜颁换浣曡妭鐐逛俊鎭? 鈥?not a providerLoading detection issue, not a switchToConfig issue. The node data arrives but is discarded during rendering due to stale cache.

## Evidence (from diagnostic log)

`
renderProxies: data.proxies keys=63, missingInData=94
renderProxies: fragment.children=0, proxies.length=94
RENDER COMPLETE 鈥?container.children=0, proxies.length=94
`

94 nodes in the proxies array, but 0 rendered because all 94 are missing from the cached data.proxies.

## Fix

Before rendering, check if any proxy name in the proxies array is missing from data.proxies. If so:
1. Invalidate the proxies cache
2. Re-fetch fresh non-cached data via getProxies()
3. If still missing (mihomo not fully updated), wait 500ms and retry once
4. Replace data.proxies with the fresh data so uildProxyWrappers() can look up every node

## Files Changed

- pps/desktop/src/ui/proxies.js 鈥?stale-cache recovery in enderProxies()

## Summary by Sourcery

Ensure proxy list rendering recovers from stale cached proxy data so groups do not appear empty when providers have just updated.

Bug Fixes:
- Detect missing proxy nodes in cached data and re-fetch fresh proxy information to prevent empty proxy containers during provider updates.

Enhancements:
- Add a short retry window when fresh proxy data is still incomplete, updating in-memory proxies once mihomo finishes populating node details.