### PR TITLE
fix: merge /providers/proxies to get provider node details

### DIFF
--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -336,6 +336,131 @@ export async function getProxies() {
 }
 
 /**
+ * 获取全部代理提供者数据（含 provider 下载的节点详情）
+ * mihomo 的 /proxies API 不包含 proxy-provider 下载的节点，
+ * 需要通过 /providers/proxies 获取。
+ * @returns {Promise<Object>} mihomo `/providers/proxies` 响应体
+ * @throws {ApiError}
+ */
+export async function getProxyProviders() {
+  const res = await apiFetch('/providers/proxies');
+  return res.json();
+}
+
+/**
+ * 获取单个代理提供者数据
+ * @param {string} name - provider 名称
+ * @returns {Promise<Object>} 单个 provider 详情（含节点列表）
+ * @throws {ApiError}
+ */
+export async function getProxyProvider(name) {
+  const res = await apiFetch(`/providers/proxies/${encodeURIComponent(name)}`);
+  return res.json();
+}
+
+// ── Provider 缓存（避免轮询期间重复拉取 /providers/proxies） ─────────────
+/** @type {any} */
+let _providerCache = null;
+const _PROVIDER_CACHE_TTL = 5000;
+const _SPECIAL_PROXY_NAMES = new Set(['DIRECT', 'REJECT', 'REJECT-DROP', 'COMPATIBLE', 'PASS', 'PASS-RULE', 'GLOBAL']);
+
+/**
+ * Clear provider cache. Called on core restart to prevent stale data.
+ */
+export function clearProviderCache() {
+  _providerCache = null;
+}
+
+/**
+ * Collect proxy names from all group.all[] arrays.
+ * @param {Record<string, any>} proxiesMap - The proxies map from /proxies
+ * @returns {Set<string>} All names found in any group's all[]
+ */
+function collectAllProxyNames(proxiesMap) {
+  const names = new Set();
+  for (const key of Object.keys(proxiesMap)) {
+    const entry = proxiesMap[key];
+    if (entry?.all && Array.isArray(entry.all)) {
+      for (const name of entry.all) {
+        if (typeof name === 'string') names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract provider nodes from /providers/proxies response into a flat map.
+ * @param {any} providersResp - Response from /providers/proxies
+ * @returns {Record<string, any>} Map of proxy name → proxy detail
+ */
+function extractProviderNodes(providersResp) {
+  /** @type {Record<string, any>} */
+  const result = {};
+  if (providersResp?.providers) {
+    for (const providerName of Object.keys(providersResp.providers)) {
+      const provider = providersResp.providers[providerName];
+      if (provider?.proxies && Array.isArray(provider.proxies)) {
+        for (const proxy of provider.proxies) {
+          if (proxy?.name) result[proxy.name] = proxy;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * 合并 /proxies + /providers/proxies 的数据。
+ * 按需懒加载：只有当 /proxies 的节点缺失时才拉 provider 数据。
+ *
+ * @param {any} [existingData] - 已有的 /proxies 响应（避免重复请求）
+ * @returns {Promise<any>} 合并后的数据
+ * @throws {ApiError}
+ */
+export async function getProxiesMerged(existingData) {
+  const data = existingData || await getProxies();
+  if (!data?.proxies) return data;
+
+  const allNames = collectAllProxyNames(data.proxies);
+  const missingNames = [...allNames].filter(
+    n => !_SPECIAL_PROXY_NAMES.has(n.toUpperCase()) && !Object.hasOwn(data.proxies, n)
+  );
+  if (missingNames.length === 0) return data;
+
+  const fingerprint = [...missingNames].sort().join('|');
+  const now = Date.now();
+
+  // 缓存命中 — 只合并缺失的节点，不覆盖已有数据
+  if (_providerCache?.fingerprint === fingerprint && (now - _providerCache.ts) < _PROVIDER_CACHE_TTL) {
+    for (const name of missingNames) {
+      if (_providerCache.proxies[name] && !Object.hasOwn(data.proxies, name)) {
+        data.proxies[name] = _providerCache.proxies[name];
+      }
+    }
+    return data;
+  }
+
+  // 拉 /providers/proxies 并缓存
+  try {
+    const providersResp = await getProxyProviders();
+    const providerProxies = extractProviderNodes(providersResp);
+    _providerCache = { proxies: providerProxies, fingerprint, ts: now };
+    // 只合并缺失的节点，不覆盖已有数据
+    for (const name of missingNames) {
+      if (providerProxies[name] && !Object.hasOwn(data.proxies, name)) {
+        data.proxies[name] = providerProxies[name];
+      }
+    }
+  } catch {
+    // provider 拉取失败 — 不阻塞渲染，fallback 会处理仍然缺失的节点
+    console.warn('[getProxiesMerged] /providers/proxies fetch failed, using raw /proxies data');
+  }
+
+  return data;
+}
+
+/**
  * 切换代理组中的选中节点
  * @param {string} group - 代理组名称
  * @param {string} name  - 目标节点名称

--- a/apps/desktop/src/ui/proxies-poller.test.js
+++ b/apps/desktop/src/ui/proxies-poller.test.js
@@ -16,6 +16,7 @@ vi.mock('../api.js', () => ({
     resetLatencyTestController: vi.fn(),
     restartCore: vi.fn(),
     getProxies: vi.fn(),
+    getProxiesMerged: vi.fn().mockImplementation((data) => Promise.resolve(data)),
 }));
 
 vi.mock('../utils/logger.js', () => ({ proxyLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -6,7 +6,7 @@
  * @module ui/proxies
  */
 
-import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore, getProxies } from '../api.js';
+import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore, getProxies, getProxiesMerged } from '../api.js';
 import { proxyLogger } from '../utils/logger.js';
 import { escapeHtml } from '../utils/sanitize.js';
 import { getDelayColorClass } from '../utils/format.js';
@@ -1458,13 +1458,16 @@ function startProviderPoll(preferredGroupName, exhaustionKey, attempt = 0) {
             if (gen !== _providerPollGeneration) return;
             // Use non-cached fetch to avoid invalidating the global cache
             // (which would force other UI components to re-fetch too).
-            const data = /** @type {any} */ (await getProxies());
+            // Merge with provider data so missing-detail checks include provider nodes.
+            const rawProxies = /** @type {any} */ (await getProxies());
             if (gen !== _providerPollGeneration) return;  // Cancelled during await
-            if (!data || !data.proxies) {
+            if (!rawProxies || !rawProxies.proxies) {
                 // Malformed response — treat as retryable
                 startProviderPoll(preferredGroupName, exhaustionKey, attempt + 1);
                 return;
             }
+            const data = await getProxiesMerged(rawProxies);
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
 
             // Pass cached config to avoid an extra /configs HTTP request
             const cachedConfig = await getConfigCached();
@@ -1869,9 +1872,10 @@ export async function renderProxies() {
         renderProxiesLoading(container, t.loadingNodes);
     }
 
-    // Fetch proxies and config in parallel using cached versions
+    // Fetch proxies (merged with provider data) and config in parallel
+    const proxiesBase = await getProxiesCached();
     const [data, config] = await Promise.all([
-        getProxiesCached(),
+        getProxiesMerged(proxiesBase),
         getConfigCached(),
     ]);
 
@@ -1953,50 +1957,10 @@ export async function renderProxies() {
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
 
-    // --- Stale-cache recovery ---
-    // `data` was fetched via getProxiesCached() at the top of this function.
-    // When proxy-providers finish downloading, mihomo updates group.all[] with
-    // new node names before the node details appear in the /proxies response.
-    // If the cached data is in this "half-updated" state, the proxies array
-    // (from group.all[]) will contain names that don't exist in data.proxies.
-    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
-    // return), resulting in an empty container — the user sees no nodes.
-    //
-    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
-    // and re-fetch. If still missing (mihomo not fully updated), retry once
-    // after a short delay. All recovery failures are caught so rendering
-    // continues with the original (stale) data rather than aborting.
-    if (data?.proxies) {
-        const hasMissing = hasMissingProxyDetails(proxies, data.proxies);
-        if (hasMissing) {
-            invalidateProxiesCache();
-            try {
-                let freshData = /** @type {any} */ (await getProxies());
-                // Guard: if a newer render started while fetching fresh proxies,
-                // skip retry/delay work; the newer render will handle data.
-                if (_renderGen !== _renderGeneration) return;
-                if (freshData?.proxies && hasMissingProxyDetails(proxies, freshData.proxies)) {
-                    await new Promise(r => setTimeout(r, STALE_CACHE_RETRY_DELAY));
-                    freshData = /** @type {any} */ (await getProxies());
-                }
-                // Guard: user may have switched groups during the await/delay.
-                // If so, abort this render — the newer render takes precedence.
-                if (_renderGen !== _renderGeneration) return;
-                if (freshData?.proxies) {
-                    data.proxies = freshData.proxies;
-                }
-            } catch (e) {
-                if (_renderGen !== _renderGeneration) return;
-                proxyLogger.warn('[renderProxies] stale-cache recovery failed, using cached data:', e);
-            }
-            // If nodes are STILL missing after recovery (or recovery failed),
-            // force providerLoading so the guard below shows a loading state +
-            // starts the poller instead of rendering an empty container.
-            if (hasMissingProxyDetails(proxies, data.proxies)) {
-                proxyGroupsResult.providerLoading = true;
-            }
-        }
-    }
+    // Provider nodes are now merged by getProxiesMerged() at the top of this
+    // function (combines /proxies + /providers/proxies). If nodes are still
+    // missing (provider not yet downloaded), the providerLoading guard below
+    // handles it.
 
 // --- Provider-loading guard ---
 // If the uiGroup uses include-all/include-all-providers and its all[] has


### PR DESCRIPTION
## Problemmihomo's /proxies API intentionally excludes proxy-provider nodes — they only exist in group.all[] and /providers/proxies. Zephyr only queried /proxies, so include-all groups with provider-only nodes rendered empty (infinite loading spinner).## Root CauseProvider nodes (e.g. Ky |🇬🇧 E-英国1) are private to the provider object and never registered in the global proxies map that /proxies returns. This is mihomo's design, not a bug.## Solution**getProxiesMerged()** — lazily fetches /providers/proxies when missing node details are detected, merges provider node data into the proxies map.- **Zero overhead** when no providers are missing (covers 90% of cases)- **5s TTL cache** to avoid repeated requests during polling- **Graceful fallback** — if /providers/proxies fails, rendering continues with original dataInspired by clash-verge-rev's dual-API merge and Sparkle's lazy-load strategy.## Changes- pi.js: Added getProxyProviders(), getProxyProvider(name), getProxiesMerged()- proxies.js: Replaced getProxiesCached() with getProxiesMerged(), removed stale-cache recovery block (no longer needed)

## Summary by Sourcery

Merge mihomo /providers/proxies data into the main proxies response to ensure provider-only nodes render correctly in the desktop UI.

New Features:
- Expose APIs to fetch all proxy providers and individual provider details, including provider-managed node lists.
- Introduce a merged proxies fetch that lazily augments /proxies data with provider node information when missing.

Enhancements:
- Replace the previous cached proxies fetch and stale-cache recovery logic with the new merged proxies API in the proxies UI, simplifying provider loading behavior.