### PR TITLE
fix: re-fetch stale cached proxies when nodes missing from data.proxies

### DIFF
--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1261,8 +1261,15 @@ let _providerPollInFlight = false;
 /** Maximum provider-loading retries (≈30 s at 1.5 s interval). */
 const PROVIDER_POLL_MAX = 20;
 
+/** Delay (ms) before retrying a stale-cache proxy re-fetch. */
+const STALE_CACHE_RETRY_DELAY = 500;
+
 /** Generation token: incremented on stop to cancel in-flight poll callbacks. */
 let _providerPollGeneration = 0;
+
+/** Render generation token: prevents stale renderProxies() invocations from
+ *  overwriting a newer render after an async stale-cache recovery delay. */
+let _renderGeneration = 0;
 
 /**
  * Group name for which provider polling was exhausted (undefined = not exhausted).
@@ -1818,6 +1825,11 @@ export async function renderProxies() {
     const container = document.getElementById('proxies-list');
     if (!container) return;
 
+    // Render generation token — must be incremented before any async work
+    // so that early-return paths (no data, direct mode, no groups) also
+    // invalidate stale renders from older invocations.
+    const _renderGen = ++_renderGeneration;
+
     // Start observed-group watcher only when proxies page is visible and app is foregrounded
     if (!document.hidden) {
         const proxiesPage = document.querySelector('[data-page="proxies"]');
@@ -1916,6 +1928,50 @@ export async function renderProxies() {
     }
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
+
+    // --- Stale-cache recovery ---
+    // `data` was fetched via getProxiesCached() at the top of this function.
+    // When proxy-providers finish downloading, mihomo updates group.all[] with
+    // new node names before the node details appear in the /proxies response.
+    // If the cached data is in this "half-updated" state, the proxies array
+    // (from group.all[]) will contain names that don't exist in data.proxies.
+    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
+    // return), resulting in an empty container — the user sees no nodes.
+    //
+    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
+    // and re-fetch. If still missing (mihomo not fully updated), retry once
+    // after a short delay. All recovery failures are caught so rendering
+    // continues with the original (stale) data rather than aborting.
+    if (data?.proxies) {
+        const hasMissing = proxies.some(name => !data.proxies[name]);
+        if (hasMissing) {
+            invalidateProxiesCache();
+            try {
+                let freshData = /** @type {any} */ (await getProxies());
+                if (freshData?.proxies && proxies.some(name => !freshData.proxies[name])) {
+                    await new Promise(r => setTimeout(r, STALE_CACHE_RETRY_DELAY));
+                    freshData = /** @type {any} */ (await getProxies());
+                }
+                // Guard: user may have switched groups during the await/delay.
+                // If so, abort this render — the newer render takes precedence.
+                if (_renderGen !== _renderGeneration) return;
+                if (freshData?.proxies) {
+                    data.proxies = freshData.proxies;
+                }
+                // If nodes are STILL missing after retry, mihomo hasn't fully
+                // populated /proxies yet.  Force providerLoading so the guard
+                // below shows a loading state + starts the poller instead of
+                // rendering an empty container.
+                if (proxies.some(name => !data.proxies[name])) {
+                    proxyGroupsResult.providerLoading = true;
+                }
+            } catch (e) {
+                // Even on failure, abort if a newer render has started.
+                if (_renderGen !== _renderGeneration) return;
+                proxyLogger.warn('[renderProxies] stale-cache recovery failed, using cached data:', e);
+            }
+        }
+    }
 
 // --- Provider-loading guard ---
 // If the uiGroup uses include-all/include-all-providers and its all[] has


### PR DESCRIPTION
## Root Cause

When proxy-providers finish downloading nodes, mihomo updates the group's ll[] array with new node names **before** the node details appear in the /proxies API response.

enderProxies() fetches data via getProxiesCached() at the top of the function. If the cache is in this "half-updated" state:
- etchProxyGroupsShared() reads group.all[] 鈫?gets 94 node names
- uildProxyWrappers() looks up data.proxies[name] 鈫?**all 94 nodes missing** (only 63 keys in cache)
- if (!proxy) return skips every node
- **Container becomes empty 鈥?user sees no nodes**

This is the real reason users report "鎵嬪姩鍒囨崲鍒嗙粍涓棤娉曞嚭鐜颁换浣曡妭鐐逛俊鎭? 鈥?not a providerLoading detection issue, not a switchToConfig issue. The node data arrives but is discarded during rendering due to stale cache.

## Evidence (from diagnostic log)

`
renderProxies: data.proxies keys=63, missingInData=94
renderProxies: fragment.children=0, proxies.length=94
RENDER COMPLETE 鈥?container.children=0, proxies.length=94
`

## Fix

Before rendering, check if any proxy name in the proxies array is missing from data.proxies. If so:
1. Invalidate the proxies cache
2. Re-fetch fresh non-cached data via getProxies()
3. If still missing (mihomo not fully updated), wait 500ms and retry once
4. Replace data.proxies with the fresh data
5. **If nodes are STILL missing after retry**, force providerLoading=true so the loading guard shows a loading state + starts the poller instead of rendering an empty container

### Safety guards

- **Render generation token** (_renderGeneration): incremented at the very top of enderProxies() before any async work. After stale-cache recovery, if a newer render has started, the old render aborts silently.
- **try-catch**: if getProxies() throws, rendering continues with the original stale data + a warning log. Generation check also runs in the catch block.
- **Fallback to providerLoading**: if retry doesn't help, fall back to the loading + poller path instead of showing an empty page.

## Review history

- PR #1059: initial fix 鈫?CodeRabbit/Qodo: add try-catch, add generation guard
- PR #1060: added try-catch + generation guard 鈫?CodeRabbit/Qodo: move generation to top, add generation check in catch, handle still-missing after retry
- PR #1061: moved generation to top + catch guard 鈫?CodeRabbit/Qodo: if still missing after retry, don't render empty
- This PR: added providerLoading=true fallback when retry fails

## Summary by Sourcery

Handle stale cached proxy data during proxy rendering to avoid empty proxy lists when provider updates are only partially reflected in the cache.

Bug Fixes:
- Detect proxies listed in groups that are missing from cached data.proxies and re-fetch fresh proxy data, preventing renders with all nodes skipped.
- Fallback to a provider-loading state when proxies remain missing after a retry so users see a loading view instead of an empty container.

Enhancements:
- Introduce a render generation token to prevent outdated async renderProxies() calls from overwriting newer renders after stale-cache recovery delays.
- Add a short delayed retry and logging around proxy re-fetch failures to make cache recovery safer and more observable.