### PR TITLE
fix: re-fetch stale cached proxies when nodes missing from data.proxies

### DIFF
--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1261,8 +1261,15 @@ let _providerPollInFlight = false;
 /** Maximum provider-loading retries (≈30 s at 1.5 s interval). */
 const PROVIDER_POLL_MAX = 20;
 
+/** Delay (ms) before retrying a stale-cache proxy re-fetch. */
+const STALE_CACHE_RETRY_DELAY = 500;
+
 /** Generation token: incremented on stop to cancel in-flight poll callbacks. */
 let _providerPollGeneration = 0;
+
+/** Render generation token: prevents stale renderProxies() invocations from
+ *  overwriting a newer render after an async stale-cache recovery delay. */
+let _renderGeneration = 0;
 
 /**
  * Group name for which provider polling was exhausted (undefined = not exhausted).
@@ -1916,6 +1923,42 @@ export async function renderProxies() {
     }
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
+
+    // --- Stale-cache recovery ---
+    // `data` was fetched via getProxiesCached() at the top of this function.
+    // When proxy-providers finish downloading, mihomo updates group.all[] with
+    // new node names before the node details appear in the /proxies response.
+    // If the cached data is in this "half-updated" state, the proxies array
+    // (from group.all[]) will contain names that don't exist in data.proxies.
+    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
+    // return), resulting in an empty container — the user sees no nodes.
+    //
+    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
+    // and re-fetch. If still missing (mihomo not fully updated), retry once
+    // after a short delay. All recovery failures are caught so rendering
+    // continues with the original (stale) data rather than aborting.
+    const _renderGen = ++_renderGeneration;
+    if (data?.proxies) {
+        const hasMissing = proxies.some(name => !data.proxies[name]);
+        if (hasMissing) {
+            invalidateProxiesCache();
+            try {
+                let freshData = /** @type {any} */ (await getProxies());
+                if (freshData?.proxies && proxies.some(name => !freshData.proxies[name])) {
+                    await new Promise(r => setTimeout(r, STALE_CACHE_RETRY_DELAY));
+                    freshData = /** @type {any} */ (await getProxies());
+                }
+                // Guard: user may have switched groups during the await/delay.
+                // If so, abort this render — the newer render takes precedence.
+                if (_renderGen !== _renderGeneration) return;
+                if (freshData?.proxies) {
+                    data.proxies = freshData.proxies;
+                }
+            } catch (e) {
+                proxyLogger.warn('[renderProxies] stale-cache recovery failed, using cached data:', e);
+            }
+        }
+    }
 
 // --- Provider-loading guard ---
 // If the uiGroup uses include-all/include-all-providers and its all[] has


### PR DESCRIPTION
## Root Cause

When proxy-providers finish downloading nodes, mihomo updates the group's ll[] array with new node names **before** the node details appear in the /proxies API response.

enderProxies() fetches data via getProxiesCached() at the top of the function. If the cache is in this "half-updated" state:
- etchProxyGroupsShared() reads group.all[] 鈫?gets 94 node names
- uildProxyWrappers() looks up data.proxies[name] 鈫?**all 94 nodes missing** (only 63 keys in cache)
- if (!proxy) return skips every node
- **Container becomes empty 鈥?user sees no nodes**

This is the real reason users report "鎵嬪姩鍒囨崲鍒嗙粍涓棤娉曞嚭鐜颁换浣曡妭鐐逛俊鎭? 鈥?not a providerLoading detection issue, not a switchToConfig issue. The node data arrives but is discarded during rendering due to stale cache.

## Evidence (from diagnostic log)

`
renderProxies: data.proxies keys=63, missingInData=94
renderProxies: fragment.children=0, proxies.length=94
RENDER COMPLETE 鈥?container.children=0, proxies.length=94
`

94 nodes in the proxies array, but 0 rendered because all 94 are missing from the cached data.proxies.

## Fix

Before rendering, check if any proxy name in the proxies array is missing from data.proxies. If so:
1. Invalidate the proxies cache
2. Re-fetch fresh non-cached data via getProxies()
3. If still missing (mihomo not fully updated), wait 500ms and retry once
4. Replace data.proxies with the fresh data so uildProxyWrappers() can look up every node

### Review feedback addressed (from PR #1059)

- **CodeRabbit/Qodo**: Wrap getProxies() in try-catch so transient failures don't abort rendering 鈥?fall back to stale data with a warning log
- **Qodo**: Add render generation token (_renderGeneration) to prevent a stale render from overwriting a newer one if the user switches groups during the 500ms delay
- **Sourcery**: Extract 500 into named constant STALE_CACHE_RETRY_DELAY

## Files Changed

- pps/desktop/src/ui/proxies.js 鈥?stale-cache recovery in enderProxies() + render generation guard

## Summary by Sourcery

Handle stale proxy cache during proxy rendering to avoid empty proxy lists when provider updates are only partially reflected in cached data.

Bug Fixes:
- Prevent proxy lists from rendering empty when group node names are updated before corresponding proxy details appear in cached data.

Enhancements:
- Add stale-cache detection and retry logic in proxy rendering, including a short delayed re-fetch and guarded cache invalidation using a render generation token to avoid overwriting newer renders.