### PR TITLE
fix: merge /providers/proxies to get provider node details

### DIFF
--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -243,6 +243,7 @@ export { invoke, listen, openUrl, getCurrentWindow };
  * @param {string} url - 完整的 HTTP 基地址，如 `http://127.0.0.1:9090`
  */
 export function setBaseUrl(url) {
+  if (BASE_URL !== url) clearProviderCache();
   BASE_URL = url;
 }
 
@@ -251,6 +252,7 @@ export function setBaseUrl(url) {
  * @param {string} s
  */
 export function setSecret(s) {
+  if (_state.secret !== (s || '')) clearProviderCache();
   _state.secret = s || '';
 }
 
@@ -333,6 +335,188 @@ function isMissingAutostartEntryError(err) {
 export async function getProxies() {
   const res = await apiFetch('/proxies');
   return res.json();
+}
+
+/**
+ * 获取全部代理提供者数据（含 provider 下载的节点详情）
+ * mihomo 的 /proxies API 不包含 proxy-provider 下载的节点，
+ * 需要通过 /providers/proxies 获取。
+ * @returns {Promise<Object>} mihomo `/providers/proxies` 响应体
+ * @throws {ApiError}
+ */
+export async function getProxyProviders() {
+  const res = await apiFetch('/providers/proxies');
+  return res.json();
+}
+
+// ── Provider 缓存（避免轮询期间重复拉取 /providers/proxies） ─────────────
+/** @type {any} */
+let _providerCache = null;
+/** @type {any} */
+let _providerInFlight = null;
+let _providerGen = 0; // Incremented on core restart to invalidate in-flight requests
+const _PROVIDER_CACHE_TTL = 5000;
+const _PROVIDER_CACHE_PARTIAL_TTL = 1500; // Aligned with poller interval (1.5s)
+
+// Safari/old WebView compat: Object.hasOwn is not available everywhere
+const hasOwn = (/** @type {any} */ obj, /** @type {string} */ key) => Object.prototype.hasOwnProperty.call(obj, key); // NOSONAR — intentional compat workaround
+
+/**
+ * Built-in proxy names that never have detail records in /proxies.
+ * Shared between api.js and ui/proxies.js to prevent drift.
+ */
+export const SPECIAL_PROXY_NAMES = new Set(['DIRECT', 'REJECT', 'REJECT-DROP', 'COMPATIBLE', 'PASS', 'PASS-RULE', 'GLOBAL']);
+
+/**
+ * Clear provider cache. Called on core restart to prevent stale data.
+ */
+export function clearProviderCache() {
+  _providerCache = null;
+  _providerInFlight = null;
+  _providerGen++;
+}
+
+/**
+ * Collect proxy names from all group.all[] arrays.
+ * @param {Record<string, any>} proxiesMap - The proxies map from /proxies
+ * @returns {Set<string>} All names found in any group's all[]
+ */
+function collectAllProxyNames(proxiesMap) {
+  const names = new Set();
+  for (const key of Object.keys(proxiesMap)) {
+    const entry = proxiesMap[key];
+    if (entry?.all && Array.isArray(entry.all)) {
+      for (const name of entry.all) {
+        if (typeof name === 'string') names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract provider nodes from /providers/proxies response into a flat map.
+ * @param {any} providersResp - Response from /providers/proxies
+ * @returns {Record<string, any>} Map of proxy name → proxy detail
+ */
+function extractProviderNodes(providersResp) {
+  const result = Object.create(null);
+  const providers = Object.values(providersResp?.providers ?? {});
+  for (const provider of providers) {
+    const proxies = Array.isArray(provider?.proxies) ? provider.proxies : [];
+    for (const proxy of proxies) {
+      if (proxy?.name) result[proxy.name] = proxy;
+    }
+  }
+  return result;
+}
+
+/**
+ * Check provider cache for a valid hit and merge cached nodes.
+ * Returns merged data object if cache hit, null if cache miss.
+ * @param {string[]} missingNames - Names missing from /proxies
+ * @param {Record<string, any>} mergedProxies - Cloned proxies map to merge into
+ * @param {number} now - Current timestamp
+ * @param {any} data - Original /proxies response (for spreading)
+ * @returns {any | null} Merged data or null
+ */
+function tryProviderCache(missingNames, mergedProxies, now, data) {
+  if (!_providerCache) return null;
+  const age = now - _providerCache.ts;
+  // If previous fetch failed, skip retry within full TTL
+  if (_providerCache.failed && age < _PROVIDER_CACHE_TTL) {
+    return { ...data, proxies: mergedProxies };
+  }
+  if (age >= _PROVIDER_CACHE_TTL) return null;
+  // Merge whatever cached nodes we have (even partial coverage).
+  const cached = _providerCache.proxies;
+  const hasAnyMissing = missingNames.some(n => !cached[n] && !hasOwn(mergedProxies, n));
+  // If cache doesn't cover all missing names, only use it for a shorter TTL
+  // so provider downloads converge faster.
+  if (hasAnyMissing && age >= _PROVIDER_CACHE_PARTIAL_TTL) return null;
+  for (const name of missingNames) {
+    if (cached[name] && !hasOwn(mergedProxies, name)) {
+      mergedProxies[name] = cached[name];
+    }
+  }
+  return { ...data, proxies: mergedProxies };
+}
+
+/**
+ * 合并 /proxies + /providers/proxies 的数据。
+ * 按需懒加载：只有当 /proxies 的节点缺失时才拉 provider 数据。
+ *
+ * @param {any} [existingData] - 已有的 /proxies 响应（避免重复请求）
+ * @returns {Promise<any>} 合并后的数据
+ * @throws {ApiError}
+ */
+export async function getProxiesMerged(existingData) {
+  const data = existingData || await getProxies();
+  if (!data?.proxies) return data;
+
+  const allNames = collectAllProxyNames(data.proxies);
+  const missingNames = [...allNames].filter(
+    n => !SPECIAL_PROXY_NAMES.has(n.toUpperCase()) && !hasOwn(data.proxies, n)
+  );
+  if (missingNames.length === 0) {
+    // Opportunistically expire stale cache to free memory
+    if (_providerCache && (Date.now() - _providerCache.ts) >= _PROVIDER_CACHE_TTL) {
+      _providerCache = null;
+    }
+    return data;
+  }
+
+  const now = Date.now();
+
+  // Clone proxies map with null prototype to prevent prototype pollution
+  const mergedProxies = Object.assign(Object.create(null), data.proxies);
+
+  // Cache hit: TTL valid AND cached map covers all currently-missing names.
+  const cached = tryProviderCache(missingNames, mergedProxies, now, data);
+  if (cached) return cached;
+
+  // Dedup concurrent requests — reuse in-flight promise if same generation
+  const gen = _providerGen;
+  if (_providerInFlight?.gen !== gen) {
+    _providerInFlight = {
+      gen,
+      promise: getProxyProviders().then(providersResp => {
+        const providerProxies = extractProviderNodes(providersResp);
+        // Only write cache if generation hasn't changed (no restart)
+        if (gen === _providerGen) {
+          _providerCache = { proxies: providerProxies, ts: Date.now() };
+          _providerInFlight = null;
+        }
+        return providerProxies;
+      }).catch(err => {
+        if (gen === _providerGen) {
+          // Preserve previous cache if it had valid data; only set failed flag
+          // so we don't wipe good nodes on a transient failure.
+          if (_providerCache && !_providerCache.failed) {
+            _providerCache.failed = true;
+            _providerCache.ts = Date.now();
+          } else {
+            _providerCache = { proxies: Object.create(null), ts: Date.now(), failed: true };
+          }
+          _providerInFlight = null;
+        }
+        apiLogger.warn('[getProxiesMerged] /providers/proxies fetch failed, using raw /proxies data', err);
+        return null;
+      }),
+    };
+  }
+
+  const providerProxies = await _providerInFlight.promise;
+  // Ignore results from a previous generation (pre-restart)
+  if (providerProxies && gen === _providerGen) {
+    for (const name of missingNames) {
+      if (providerProxies[name] && !hasOwn(mergedProxies, name)) {
+        mergedProxies[name] = providerProxies[name];
+      }
+    }
+  }
+
+  return { ...data, proxies: mergedProxies };
 }
 
 /**
@@ -604,6 +788,7 @@ export async function restartCore(configPath, customArgs = []) {
   setWsBaseUrl(`ws://127.0.0.1:${coreResult.port}`);
   setWsSecret(coreResult.secret);
   setCoreReachable(true);
+  clearProviderCache();
   Bus.emit(Events.CORE_RESTARTED);
   return coreResult;
 }

--- a/apps/desktop/src/ui/proxies-poller.test.js
+++ b/apps/desktop/src/ui/proxies-poller.test.js
@@ -5,18 +5,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // (cache), fetchProxyGroupsShared (proxy-groups).  All other imports are mocked
 // as no-ops so the module loads cleanly.
 
-vi.mock('../api.js', () => ({
-    switchProxy: vi.fn(),
-    testProxy: vi.fn(),
-    abortLatencyTests: vi.fn(),
-    closeAllConnections: vi.fn(),
-    getConfig: vi.fn().mockResolvedValue({ mode: 'rule' }),
-    invoke: vi.fn(),
-    getLatencyTestSignal: vi.fn(),
-    resetLatencyTestController: vi.fn(),
-    restartCore: vi.fn(),
-    getProxies: vi.fn(),
-}));
+vi.mock('../api.js', async (importOriginal) => {
+    const real = await importOriginal();
+    return {
+        ...real,
+        switchProxy: vi.fn(),
+        testProxy: vi.fn(),
+        abortLatencyTests: vi.fn(),
+        closeAllConnections: vi.fn(),
+        getConfig: vi.fn().mockResolvedValue({ mode: 'rule' }),
+        invoke: vi.fn(),
+        getLatencyTestSignal: vi.fn(),
+        resetLatencyTestController: vi.fn(),
+        restartCore: vi.fn(),
+        getProxies: vi.fn(),
+        getProxiesMerged: vi.fn().mockImplementation((data) => Promise.resolve(data)),
+    };
+});
 
 vi.mock('../utils/logger.js', () => ({ proxyLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
 vi.mock('../utils/sanitize.js', () => ({ escapeHtml: vi.fn(s => s) }));

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -6,7 +6,7 @@
  * @module ui/proxies
  */
 
-import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore, getProxies } from '../api.js';
+import { switchProxy, testProxy, abortLatencyTests, closeAllConnections, getConfig, invoke, getLatencyTestSignal, resetLatencyTestController, restartCore, getProxies, getProxiesMerged, SPECIAL_PROXY_NAMES } from '../api.js';
 import { proxyLogger } from '../utils/logger.js';
 import { escapeHtml } from '../utils/sanitize.js';
 import { getDelayColorClass } from '../utils/format.js';
@@ -866,7 +866,7 @@ let _dismissedMismatchKey = null;
 async function reportFailover(name, success) {
     if (!appStore.get('failoverEnabled')) return;
     const uiGroupName = appStore.get('uiGroupName');
-    const proxyMap = await getProxiesCached().then(d => d?.proxies).catch(() => null);
+    const proxyMap = await getProxiesCached().then(getProxiesMerged).then(d => d?.proxies).catch(() => null);
     const currentNode = proxyMap?.[uiGroupName]?.now;
     const activeLeaf = currentNode ? resolveLeafNode(currentNode, proxyMap) : null;
     const activeNode = activeLeaf || currentNode;
@@ -897,7 +897,7 @@ async function handleFailoverAction(action) {
         const uiGroupName = appStore.get('uiGroupName');
         if (!uiGroupName) return;
 
-        const proxyMap = /** @type {Record<string, any>} */ (await getProxiesCached().then(d => d?.proxies).catch(() => null));
+        const proxyMap = /** @type {Record<string, any>} */ (await getProxiesCached().then(getProxiesMerged).then(d => d?.proxies).catch(() => null));
         if (!proxyMap) return;
 
         const group = proxyMap[uiGroupName];
@@ -1261,11 +1261,8 @@ let _providerPollInFlight = false;
 /** Maximum provider-loading retries (≈30 s at 1.5 s interval). */
 const PROVIDER_POLL_MAX = 20;
 
-/** Delay (ms) before retrying a stale-cache proxy re-fetch. */
-const STALE_CACHE_RETRY_DELAY = 500;
-
 /** Special proxy names that never have detail records in /proxies. */
-const SPECIAL_PROXY_NAMES = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE']);
+// SPECIAL_PROXY_NAMES imported from api.js (single source of truth)
 
 /**
  * Check whether any proxy name in `names` is missing from `proxiesMap`.
@@ -1287,7 +1284,7 @@ function hasMissingProxyDetails(names, proxiesMap) {
 let _providerPollGeneration = 0;
 
 /** Render generation token: prevents stale renderProxies() invocations from
- *  overwriting a newer render after an async stale-cache recovery delay. */
+ *  overwriting a newer render after an async fetch completes. */
 let _renderGeneration = 0;
 
 /**
@@ -1458,13 +1455,16 @@ function startProviderPoll(preferredGroupName, exhaustionKey, attempt = 0) {
             if (gen !== _providerPollGeneration) return;
             // Use non-cached fetch to avoid invalidating the global cache
             // (which would force other UI components to re-fetch too).
-            const data = /** @type {any} */ (await getProxies());
+            // Merge with provider data so missing-detail checks include provider nodes.
+            const rawProxies = /** @type {any} */ (await getProxies());
             if (gen !== _providerPollGeneration) return;  // Cancelled during await
-            if (!data || !data.proxies) {
+            if (!rawProxies?.proxies) {
                 // Malformed response — treat as retryable
                 startProviderPoll(preferredGroupName, exhaustionKey, attempt + 1);
                 return;
             }
+            const data = await getProxiesMerged(rawProxies);
+            if (gen !== _providerPollGeneration) return;  // Cancelled during await
 
             // Pass cached config to avoid an extra /configs HTTP request
             const cachedConfig = await getConfigCached();
@@ -1869,11 +1869,14 @@ export async function renderProxies() {
         renderProxiesLoading(container, t.loadingNodes);
     }
 
-    // Fetch proxies and config in parallel using cached versions
+    // Fetch proxies (merged with provider data) and config in parallel
     const [data, config] = await Promise.all([
-        getProxiesCached(),
+        getProxiesCached().then(getProxiesMerged),
         getConfigCached(),
     ]);
+
+    // Guard: if a newer render started while fetching, abort — the newer render takes precedence.
+    if (_renderGen !== _renderGeneration) return;
 
     // Clear loading timeout — data fetch completed (success or failure)
     clearLoadingTimeout();
@@ -1953,49 +1956,12 @@ export async function renderProxies() {
 
     let proxies = [...proxyGroupsResult.proxies]; // Mutable copy
 
-    // --- Stale-cache recovery ---
-    // `data` was fetched via getProxiesCached() at the top of this function.
-    // When proxy-providers finish downloading, mihomo updates group.all[] with
-    // new node names before the node details appear in the /proxies response.
-    // If the cached data is in this "half-updated" state, the proxies array
-    // (from group.all[]) will contain names that don't exist in data.proxies.
-    // buildProxyWrappers() skips nodes missing from data.proxies (if (!proxy)
-    // return), resulting in an empty container — the user sees no nodes.
-    //
-    // Fix: if any proxy name is missing from data.proxies, invalidate the cache
-    // and re-fetch. If still missing (mihomo not fully updated), retry once
-    // after a short delay. All recovery failures are caught so rendering
-    // continues with the original (stale) data rather than aborting.
-    if (data?.proxies) {
-        const hasMissing = hasMissingProxyDetails(proxies, data.proxies);
-        if (hasMissing) {
-            invalidateProxiesCache();
-            try {
-                let freshData = /** @type {any} */ (await getProxies());
-                // Guard: if a newer render started while fetching fresh proxies,
-                // skip retry/delay work; the newer render will handle data.
-                if (_renderGen !== _renderGeneration) return;
-                if (freshData?.proxies && hasMissingProxyDetails(proxies, freshData.proxies)) {
-                    await new Promise(r => setTimeout(r, STALE_CACHE_RETRY_DELAY));
-                    freshData = /** @type {any} */ (await getProxies());
-                }
-                // Guard: user may have switched groups during the await/delay.
-                // If so, abort this render — the newer render takes precedence.
-                if (_renderGen !== _renderGeneration) return;
-                if (freshData?.proxies) {
-                    data.proxies = freshData.proxies;
-                }
-            } catch (e) {
-                if (_renderGen !== _renderGeneration) return;
-                proxyLogger.warn('[renderProxies] stale-cache recovery failed, using cached data:', e);
-            }
-            // If nodes are STILL missing after recovery (or recovery failed),
-            // force providerLoading so the guard below shows a loading state +
-            // starts the poller instead of rendering an empty container.
-            if (hasMissingProxyDetails(proxies, data.proxies)) {
-                proxyGroupsResult.providerLoading = true;
-            }
-        }
+    // Provider nodes are now merged by getProxiesMerged() at the top of this
+    // function (combines /proxies + /providers/proxies). If nodes are still
+    // missing (provider not yet downloaded or /providers/proxies failed),
+    // force providerLoading so the poller starts.
+    if (data?.proxies && hasMissingProxyDetails(proxies, data.proxies)) {
+        proxyGroupsResult.providerLoading = true;
     }
 
 // --- Provider-loading guard ---
@@ -2160,11 +2126,12 @@ Bus.on(Events.CONFIG_UPDATED, async () => {
 });
 
 Bus.on(Events.CORE_RESTARTED, () => {
-    invalidateRunConfigCache();
-    // Do NOT reset uiGroupName here — restoreProxySelection depends on it
-    // to restore the correct group after core restart. The resolver will
-    // re-validate uiGroupName against the new proxyMap on next render.
-    renderProxies();
+invalidateRunConfigCache();
+invalidateProxiesCache();
+// Do NOT reset uiGroupName here — restoreProxySelection depends on it
+// to restore the correct group after core restart. The resolver will
+// re-validate uiGroupName against the new proxyMap on next render.
+renderProxies();
 });
 
 // --- Observed Group Watcher: start/stop with page visibility ---

--- a/apps/desktop/src/ui/proxy-groups.js
+++ b/apps/desktop/src/ui/proxy-groups.js
@@ -13,13 +13,12 @@
  * @module ui/proxy-groups
  */
 
-import { getProxies, getConfig } from '../api.js';
+import { getProxies, getConfig, SPECIAL_PROXY_NAMES } from '../api.js';
 import { getRunConfigCached } from './run-config-cache.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────
 
-/** Names that are always treated as special / non-selectable groups. */
-const SPECIAL_GROUPS = new Set(['DIRECT', 'REJECT', 'PASS', 'COMPATIBLE']);
+// SPECIAL_PROXY_NAMES imported from api.js (single source of truth)
 
 /**
  * Returns true if the proxy entry is a "group node" (has `all` array).
@@ -86,7 +85,7 @@ function buildOrderedGroups(runConfig, proxyMap) {
     if (runConfig && Array.isArray(runConfig['proxy-groups'])) {
         for (const pg of runConfig['proxy-groups']) {
             const name = pg?.name;
-            if (!name || SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (!name || SPECIAL_PROXY_NAMES.has(name.toUpperCase())) continue;
             if (seen.has(name)) continue;
             seen.add(name);
 
@@ -104,7 +103,7 @@ function buildOrderedGroups(runConfig, proxyMap) {
     // 2. Fallback: GLOBAL.all (preserves subscription-defined order)
     if (all.length === 0 && proxyMap['GLOBAL']?.all) {
         for (const name of proxyMap['GLOBAL'].all) {
-            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (SPECIAL_PROXY_NAMES.has(name.toUpperCase())) continue;
             if (seen.has(name)) continue;
             const p = proxyMap[name];
             if (!p || !isGroup(p)) continue;
@@ -120,7 +119,7 @@ function buildOrderedGroups(runConfig, proxyMap) {
     // 3. Last resort: all group nodes from proxyMap, sorted by name
     if (all.length === 0) {
         for (const name of Object.keys(proxyMap).sort()) {
-            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (SPECIAL_PROXY_NAMES.has(name.toUpperCase())) continue;
             const p = proxyMap[name];
             if (!isGroup(p)) continue;
             if (p.hidden) continue;
@@ -199,7 +198,7 @@ function buildTopLevelGroups(proxyMap, orderedGroups) {
     // 1. GLOBAL.all items that are also groups (preserves subscription order)
     if (proxyMap['GLOBAL']?.all) {
         for (const name of proxyMap['GLOBAL'].all) {
-            if (SPECIAL_GROUPS.has(name.toUpperCase())) continue;
+            if (SPECIAL_PROXY_NAMES.has(name.toUpperCase())) continue;
             const p = proxyMap[name];
             if (!p || !isGroup(p)) continue;
             if (p.hidden) continue;
@@ -453,7 +452,7 @@ export async function fetchProxyGroups(options = {}) {
     const hasProviderProxies = Array.isArray(proxies)
         && proxies.some(name =>
             typeof name === 'string'
-            && !SPECIAL_GROUPS.has(name.toUpperCase())
+            && !SPECIAL_PROXY_NAMES.has(name.toUpperCase())
             && !localProxyNames.has(name)
             && !groupNames.has(name)
         );

--- a/apps/desktop/src/ui/proxy-groups.test.js
+++ b/apps/desktop/src/ui/proxy-groups.test.js
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock API + run-config-cache so fetchProxyGroups can be tested in isolation
-vi.mock('../api.js', () => ({
-    getProxies: vi.fn(),
-    getConfig: vi.fn(),
-}));
+vi.mock('../api.js', async (importOriginal) => {
+    const real = await importOriginal();
+    return {
+        ...real,
+        getProxies: vi.fn(),
+        getConfig: vi.fn(),
+    };
+});
 vi.mock('./run-config-cache.js', () => ({
     getRunConfigCached: vi.fn(),
     invalidateRunConfigCache: vi.fn(),


### PR DESCRIPTION
Fix empty proxy lists by merging /providers/proxies. See commit for details.

## Summary by Sourcery

Merge proxy provider node details into desktop proxies API and UI to fix missing proxy entries and improve provider polling and rendering reliability.

New Features:
- Expose an API for fetching proxy providers and a merged proxies view that combines /proxies and /providers/proxies data.

Bug Fixes:
- Ensure failover and provider polling logic correctly handle nodes whose names exist in group all[] lists but are missing detail records, excluding special proxies like DIRECT and COMPATIBLE.
- Prevent stale provider and proxy state after core restarts by clearing provider and proxies caches and guarding against outdated renders.

Enhancements:
- Introduce shared SPECIAL_PROXY_NAMES across API and UI modules to centralize handling of special proxy entries.
- Optimize provider polling and rendering with generation tokens, provider cache, and merged proxies to reduce redundant requests and avoid transient inconsistencies.

Tests:
- Extend proxies poller and proxy-groups tests to cover merged provider data, special-name handling, and missing node detail scenarios.