### PR TITLE
fix: re-fetch stale cached proxies when nodes missing from data.proxies

### DIFF
--- a/apps/desktop/src/ui/proxies-poller.test.js
+++ b/apps/desktop/src/ui/proxies-poller.test.js
@@ -121,7 +121,7 @@ describe('Provider poller state machine', () => {
         it('calls invalidateProxiesCache when nodes arrive during polling', async () => {
             vi.useFakeTimers();
 
-            const proxyData = { proxies: { MyGroup: { type: 'Selector', all: ['n1', 'n2'] } } };
+            const proxyData = { proxies: { MyGroup: { type: 'Selector', all: ['n1', 'n2'] }, n1: { type: 'Shadowsocks' }, n2: { type: 'Shadowsocks' } } };
             getProxies.mockResolvedValue(proxyData);
             getConfigCached.mockResolvedValue({ mode: 'rule' });
             fetchProxyGroups.mockResolvedValue({
@@ -162,6 +162,54 @@ describe('Provider poller state machine', () => {
             expect(getProxies).toHaveBeenCalledTimes(2);
         });
     });
+
+    // ─── Missing node details ─────────────────────────────────────────
+    describe('missing node details', () => {
+        it('retries when proxy names exist in all[] but details missing from data.proxies', async () => {
+            vi.useFakeTimers();
+
+            // Group has nodes in all[], but data.proxies doesn't have their details
+            // (mihomo half-updated state)
+            getProxies.mockResolvedValue({ proxies: { MyGroup: { type: 'Selector', all: ['n1', 'n2'] } } });
+            getConfigCached.mockResolvedValue({ mode: 'rule' });
+            fetchProxyGroups.mockResolvedValue({
+                proxies: ['n1', 'n2'],
+                providerLoading: false,
+                uiGroupName: 'MyGroup',
+            });
+
+            startProviderPoll('MyGroup', 'MyGroup', 0);
+            await vi.advanceTimersByTimeAsync(1500);
+
+            // Should NOT call invalidateProxiesCache — nodes are still missing details
+            expect(invalidateProxiesCache).not.toHaveBeenCalled();
+            // Should retry — schedule next poll
+            expect(getProxies).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(1500);
+            expect(getProxies).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not retry when all[] contains special names (DIRECT, COMPATIBLE) alongside detailed nodes', async () => {
+            vi.useFakeTimers();
+
+            // Group has DIRECT + COMPATIBLE (special, no detail records) + real nodes
+            getProxies.mockResolvedValue({ proxies: { MyGroup: { type: 'Selector', all: ['DIRECT', 'COMPATIBLE', 'n1'] }, n1: { type: 'Shadowsocks' } } });
+            getConfigCached.mockResolvedValue({ mode: 'rule' });
+            fetchProxyGroups.mockResolvedValue({
+                proxies: ['DIRECT', 'COMPATIBLE', 'n1'],
+                providerLoading: false,
+                uiGroupName: 'MyGroup',
+            });
+
+            startProviderPoll('MyGroup', 'MyGroup', 0);
+            await vi.advanceTimersByTimeAsync(1500);
+
+            // Should call invalidateProxiesCache — special names are excluded from check
+            expect(invalidateProxiesCache).toHaveBeenCalledTimes(1);
+        });
+    });
+
 
     // ─── Exhaustion ─────────────────────────────────────────────────────
     describe('exhaustion after max retries', () => {
@@ -239,7 +287,7 @@ describe('Provider poller state machine', () => {
         it('allows starting a new poll after stop', async () => {
             vi.useFakeTimers();
 
-            getProxies.mockResolvedValue({ proxies: { G: { type: 'Selector', all: ['n1'] } } });
+            getProxies.mockResolvedValue({ proxies: { G: { type: 'Selector', all: ['n1'] }, n1: { type: 'Shadowsocks' } } });
             getConfigCached.mockResolvedValue({ mode: 'rule' });
             fetchProxyGroups.mockResolvedValue({ proxies: ['n1'], providerLoading: false });
 

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1261,8 +1261,34 @@ let _providerPollInFlight = false;
 /** Maximum provider-loading retries (≈30 s at 1.5 s interval). */
 const PROVIDER_POLL_MAX = 20;
 
+/** Delay (ms) before retrying a stale-cache proxy re-fetch. */
+const STALE_CACHE_RETRY_DELAY = 500;
+
+/** Special proxy names that never have detail records in /proxies. */
+const SPECIAL_PROXY_NAMES = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE']);
+
+/**
+ * Check whether any proxy name in `names` is missing from `proxiesMap`.
+ * Special entries (DIRECT, REJECT, PASS, COMPATIBLE) are excluded because
+ * they never appear as detail records in the /proxies API response.
+ * @param {string[]} names - Proxy names from group.all[]
+ * @param {Record<string, any>|undefined} proxiesMap - The proxies map from /proxies
+ * @returns {boolean}
+ */
+function hasMissingProxyDetails(names, proxiesMap) {
+    return names.some(name =>
+        typeof name === 'string'
+        && !SPECIAL_PROXY_NAMES.has(name.toUpperCase())
+        && !proxiesMap?.[name]
+    );
+}
+
 /** Generation token: incremented on stop to cancel in-flight poll callbacks. */
 let _providerPollGeneration = 0;
+
+/** Render generation token: prevents stale renderProxies() invocations from
+ *  overwriting a newer render after an async stale-cache recovery delay. */
+let _renderGeneration = 0;
 
 /**
  * Group name for which provider polling was exhausted (undefined = not exhausted).
@@ -1449,7 +1475,12 @@ function startProviderPoll(preferredGroupName, exhaustionKey, attempt = 0) {
                 preferredGroupName: preferredGroupName || undefined,
             });
             if (gen !== _providerPollGeneration) return;  // Cancelled during await
-            if (result && !result.providerLoading) {
+            // Check both providerLoading AND that all proxy names exist in
+            // data.proxies — mihomo can update group.all[] before node details
+            // appear in /proxies, causing buildProxyWrappers to skip nodes.
+            const _hasMissingDetails = result && !result.providerLoading
+                && hasMissingProxyDetails(result.proxies || [], data.proxies);
+            if (result && !result.providerLoading && !_hasMissingDetails) {
                 // Nodes have arrived — invalidate cache + re-render
                 invalidateProxiesCache();
                 renderProxies().catch(() => {});
@@ -1818,6 +1849,11 @@ export async function renderProxies() {
     const container = document.getElementById('proxies-list');
     if (!container) return;
 
+    // Render generation token — must be incremented before any async work
+    // so that early-return paths (no data, direct mode, no groups) also
+    // invalidate stale renders from older invocations.
+    const _renderGen = ++_renderGeneration;
+
     // Start observed-group watcher only when proxies page is visible and app is foregrounded
     if (!document.hidden) {
         const proxiesPage = document.querySelector('[data-page="proxies"]');
@@ -1916,6 +1952,51 @@ export async function renderProxies() {
     }
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
+
+    // --- Stale-cache recovery ---
+    // `data` was fetched via getProxiesCached() at the top of this function.
+    // When proxy-providers finish downloading, mihomo updates group.all[] with
+    // new node names before the node details appear in the /proxies response.
+    // If the cached data is in this "half-updated" state, the proxies array
+    // (from group.all[]) will contain names that don't exist in data.proxies.
+    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
+    // return), resulting in an empty container — the user sees no nodes.
+    //
+    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
+    // and re-fetch. If still missing (mihomo not fully updated), retry once
+    // after a short delay. All recovery failures are caught so rendering
+    // continues with the original (stale) data rather than aborting.
+    if (data?.proxies) {
+        const hasMissing = hasMissingProxyDetails(proxies, data.proxies);
+        if (hasMissing) {
+            invalidateProxiesCache();
+            try {
+                let freshData = /** @type {any} */ (await getProxies());
+                // Guard: if a newer render started while fetching fresh proxies,
+                // skip retry/delay work; the newer render will handle data.
+                if (_renderGen !== _renderGeneration) return;
+                if (freshData?.proxies && hasMissingProxyDetails(proxies, freshData.proxies)) {
+                    await new Promise(r => setTimeout(r, STALE_CACHE_RETRY_DELAY));
+                    freshData = /** @type {any} */ (await getProxies());
+                }
+                // Guard: user may have switched groups during the await/delay.
+                // If so, abort this render — the newer render takes precedence.
+                if (_renderGen !== _renderGeneration) return;
+                if (freshData?.proxies) {
+                    data.proxies = freshData.proxies;
+                }
+            } catch (e) {
+                if (_renderGen !== _renderGeneration) return;
+                proxyLogger.warn('[renderProxies] stale-cache recovery failed, using cached data:', e);
+            }
+            // If nodes are STILL missing after recovery (or recovery failed),
+            // force providerLoading so the guard below shows a loading state +
+            // starts the poller instead of rendering an empty container.
+            if (hasMissingProxyDetails(proxies, data.proxies)) {
+                proxyGroupsResult.providerLoading = true;
+            }
+        }
+    }
 
 // --- Provider-loading guard ---
 // If the uiGroup uses include-all/include-all-providers and its all[] has


### PR DESCRIPTION
## Root Cause

When proxy-providers finish downloading nodes, mihomo updates the group's ll[] array with new node names **before** the node details appear in the /proxies API response.

enderProxies() fetches data via getProxiesCached(). If the cache is in this "half-updated" state:
- etchProxyGroupsShared() reads group.all[] 鈫?gets 94 node names
- uildProxyWrappers() looks up data.proxies[name] 鈫?**all 94 nodes missing** (only 63 keys in cache)
- if (!proxy) return skips every node
- **Container becomes empty 鈥?user sees no nodes**

## Evidence (from diagnostic log)

`
renderProxies: data.proxies keys=63, missingInData=94
renderProxies: fragment.children=0, proxies.length=94
RENDER COMPLETE 鈥?container.children=0, proxies.length=94
`

## Fix

### 1. hasMissingProxyDetails() helper
Shared predicate that checks whether any proxy name (excluding SPECIAL_PROXY_NAMES = DIRECT/REJECT/PASS/COMPATIBLE, case-insensitive) is missing from the proxies map. Used in 4 places: poller success check, stale-cache detection, retry decision, and still-missing-after-recovery fallback.

### 2. Stale-cache recovery in enderProxies()
Before rendering, if hasMissingProxyDetails is true:
1. Invalidate the proxies cache
2. Re-fetch fresh non-cached data via getProxies()
3. Generation check 鈥?if newer render started, abort early
4. If still missing (using hasMissingProxyDetails), wait 500ms and retry once
5. Replace data.proxies with the fresh data
6. If nodes are STILL missing, force providerLoading=true to show loading state + start poller

### 3. Poller infinite-loop prevention
The poller's success check now also calls hasMissingProxyDetails 鈥?prevents a loop where poller calls enderProxies() thinking nodes arrived, but enderProxies detects missing details and forces providerLoading=true again.

### 4. Special groups exclusion (case-insensitive)
COMPATIBLE, DIRECT, REJECT, PASS are mihomo built-in names that never have detail records in /proxies. They are excluded from all missing-details checks via SPECIAL_PROXY_NAMES (compared case-insensitively via 	oUpperCase()) to avoid false positives.

### 5. Tests
- etries when proxy names exist in all[] but details missing from data.proxies
- does not retry when all[] contains special names (DIRECT, COMPATIBLE) alongside detailed nodes

### Safety guards
- **Render generation token**: incremented at the top of enderProxies() before any async work
- **Generation checks at 3 points**: after first fetch, after second fetch, in catch block
- **try-catch**: if getProxies() throws, falls through to providerLoading=true fallback
- **providerLoading=true fallback outside try-catch**: catches both recovery failure and still-missing cases

## Files Changed

- pps/desktop/src/ui/proxies.js 鈥?hasMissingProxyDetails helper + stale-cache recovery + poller guard + render generation guard
- pps/desktop/src/ui/proxies-poller.test.js 鈥?updated mock data + 2 new tests

## Summary by Sourcery

Improve proxy rendering resilience when provider updates cause a mismatch between group node names and cached proxy details.

Bug Fixes:
- Prevent proxies list from rendering empty when group.all[] contains nodes that are missing from cached data.proxies.
- Avoid infinite polling loops by ensuring poll success requires both providerLoading=false and presence of proxy details.

Enhancements:
- Introduce a shared helper to detect missing proxy details and exclude special proxy names that never have detail records.
- Add a render-generation token to prevent stale renderProxies invocations from overwriting newer renders after async recovery delays.
- Implement stale-cache recovery in renderProxies, including cache invalidation, retry with delay, and safe fallbacks to provider loading state.

Tests:
- Expand provider poller tests to cover missing proxy detail scenarios and special-name handling, and update fixtures to include node detail records.