### PR TITLE
fix: use getProxiesMerged in aux UI paths and add unit tests

### DIFF
--- a/apps/desktop/src/api.test.js
+++ b/apps/desktop/src/api.test.js
@@ -6,6 +6,9 @@ import {
     isCoreReachable,
     setCoreReachable,
     getProxies,
+    getProxiesMerged,
+    clearProviderCache,
+    SPECIAL_PROXY_NAMES,
     switchProxy,
     getConfig,
     patchConfig,
@@ -507,5 +510,59 @@ describe('listen', () => {
 describe('openUrl', () => {
     it('throws when Tauri IPC is not available', async () => {
         await expect(openUrl('https://example.com')).rejects.toThrow('[API] Tauri IPC not available');
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  getProxiesMerged / SPECIAL_PROXY_NAMES / clearProviderCache
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('SPECIAL_PROXY_NAMES', () => {
+    it('contains expected built-in proxy names', () => {
+        expect(SPECIAL_PROXY_NAMES.has('DIRECT')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('REJECT')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('REJECT-DROP')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('PASS')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('PASS-RULE')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('COMPATIBLE')).toBe(true);
+    });
+
+    it('does not contain GLOBAL (GLOBAL is a real group)', () => {
+        expect(SPECIAL_PROXY_NAMES.has('GLOBAL')).toBe(false);
+    });
+});
+
+describe('getProxiesMerged', () => {
+    beforeEach(() => {
+        clearProviderCache();
+        vi.restoreAllMocks();
+    });
+
+    it('returns data as-is when no proxies are missing', async () => {
+        const data = {
+            proxies: {
+                'GLOBAL': { name: 'GLOBAL', all: ['node1', 'node2'] },
+                'node1': { name: 'node1', type: 'Shadowsocks' },
+                'node2': { name: 'node2', type: 'Vmess' },
+            },
+        };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data); // No merge needed — same data returned
+    });
+
+    it('returns data as-is when only special names are missing', async () => {
+        const data = {
+            proxies: {
+                'GLOBAL': { name: 'GLOBAL', all: ['DIRECT', 'REJECT'] },
+            },
+        };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data);
+    });
+
+    it('returns data unchanged when data.proxies is missing', async () => {
+        const data = { mode: 'rule' };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data);
     });
 });

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -2163,7 +2163,7 @@ const _renderExplanationBarFromStore = debounce(async () => {
     const proxiesPage = document.querySelector('[data-page="proxies"]');
     if (proxiesPage && !proxiesPage.classList.contains('hidden')) {
         try {
-            const data = await getProxiesCached();
+            const data = await getProxiesCached().then(getProxiesMerged);
             const uiGroupName = appStore.get('uiGroupName');
             const effectiveGroupName = appStore.get('effectiveGroupName');
             const observedGroupName = appStore.get('observedGroupName');
@@ -2202,7 +2202,7 @@ const updateCapsuleDisplay = () => {
     const currentGroupName = currentNodeEl.dataset.group;
     if (!currentGroupName) return;
 
-    getProxiesCached().then(data => {
+    getProxiesCached().then(getProxiesMerged).then(data => {
         // Verify the group hasn't changed during the async API call to prevent race conditions
         if (currentNodeEl.dataset.group !== currentGroupName) return;
 


### PR DESCRIPTION
Follow-up to #1085. Use getProxiesMerged in explanation bar and capsule display. Add unit tests for SPECIAL_PROXY_NAMES and getProxiesMerged.

## Summary by Sourcery

Use merged proxy data in auxiliary proxy UI paths and add coverage for proxy merging utilities.

New Features:
- Apply getProxiesMerged to the explanation bar and capsule display so they consume merged proxy information.

Tests:
- Add unit tests for SPECIAL_PROXY_NAMES to validate built-in proxy name handling.
- Add unit tests for getProxiesMerged and clearProviderCache to verify behavior when proxies are present, missing, or absent.