### PR TITLE
feat: add console dashboard home page with real-time traffic, node controls, and subscription info

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "core:window:allow-show",
     "core:window:allow-set-focus",
     "core:window:allow-is-visible",
+    "core:window:allow-is-maximized",
     "core:window:allow-set-title",
     "core:event:allow-listen",
     "core:event:allow-unlisten",

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -27,7 +27,7 @@ const HEALTH_CHECK_INITIAL_INTERVAL_MS: u64 = 50;
 const HEALTH_CHECK_MAX_INTERVAL_MS: u64 = 1000;
 #[cfg(target_os = "macos")]
 use super::tun_manager::{is_tun_mode, restart_core_as_root};
-use super::{AppPaths, CoreStartResult, MihomoState, CORE_STARTING};
+use super::{AppPaths, CoreData, CoreStartResult, MihomoState, CORE_STARTING};
 
 #[cfg(target_os = "windows")]
 use super::CREATE_NO_WINDOW;
@@ -1427,6 +1427,14 @@ pub async fn start_core_inner(
     #[cfg(target_os = "macos")]
     if is_tun_mode() {
         let secret = restart_core_as_root(&app, true).await?;
+        // Record uptime for the TUN start path (restart_core_as_root spawns
+        // mihomo as root; the normal spawn path below is never reached).
+        // Best-effort: if the lock fails, mihomo is already running — don't
+        // fail the entire start just because we couldn't record the timestamp.
+        if let Ok(mut lock) = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)
+        {
+            lock.set_started_at(Some(std::time::Instant::now()));
+        }
         // For TUN mode, use the config_path as-is to match the frontend's requested name.
         // Do NOT strip extension here, as normal mode returns full filename with extension.
         return Ok(CoreStartResult {
@@ -1597,6 +1605,7 @@ pub async fn start_core_inner(
         &paths.app_data_dir,
     )
     .await?;
+    let started_at = std::time::Instant::now();
 
     // Windows: assign child to a Job Object with KILL_ON_JOB_CLOSE so that
     // mihomo is automatically terminated if the Tauri process dies (even from
@@ -1638,6 +1647,7 @@ pub async fn start_core_inner(
     lock.set_last_port(Some(port));
     lock.set_last_proxy_port(Some(proxy_port));
     lock.set_last_log_path(Some(log_path.to_string_lossy().into_owned()));
+    lock.set_started_at(Some(started_at));
     drop(lock);
 
     Ok(CoreStartResult {
@@ -1683,6 +1693,16 @@ pub async fn start_core(
     .and_then(std::convert::identity)
 }
 
+/// Clear all state fields that become stale when the core process stops.
+/// Called from both `stop_core_inner` and the exited-process branch of
+/// `get_core_uptime` to keep the reset logic in one place.
+fn clear_stopped_core_state(lock: &mut CoreData) {
+    lock.set_started_at(None);
+    lock.set_process(None);
+    lock.set_last_port(None);
+    lock.set_last_proxy_port(None);
+}
+
 /// Internal: stop the core process (no rate limiter reset).
 pub fn stop_core_inner(app: &AppHandle, state: &MihomoState) -> Result<(), String> {
     // Take the child process
@@ -1691,9 +1711,10 @@ pub fn stop_core_inner(app: &AppHandle, state: &MihomoState) -> Result<(), Strin
             .0
             .lock()
             .map_err(|e| format!("Failed to lock state: {e}"))?;
-        lock.set_last_port(None);
-        lock.set_last_proxy_port(None);
-        lock.take_process()
+        let child = lock.take_process();
+        clear_stopped_core_state(&mut lock);
+        drop(lock);
+        child
     };
 
     if let Some(mut child_process) = child {
@@ -1770,6 +1791,53 @@ pub async fn stop_core(app: AppHandle) -> Result<String, String> {
     .await
     .map_err(|e| format!("Failed to stop core: {e}"))??;
     Ok("Core stopped and cleaned up".to_owned())
+}
+
+/// Returns the number of seconds since mihomo was spawned, or `None` if the
+/// core is not running.  Uses the monotonic timestamp recorded at spawn in
+/// `CoreData::started_at` (`std::time::Instant`), immune to system clock changes.
+#[tauri::command]
+pub async fn get_core_uptime(app: AppHandle) -> Result<Option<u64>, String> {
+    let state = app.state::<MihomoState>();
+    let mut lock = lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)?;
+    // If we have a Child handle, verify liveness via try_wait().
+    // Distinguish "process exited" from "try_wait error" — only clear
+    // started_at when the process actually exited.
+    if let Some(child) = lock.process_mut() {
+        match child.try_wait() {
+            Ok(None) => { /* alive — proceed */ }
+            Ok(Some(_)) => {
+                // Process exited — clear started_at, process handle, and stale ports.
+                // Without clearing ports, other commands (e.g. update_config) may
+                // attempt requests to a stale/reused localhost port.
+                clear_stopped_core_state(&mut lock);
+                return Ok(None);
+            }
+            Err(e) => {
+                // Could not determine process state — log and trust started_at.
+                emit_warn!(
+                    Core,
+                    CORE_HEALTH_CHECK_FAILED,
+                    "Failed to check core process status: {}",
+                    e
+                );
+            }
+        }
+    }
+    // If there's no Child (e.g. macOS TUN mode where mihomo is started as root),
+    // we cannot check process liveness via try_wait(). We trust started_at as a
+    // best-effort uptime. Known limitation: if the root-spawned process exits
+    // unexpectedly, this branch will continue reporting stale uptime until the
+    // next start_core/stop_core call clears started_at. The frontend mitigates
+    // this by re-syncing uptime every 30 seconds and detecting core stops via
+    // traffic WS disconnection and connection API failures.
+    match lock.started_at() {
+        Some(start) => {
+            let elapsed = start.elapsed().as_secs();
+            Ok(Some(elapsed))
+        }
+        None => Ok(None),
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/core/mod.rs
+++ b/apps/desktop/src-tauri/src/core/mod.rs
@@ -46,6 +46,8 @@ pub struct CoreData {
     last_port: Option<u16>,
     last_proxy_port: Option<u16>,
     last_log_path: Option<String>,
+    /// Monotonic time when mihomo process was spawned (None if not started).
+    started_at: Option<std::time::Instant>,
 }
 
 impl Default for CoreData {
@@ -65,6 +67,7 @@ impl CoreData {
             last_port: None,
             last_proxy_port: None,
             last_log_path: None,
+            started_at: None,
         }
     }
 
@@ -125,6 +128,13 @@ impl CoreData {
     pub fn set_last_log_path(&mut self, p: Option<String>) {
         self.last_log_path = p;
     }
+    #[must_use]
+    pub const fn started_at(&self) -> Option<std::time::Instant> {
+        self.started_at
+    }
+    pub const fn set_started_at(&mut self, t: Option<std::time::Instant>) {
+        self.started_at = t;
+    }
 }
 pub struct MihomoState(pub Mutex<CoreData>);
 
@@ -178,8 +188,9 @@ pub use config_manager::{
 };
 pub use core_log::read_core_log;
 pub use core_process::{
-    core_binary_name, ensure_app_storage, ensure_executable, get_core_exe_path, get_core_version,
-    kill_mihomo, resolve_app_paths, start_core, stop_core, stop_core_inner, DEFAULT_MIXED_PORT,
+    core_binary_name, ensure_app_storage, ensure_executable, get_core_exe_path, get_core_uptime,
+    get_core_version, kill_mihomo, resolve_app_paths, start_core, stop_core, stop_core_inner,
+    DEFAULT_MIXED_PORT,
 };
 pub use crypto::{
     decrypt_all_profiles, encrypt_all_profiles, is_machine_key_persisted, read_profile_file,

--- a/apps/desktop/src-tauri/src/core_manager.rs
+++ b/apps/desktop/src-tauri/src/core_manager.rs
@@ -19,6 +19,7 @@ pub use core::{
     export_logs,
     fetch_text,
     get_core_exe_path,
+    get_core_uptime,
     get_core_version,
     grant_linux_tun_permission,
     init_tun_mode_from_config,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -34,11 +34,11 @@ use config_manager::{read_config, update_config};
 use core_manager::core::subscription_scheduler::start_scheduler;
 use core_manager::{
     decrypt_all_profiles, delete_config, disable_tun_cmd, download_sub, download_sub_batch,
-    encrypt_all_profiles, ensure_app_storage, export_logs, fetch_text, get_core_version,
-    grant_linux_tun_permission, init_tun_mode_from_config, is_machine_key_persisted,
-    kill_all_mihomo_as_root_cmd, kill_mihomo, list_configs, open_config_folder, open_log_folder,
-    read_config_file, rename_config, restart_core_as_root_cmd, set_tun_enabled,
-    smart_kill_all_mihomo_as_root, start_core, stop_core, update_config_url,
+    encrypt_all_profiles, ensure_app_storage, export_logs, fetch_text, get_core_uptime,
+    get_core_version, grant_linux_tun_permission, init_tun_mode_from_config,
+    is_machine_key_persisted, kill_all_mihomo_as_root_cmd, kill_mihomo, list_configs,
+    open_config_folder, open_log_folder, read_config_file, rename_config, restart_core_as_root_cmd,
+    set_tun_enabled, smart_kill_all_mihomo_as_root, start_core, stop_core, update_config_url,
     update_subscription_interval, update_subscription_ua, write_config_file, CoreData, MihomoState,
 };
 use global_shortcut::ShortcutRegistry;
@@ -254,6 +254,11 @@ pub(crate) struct Settings {
     /// Values: "bash", "fish", "cmd", "powershell", "nushell".
     #[serde(default = "default_copy_env_format")]
     copy_env_format: String,
+    /// Home page mode: "minimal" (default) or "console".
+    /// Controls which layout is shown when the user navigates to the home page.
+    #[serde(default)]
+    home_page_mode: Option<String>,
+
     /// Settings schema version for automatic migration.
     /// Increment when breaking changes are made to the Settings struct.
     /// On load, if the stored version < `CURRENT_SCHEMA_VERSION`, migration
@@ -780,6 +785,22 @@ fn patch_settings(
             patch_field!(log_retention_days);
             patch_field!(log_max_file_mb);
             patch_field!(copy_env_format);
+            // Validate home_page_mode: only accept 'minimal' or 'console'
+            if let Some(v) = map.get("home_page_mode") {
+                if let Ok(val) = serde_json::from_value::<String>(v.clone()) {
+                    if val == "minimal" || val == "console" {
+                        guard.home_page_mode = Some(val);
+                        modified = true;
+                    } else {
+                        emit_warn!(
+                            Core,
+                            CORE_START_FAILED,
+                            "rejected invalid home_page_mode: {:?}",
+                            val
+                        );
+                    }
+                }
+            }
         }
         if !modified {
             return Ok(());
@@ -1377,45 +1398,12 @@ pub fn run() {
             } else {
                 Settings {
                     close_to_tray: true, // 默认开启
-                    auto_update: false,
-                    auto_update_client: false,
-                    autostart: false,
-                    theme: None,
-                    last_config: None,
-                    custom_args: Vec::new(),
-                    dns_nameservers: None,
-                    dns_fallbacks: None,
-                    auto_apply: false,
                     ui_scale: 1.0,
-                    config_order: Vec::new(),
-                    last_proxy_selection: std::collections::HashMap::new(),
-                    primary_group_preference: std::collections::HashMap::new(),
-                    subscription_user_agent: None,
-                    hide_timeout_nodes: false,
-                    // Global user preferences (all None = use YAML defaults)
-                    mode: None,
-                    tun_enabled: None,
-                    mixed_port: None,
-                    socks_port: None,
-                    http_port: None,
-                    ipv6: None,
-                    allow_lan: None,
-                    unified_delay: None,
-                    dns_rewrite_enabled: None,
-                    theme_mode: None,
-                    app_opacity: None,
-                    node_scroll: None,
-                    failover_enabled: false,
-                    network_optim_auto_apply: false,
-                    lightweight_mode: false,
-                    silent_start: false,
-                    encrypt_configs: false,
-                    log_app_enabled: false,
-                    log_core_enabled: false,
                     log_retention_days: default_log_retention_days(),
                     log_max_file_mb: default_log_max_file_mb(),
                     copy_env_format: default_copy_env_format(),
                     schema_version: CURRENT_SCHEMA_VERSION,
+                    ..Default::default()
                 }
             };
 
@@ -1599,6 +1587,7 @@ invalidate_heartbeat(window.app_handle());
             update_subscription_user_agent,
             update_last_config,
             get_core_version,
+            get_core_uptime,
             exempt_uwp_apps,
             read_config_file,
             write_config_file,

--- a/apps/desktop/src/api.test.js
+++ b/apps/desktop/src/api.test.js
@@ -6,6 +6,9 @@ import {
     isCoreReachable,
     setCoreReachable,
     getProxies,
+    getProxiesMerged,
+    clearProviderCache,
+    SPECIAL_PROXY_NAMES,
     switchProxy,
     getConfig,
     patchConfig,
@@ -507,5 +510,59 @@ describe('listen', () => {
 describe('openUrl', () => {
     it('throws when Tauri IPC is not available', async () => {
         await expect(openUrl('https://example.com')).rejects.toThrow('[API] Tauri IPC not available');
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  getProxiesMerged / SPECIAL_PROXY_NAMES / clearProviderCache
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('SPECIAL_PROXY_NAMES', () => {
+    it('contains expected built-in proxy names', () => {
+        expect(SPECIAL_PROXY_NAMES.has('DIRECT')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('REJECT')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('REJECT-DROP')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('PASS')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('PASS-RULE')).toBe(true);
+        expect(SPECIAL_PROXY_NAMES.has('COMPATIBLE')).toBe(true);
+    });
+
+    it('does not contain GLOBAL (GLOBAL is a real group)', () => {
+        expect(SPECIAL_PROXY_NAMES.has('GLOBAL')).toBe(false);
+    });
+});
+
+describe('getProxiesMerged', () => {
+    beforeEach(() => {
+        clearProviderCache();
+        vi.restoreAllMocks();
+    });
+
+    it('returns data as-is when no proxies are missing', async () => {
+        const data = {
+            proxies: {
+                'GLOBAL': { name: 'GLOBAL', all: ['node1', 'node2'] },
+                'node1': { name: 'node1', type: 'Shadowsocks' },
+                'node2': { name: 'node2', type: 'Vmess' },
+            },
+        };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data); // No merge needed — same data returned
+    });
+
+    it('returns data as-is when only special names are missing', async () => {
+        const data = {
+            proxies: {
+                'GLOBAL': { name: 'GLOBAL', all: ['DIRECT', 'REJECT'] },
+            },
+        };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data);
+    });
+
+    it('returns data unchanged when data.proxies is missing', async () => {
+        const data = { mode: 'rule' };
+        const result = await getProxiesMerged(data);
+        expect(result).toEqual(data);
     });
 });

--- a/apps/desktop/src/i18n.js
+++ b/apps/desktop/src/i18n.js
@@ -120,6 +120,10 @@ export const translations = {
         languageDesc: "Select interface language",
         uiScale: "UI Scale",
         uiScaleDesc: "Adjust interface zoom level",
+homePageMode: "Home Page Mode",
+homePageModeDesc: "Switch between minimal and console dashboard",
+homePageMinimal: "Minimal",
+homePageConsole: "Console",
         minToTray: "Hide on Close",
         minToTrayDesc: "Hide to tray instead of quitting when closing window",
         lightweightMode: "Lightweight Mode",
@@ -483,6 +487,7 @@ export const translations = {
         tunDisabled: "TUN disabled",
         tunToggleFailed: "TUN toggle failed",
         switchedTo: "Switched to",
+        notifSwitchFailed: "Failed to switch node",
         modeSwitchFailed: "Mode switch failed",
         modeRule: "Rule",
         modeGlobal: "Global",
@@ -505,6 +510,7 @@ export const translations = {
         coreUpdate: "Core Update",
 
         // Dual update notification
+        coreUpdateAvailable: "Core update available",
         bothUpdateAvailable: "Both core and client have updates",
         recommendFullVersion: "Recommend installing Full version",
 
@@ -734,6 +740,68 @@ export const translations = {
         networkOptimCanceled: "Operation canceled",
         networkOptimApplyFailed: "Failed to apply network optimizations",
         networkOptimRevertFailed: "Failed to revert network optimizations",
+
+        // ── Console Dashboard ──
+        consoleTitle: "Console",
+        consoleUptimeRunning: "Core running —",
+        consoleUptimeStopped: "Core stopped —",
+        consoleUptimeFmt: "Uptime @@days@@d @@time@@",
+        consoleDownSpeed: "Download Speed",
+        consoleUpSpeed: "Upload Speed",
+        consoleTotalTraffic: "Total Traffic",
+consoleSessionTraffic: "Session Traffic",
+        consoleActiveConn: "Active Connections",
+        consoleConnUnit: "conn",
+        consoleNodeLatency: "Node Latency",
+        consolePeak: "Peak",
+        consoleRealtimeTraffic: "Real-time Traffic",
+        consoleDownload: "Download",
+        consoleUpload: "Upload",
+        consoleAvgMin: "1 min avg",
+        consoleSessionDown: "Session DL",
+        consoleSessionUp: "Session UL",
+        consoleSampleInterval: "Sample interval",
+        consoleSampleValue: "1s · 60pt window",
+        consoleCurrentNode: "Current Node",
+        consoleSwitch: "Switch",
+        consoleTestLatency: "Test",
+        consoleQuickControl: "Quick Controls",
+        consoleSysProxy: "System Proxy",
+        consoleTunAdapter: "TUN Adapter",
+        consoleSortBySpeed: "Sort by Speed",
+        consoleSortByTraffic: "Sort by Traffic",
+        consoleSortByProcess: "Sort by Process",
+        consoleSortHint: "Click to toggle sort",
+        consoleCopyHint: "Click to copy",
+        consoleSubUsage: "Subscription",
+        consoleConnStatus: "Status",
+        consoleStatusActive: "Active",
+        consoleProxyMode: "Mode",
+        consoleRecentEvents: "Recent Events",
+        consoleLatencyExcellent: "Excellent",
+        consoleLatencyFair: "Fair",
+        consoleLatencyHigh: "High",
+        consoleCurrentSub: "Current",
+        consoleSystem: "System",
+        consoleNodePicker: "Switch node",
+        consoleAllLogs: "All Logs",
+        consoleSubUsed: "used",
+        consoleSubExpiry: "Expires",
+        consoleSubDaysLeft: { one: "@@d@@ day left", other: "@@d@@ days left" },
+        consoleSubLastUpdate: "Last update",
+        consoleSubNextUpdate: "Next auto-update",
+        consoleSubUpdateNow: "Update Now",
+consoleSubUpdateOk: "Subscription updated successfully",
+consoleSubUpdateFail: "Subscription update failed",
+        consoleSubManage: "Manage",
+        consoleSubNoSub: "No subscription",
+        consoleSubUpdating: "Updating…",
+                consoleSubNodes: { one: "@@count@@ node", other: "@@count@@ nodes" },
+        consoleSubJustNow: "Just now",
+        consoleSubNever: "Never",
+        consoleSubMinAgo: "@@m@@ min ago",
+        consoleSubHoursAgo: "@@h@@h ago",
+        consoleSubDaysAgo: "@@d@@d ago",
     },
 
     zh: {
@@ -826,6 +894,10 @@ export const translations = {
         languageDesc: "选择界面显示语言",
         uiScale: "界面缩放",
         uiScaleDesc: "调整界面缩放比例",
+homePageMode: "主页模式",
+homePageModeDesc: "在极简主页和控制台仪表盘之间切换",
+homePageMinimal: "极简",
+homePageConsole: "控制台",
         minToTray: "最小化到托盘",
         minToTrayDesc: "关闭窗口时隐藏到后台，而不是退出",
         lightweightMode: "轻量模式",
@@ -1189,6 +1261,7 @@ export const translations = {
         tunDisabled: "TUN 已关闭",
         tunToggleFailed: "TUN 切换失败",
         switchedTo: "已切换到",
+        notifSwitchFailed: "节点切换失败",
         modeSwitchFailed: "模式切换失败",
         modeRule: "规则",
         modeGlobal: "全局",
@@ -1211,6 +1284,7 @@ export const translations = {
         coreUpdate: "内核更新",
 
         // Dual update notification
+        coreUpdateAvailable: "内核有更新",
         bothUpdateAvailable: "内核和软件都有更新",
         recommendFullVersion: "推荐安装 Full 版本",
 
@@ -1440,6 +1514,68 @@ export const translations = {
         networkOptimCanceled: "操作已取消",
         networkOptimApplyFailed: "应用网络优化失败",
         networkOptimRevertFailed: "回退网络优化失败",
+
+        // ── 控制台仪表盘 ──
+        consoleTitle: "控制台",
+        consoleUptimeRunning: "核心已运行 —",
+        consoleUptimeStopped: "核心已停止 —",
+        consoleUptimeFmt: "核心已运行 @@days@@ 天 @@time@@",
+        consoleDownSpeed: "下载速度",
+        consoleUpSpeed: "上传速度",
+        consoleTotalTraffic: "总流量",
+consoleSessionTraffic: "会话流量",
+        consoleActiveConn: "活动连接",
+        consoleConnUnit: "个",
+        consoleNodeLatency: "节点延迟",
+        consolePeak: "峰值",
+        consoleRealtimeTraffic: "实时流量",
+        consoleDownload: "下载",
+        consoleUpload: "上传",
+        consoleAvgMin: "1 分钟平均",
+        consoleSessionDown: "会话总下载",
+        consoleSessionUp: "会话总上传",
+        consoleSampleInterval: "采样间隔",
+        consoleSampleValue: "1s · 60 点滚动窗",
+        consoleCurrentNode: "当前节点",
+        consoleSwitch: "切换",
+        consoleTestLatency: "测速",
+        consoleQuickControl: "快捷控制",
+        consoleSysProxy: "系统代理",
+        consoleTunAdapter: "TUN 虚拟网卡",
+        consoleSortBySpeed: "按速率排序",
+        consoleSortByTraffic: "按流量排序",
+        consoleSortByProcess: "按进程排序",
+        consoleSortHint: "点击切换排序方式",
+        consoleCopyHint: "点击复制",
+        consoleSubUsage: "订阅用量",
+        consoleConnStatus: "连接状态",
+        consoleStatusActive: "活跃中",
+        consoleProxyMode: "代理模式",
+        consoleRecentEvents: "最近事件",
+        consoleLatencyExcellent: "优秀",
+        consoleLatencyFair: "一般",
+        consoleLatencyHigh: "较高",
+        consoleCurrentSub: "当前订阅",
+        consoleSystem: "系统",
+        consoleNodePicker: "切换节点",
+        consoleAllLogs: "全部日志",
+        consoleSubUsed: "已用",
+        consoleSubExpiry: "到期时间",
+        consoleSubDaysLeft: { other: "剩 @@d@@ 天" },
+        consoleSubLastUpdate: "最近更新",
+        consoleSubNextUpdate: "下次自动更新",
+        consoleSubUpdateNow: "立即更新",
+consoleSubUpdateOk: "订阅更新成功",
+consoleSubUpdateFail: "订阅更新失败",
+        consoleSubManage: "管理订阅",
+        consoleSubNoSub: "暂无订阅",
+        consoleSubUpdating: "更新中…",
+        consoleSubNodes: { other: "@@count@@ 个节点" },
+        consoleSubJustNow: "刚刚",
+        consoleSubNever: "从未",
+        consoleSubMinAgo: "@@m@@ 分钟前",
+        consoleSubHoursAgo: "@@h@@ 小时前",
+        consoleSubDaysAgo: "@@d@@ 天前",
     },
 
     ja: {
@@ -1451,6 +1587,10 @@ export const translations = {
         delete: "",
         language: "言語",
         languageDesc: "表示言語を選択",
+        homePageMode: "ホームページモード",
+        homePageModeDesc: "ミニマルとコンソールダッシュボードを切り替え",
+        homePageMinimal: "ミニマル",
+        homePageConsole: "コンソール",
         loading: "読み込み中...",
         errorPrefix: "エラー",
         unknown: "不明",
@@ -1472,6 +1612,7 @@ export const translations = {
         tunDisabled: "",
         tunToggleFailed: "",
         switchedTo: "",
+        notifSwitchFailed: "ノードの切り替えに失敗しました",
         modeSwitchFailed: "",
         modeRule: "",
         modeGlobal: "",
@@ -1488,6 +1629,7 @@ export const translations = {
         clientUpToDate: "",
         clientNewVersionTag: "",
         bothUpdateAvailable: "",
+        coreUpdateAvailable: "コアの更新があります",
         recommendFullVersion: "",
         coreUpdate: "",
 
@@ -1635,6 +1777,68 @@ export const translations = {
         copyEnvFormat: "シェル形式",
         copyEnvCopied: "コピー済み",
         copy: "コピー",
+
+        // ── コンソールダッシュボード ──
+        consoleTitle: "コンソール",
+        consoleUptimeRunning: "コア実行中 —",
+        consoleUptimeStopped: "コア停止 —",
+        consoleUptimeFmt: "実行時間 @@days@@日 @@time@@",
+        consoleDownSpeed: "ダウンロード速度",
+        consoleUpSpeed: "アップロード速度",
+        consoleTotalTraffic: "総トラフィック",
+        consoleSessionTraffic: "セッショントラフィック",
+        consoleActiveConn: "アクティブ接続",
+        consoleConnUnit: "件",
+        consoleNodeLatency: "ノード遅延",
+        consolePeak: "ピーク",
+        consoleRealtimeTraffic: "リアルタイムトラフィック",
+        consoleDownload: "ダウンロード",
+        consoleUpload: "アップロード",
+        consoleAvgMin: "1分平均",
+        consoleSessionDown: "セッションDL",
+        consoleSessionUp: "セッションUL",
+        consoleSampleInterval: "サンプリング間隔",
+        consoleSampleValue: "1s · 60ptウィンドウ",
+        consoleCurrentNode: "現在のノード",
+        consoleSwitch: "切替",
+        consoleTestLatency: "テスト",
+        consoleQuickControl: "クイック制御",
+        consoleSysProxy: "システムプロキシ",
+        consoleTunAdapter: "TUNアダプター",
+        consoleSortBySpeed: "速度順",
+        consoleSortByTraffic: "トラフィック順",
+        consoleSortByProcess: "プロセス順",
+        consoleSortHint: "クリックでソート切替",
+        consoleCopyHint: "クリックでコピー",
+        consoleSubUsage: "サブスクリプション",
+        consoleConnStatus: "ステータス",
+        consoleStatusActive: "アクティブ",
+        consoleProxyMode: "モード",
+        consoleRecentEvents: "最近のイベント",
+        consoleLatencyExcellent: "優秀",
+        consoleLatencyFair: "普通",
+        consoleLatencyHigh: "高い",
+        consoleCurrentSub: "現在",
+        consoleSystem: "システム",
+        consoleNodePicker: "ノード切替",
+        consoleAllLogs: "全ログ",
+        consoleSubUsed: "使用済",
+        consoleSubExpiry: "有効期限",
+        consoleSubDaysLeft: { other: "残り@@d@@日" },
+        consoleSubLastUpdate: "最終更新",
+        consoleSubNextUpdate: "次回自動更新",
+        consoleSubUpdateNow: "今すぐ更新",
+        consoleSubUpdateOk: "サブスクリプションの更新に成功しました",
+        consoleSubUpdateFail: "サブスクリプションの更新に失敗しました",
+        consoleSubManage: "管理",
+        consoleSubNoSub: "サブスクリプションなし",
+        consoleSubUpdating: "更新中…",
+        consoleSubNodes: { other: "@@count@@ノード" },
+        consoleSubJustNow: "たった今",
+        consoleSubNever: "なし",
+        consoleSubMinAgo: "@@m@@分前",
+        consoleSubHoursAgo: "@@h@@時間前",
+        consoleSubDaysAgo: "@@d@@日前",
     },
 
     ko: {
@@ -1646,6 +1850,10 @@ export const translations = {
         delete: "",
         language: "언어",
         languageDesc: "표시 언어 선택",
+        homePageMode: "홈 페이지 모드",
+        homePageModeDesc: "미니멀과 콘솔 대시보드 전환",
+        homePageMinimal: "미니멀",
+        homePageConsole: "콘솔",
         loading: "로딩 중...",
         errorPrefix: "오류",
         unknown: "알 수 없음",
@@ -1667,6 +1875,7 @@ export const translations = {
         tunDisabled: "",
         tunToggleFailed: "",
         switchedTo: "",
+        notifSwitchFailed: "노드 전환에 실패했습니다",
         modeSwitchFailed: "",
         modeRule: "",
         modeGlobal: "",
@@ -1683,6 +1892,7 @@ export const translations = {
         clientUpToDate: "",
         clientNewVersionTag: "",
         bothUpdateAvailable: "",
+        coreUpdateAvailable: "코어 업데이트 사용 가능",
         recommendFullVersion: "",
         coreUpdate: "",
 
@@ -1732,6 +1942,68 @@ export const translations = {
         copyEnvFormat: "셸 형식",
         copyEnvCopied: "복사됨",
         copy: "복사",
+
+        // ── 콘솔 대시보드 ──
+        consoleTitle: "콘솔",
+        consoleUptimeRunning: "코어 실행 중 —",
+        consoleUptimeStopped: "코어 중지됨 —",
+        consoleUptimeFmt: "가동 시간 @@days@@일 @@time@@",
+        consoleDownSpeed: "다운로드 속도",
+        consoleUpSpeed: "업로드 속도",
+        consoleTotalTraffic: "총 트래픽",
+        consoleSessionTraffic: "세션 트래픽",
+        consoleActiveConn: "활성 연결",
+        consoleConnUnit: "개",
+        consoleNodeLatency: "노드 지연",
+        consolePeak: "피크",
+        consoleRealtimeTraffic: "실시간 트래픽",
+        consoleDownload: "다운로드",
+        consoleUpload: "업로드",
+        consoleAvgMin: "1분 평균",
+        consoleSessionDown: "세션 DL",
+        consoleSessionUp: "세션 UL",
+        consoleSampleInterval: "샘플 간격",
+        consoleSampleValue: "1s · 60pt 윈도우",
+        consoleCurrentNode: "현재 노드",
+        consoleSwitch: "전환",
+        consoleTestLatency: "테스트",
+        consoleQuickControl: "빠른 제어",
+        consoleSysProxy: "시스템 프록시",
+        consoleTunAdapter: "TUN 어댑터",
+        consoleSortBySpeed: "속도순",
+        consoleSortByTraffic: "트래픽순",
+        consoleSortByProcess: "프로세스순",
+        consoleSortHint: "클릭하여 정렬 전환",
+        consoleCopyHint: "클릭하여 복사",
+        consoleSubUsage: "구독",
+        consoleConnStatus: "상태",
+        consoleStatusActive: "활성",
+        consoleProxyMode: "모드",
+        consoleRecentEvents: "최근 이벤트",
+        consoleLatencyExcellent: "우수",
+        consoleLatencyFair: "보통",
+        consoleLatencyHigh: "높음",
+        consoleCurrentSub: "현재",
+        consoleSystem: "시스템",
+        consoleNodePicker: "노드 전환",
+        consoleAllLogs: "전체 로그",
+        consoleSubUsed: "사용됨",
+        consoleSubExpiry: "만료일",
+        consoleSubDaysLeft: { other: "남은 @@d@@일" },
+        consoleSubLastUpdate: "최근 업데이트",
+        consoleSubNextUpdate: "다음 자동 업데이트",
+        consoleSubUpdateNow: "지금 업데이트",
+        consoleSubUpdateOk: "구독 업데이트 성공",
+        consoleSubUpdateFail: "구독 업데이트 실패",
+        consoleSubManage: "관리",
+        consoleSubNoSub: "구독 없음",
+        consoleSubUpdating: "업데이트 중…",
+        consoleSubNodes: { other: "@@count@@개 노드" },
+        consoleSubJustNow: "방금",
+        consoleSubNever: "없음",
+        consoleSubMinAgo: "@@m@@분 전",
+        consoleSubHoursAgo: "@@h@@시간 전",
+        consoleSubDaysAgo: "@@d@@일 전",
     },
 };
 
@@ -1853,15 +2125,15 @@ function interpolate(template, vars, key) {
 /**
  * Resolve a translation key through the fallback chain: currentLang -> en.
  * @param {string} key
- * @returns {{ value: string, found: boolean }}
+ * @returns {{ value: unknown, found: boolean }}
  */
 function resolveKey(key) {
     const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-    const primary = /** @type {Record<string, string>} */(translations[langKey]);
+    const primary = /** @type {Record<string, unknown>} */(translations[langKey]);
     if (primary && Object.prototype.hasOwnProperty.call(primary, key)) {
         return { value: primary[key], found: true };
     }
-    const fallback = /** @type {Record<string, string>} */(translations.en);
+    const fallback = /** @type {Record<string, unknown>} */(translations.en);
     if (fallback && Object.prototype.hasOwnProperty.call(fallback, key)) {
         return { value: fallback[key], found: true };
     }
@@ -1902,21 +2174,21 @@ export function t(key, optionsOrCount, extraVars) {
         if (typeof value === 'object' && value !== null) {
             const category = pluralCategory(count, currentLang);
             /** @type {Record<string, string>} */
-            const pluralObj = value;
+            const pluralObj = /** @type {Record<string, string>} */ (value);
             const template = pluralObj[category] || pluralObj.other || pluralObj.one || '';
             return interpolate(template, { count, ...extraVars }, key);
         }
         // Fallback: value is a plain string, inject count as @@count@@
-        return interpolate(value, { count, ...extraVars }, key);
+        return interpolate(typeof value === 'string' ? value : key, { count, ...extraVars }, key);
     }
 
     // Interpolation path: second argument is an object
     if (optionsOrCount && typeof optionsOrCount === 'object') {
-        return interpolate(value, optionsOrCount, key);
+        return interpolate(typeof value === 'string' ? value : key, optionsOrCount, key);
     }
 
     // Simple lookup
-    return value;
+    return typeof value === 'string' ? value : key;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/i18n.test.js
+++ b/apps/desktop/src/i18n.test.js
@@ -39,17 +39,32 @@ describe('translations', () => {
         expect(zhKeys).toEqual(enKeys);
     });
 
-    it('all en translations are non-empty strings', () => {
+    it('all en translations are non-empty strings or plural objects', () => {
         for (const [key, value] of Object.entries(translations.en)) {
-            expect(typeof value).toBe('string');
-            expect(value.length).toBeGreaterThan(0);
+            if (typeof value === 'object' && value !== null) {
+                // Plural object: every variant must be a non-empty string
+                for (const [variant, text] of Object.entries(value)) {
+                    expect(typeof text).toBe('string');
+                    expect(text.length).toBeGreaterThan(0);
+                }
+            } else {
+                expect(typeof value).toBe('string');
+                expect(value.length).toBeGreaterThan(0);
+            }
         }
     });
 
-    it('all zh translations are non-empty strings', () => {
+    it('all zh translations are non-empty strings or plural objects', () => {
         for (const [key, value] of Object.entries(translations.zh)) {
-            expect(typeof value).toBe('string');
-            expect(value.length).toBeGreaterThan(0);
+            if (typeof value === 'object' && value !== null) {
+                for (const [variant, text] of Object.entries(value)) {
+                    expect(typeof text).toBe('string');
+                    expect(text.length).toBeGreaterThan(0);
+                }
+            } else {
+                expect(typeof value).toBe('string');
+                expect(value.length).toBeGreaterThan(0);
+            }
         }
     });
 });
@@ -189,11 +204,22 @@ describe('t() — interpolation', () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe('t() — pluralization', () => {
-    // No current translations use plural objects, but we can test the fallback behavior
     it('returns string as-is when no plural object', () => {
         // 'home' is a plain string, passing a count should still return 'Home'
         expect(t('home', 1)).toBe('Home');
         expect(t('home', 5)).toBe('Home');
+    });
+
+    it('returns singular form for count === 1', () => {
+        const result = t('consoleSubDaysLeft', 1, { d: '1' });
+        expect(typeof result).toBe('string');
+        expect(result).toContain('1');
+    });
+
+    it('returns plural form for count !== 1', () => {
+        const result = t('consoleSubDaysLeft', 30, { d: '30' });
+        expect(typeof result).toBe('string');
+        expect(result).toContain('30');
     });
 });
 

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -19,6 +19,7 @@
     <div id="app-main-container" class="w-full h-full flex overflow-hidden p-3 gap-0 rounded-[var(--zephyr-radius-overlay)] transition-all duration-[var(--zephyr-time-standard)] relative">
         <!-- Page Background Glows (shared layer, above sidebar but below content) -->
         <div id="glow-home" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-accent/10 blur-[120px] pointer-events-none rounded-full z-0"></div>
+        <div id="glow-console" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-accent/10 blur-[120px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-subscriptions" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-proxies" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
         <div id="glow-connections" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-cyan/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
@@ -213,6 +214,9 @@
                 </div>
             </div>
 
+            <!-- Console Dashboard Page (injected by ui/console-home.js) -->
+            <div data-page="console" class="flex-1 hidden flex flex-col overflow-hidden relative min-w-0"></div>
+
             <!-- Subscriptions Page -->
             <div data-page="subscriptions" class="flex-1 hidden flex flex-col p-8 gap-6 overflow-hidden relative">
 
@@ -356,7 +360,7 @@
                 <!-- Group Explanation Bar: shown when uiGroup differs from effectiveGroup -->
                 <div id="group-explanation-bar" class="hidden items-center gap-2 px-4 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 relative z-10 shrink-0" data-flex-class="flex"></div>
                 <!-- Container added p-4 to prevent 3D scale clipping -->
-                <div id="proxies-list" role="listbox" aria-label="Proxy Nodes" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 overflow-y-auto p-4 -mx-4 -mt-4 -mb-8 custom-scrollbar relative z-10">
+                <div id="proxies-list" role="listbox" aria-label="Proxy Nodes" class="grid gap-6 overflow-y-auto p-4 -mx-4 -mt-4 -mb-8 custom-scrollbar relative z-10">
                     <!-- Cards will be injected here -->
                 </div>
             </div>
@@ -512,6 +516,26 @@
                                     <button type="button" id="ui-scale-110" class="ui-scale-btn px-2.5 py-1 text-xs rounded-md bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-input)] transition-colors">110%</button>
                                     <button type="button" id="ui-scale-125" class="ui-scale-btn px-2.5 py-1 text-xs rounded-md bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-input)] transition-colors">125%</button>
                                     <button type="button" id="ui-scale-150" class="ui-scale-btn px-2.5 py-1 text-xs rounded-md bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-input)] transition-colors">150%</button>
+                                </div>
+                            </div>
+
+                            <div class="h-px bg-[var(--zephyr-bg-muted)]"></div>
+
+                            <!-- Home Page Mode -->
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-4">
+                                    <div class="text-[var(--text-secondary)]">
+                                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1.5"/><rect x="14" y="3" width="7" height="5" rx="1.5"/><rect x="14" y="12" width="7" height="9" rx="1.5"/><rect x="3" y="16" width="7" height="5" rx="1.5"/></svg>
+                                    </div>
+                                    <div>
+                                        <p class="text-sm font-semibold text-[var(--text-primary)]" data-i18n="homePageMode">Home Page Mode</p>
+                                        <p class="text-2xs text-[var(--text-muted)]" data-i18n="homePageModeDesc">Switch between minimal and console dashboard</p>
+                                    </div>
+                                </div>
+                                <div id="setting-home-mode-container" class="relative grid grid-cols-2 items-stretch p-1 bg-[var(--zephyr-bg-muted)] rounded-lg border border-[var(--zephyr-border-subtle)] h-9 transition-all duration-[var(--zephyr-time-standard)] w-[180px]">
+                                    <div id="setting-home-mode-slider" class="absolute top-1 bottom-1 left-1 w-[calc((100%-8px)/2)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
+                                    <button type="button" data-home-mode="minimal" aria-pressed="true" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-primary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="homePageMinimal">Minimal</button>
+                                    <button type="button" data-home-mode="console" aria-pressed="false" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="homePageConsole">Console</button>
                                 </div>
                             </div>
                         </div>

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -62,10 +62,11 @@ import * as prism from './ui/prism.js';
 import { showNotification } from './ui/notifications.js';
 import { initSettings, initUwpExemption } from './ui/settings.js';
 import { autoApplyIfNeeded } from './ui/network-optim.js';
-import { initNavigation } from './ui/navigation.js';
+import { initNavigation, switchPage, navigateTo } from './ui/navigation.js';
 import { initProxyControls, syncCoreConfig, renderProxies } from './ui/proxies.js';
 import { initPlugins } from './ui/plugins.js';
 import { initModeSelector } from './ui/modes.js';
+import { initConsoleHome, activateConsole, deactivateConsole } from './ui/console-home.js';
 import { initTunToggle } from './ui/tun.js';
 import { initDnsRewriteToggle } from './ui/dns.js';
 import { initNodeWheel } from './ui/node-wheel.js';
@@ -186,6 +187,189 @@ function initReactiveBindings() {
 }
 
 // ═══════════════════════════════════════════════════════════════════
+//  Helper: Start core and configure API endpoints
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Start the mihomo core, apply early UI settings, and configure API endpoints.
+ * Returns true on success, false on failure (error already shown to user).
+ * @returns {Promise<boolean>}
+ */
+async function startCoreAndConfigure() {
+  /** @type {string|null} */
+  let secret = null;
+  try {
+    const tGetSettings = performance.now();
+    const settings = await invoke(COMMANDS.GET_SETTINGS);
+    apiLogger.info(`[Zephyr] get_settings: +${(performance.now() - tGetSettings).toFixed(0)}ms`);
+
+    // Apply saved UI scale early (before UI renders)
+    if (settings.ui_scale && settings.ui_scale > 0 && settings.ui_scale !== 1) {
+      document.documentElement.style.setProperty('--ui-scale', String(settings.ui_scale));
+    }
+
+    // Set home page mode and apply initial page visibility BEFORE any UI renders.
+    // This prevents the flash of the minimal home page when console mode is enabled.
+    const homePageMode = settings.home_page_mode || 'minimal';
+    appStore.set('homePageMode', homePageMode);
+    if (homePageMode === 'console') {
+      // Use switchPage() to toggle page + glow visibility consistently
+      switchPage('console');
+      // Initialize console DOM early so content exists before rendering.
+      // activateConsole() is called later in step 8b after the core is started.
+      try { initConsoleHome(); } catch (err) { apiLogger.warn('Early console init failed', err); }
+    }
+
+    const tStartCore = performance.now();
+    const configPath = settings.last_config || 'config.yaml';
+    const customArgs = settings.custom_args || [];
+    apiLogger.info(`[Zephyr] calling start_core (config=${configPath})`);
+    const coreResult = await invoke(COMMANDS.START_CORE, {
+      configPath,
+      test: false,
+      customArgs,
+      secret: null,
+    });
+    apiLogger.info(`[Zephyr] start_core: +${(performance.now() - tStartCore).toFixed(0)}ms`);
+
+    // If start_core silently fell back (requested config doesn't exist),
+    // correct last_config to the actually loaded file.
+    if (coreResult.active_config && coreResult.active_config !== configPath) {
+      apiLogger.info(`[Zephyr] config fallback detected: requested "${configPath}" but loaded "${coreResult.active_config}", updating last_config`);
+      try {
+        await invoke(COMMANDS.UPDATE_LAST_CONFIG, { configName: coreResult.active_config });
+      } catch (e) {
+        apiLogger.warn(`[Zephyr] failed to update last_config after fallback: ${e}`);
+      }
+    }
+
+    secret = coreResult.secret;
+    const port = coreResult.port;
+
+    setBaseUrl(`http://127.0.0.1:${port}`);
+    setWsBaseUrl(`ws://127.0.0.1:${port}`);
+    setSecret(secret || '');
+    setWsSecret(secret || '');
+    setCoreReachable(true);
+
+    // 5b. Initialize Prism engine — compile patches and populate rule annotations.
+    const tPrism = performance.now();
+    prism.apply().then((applyResult) => {
+        const elapsed = (performance.now() - tPrism).toFixed(0);
+        const stats = applyResult?.stats;
+        const annotationCount = applyResult?.rule_annotations?.length ?? 0;
+        apiLogger.info(
+            `[Zephyr] prism.apply: +${elapsed}ms | patches=${stats?.succeeded ?? '?'}/${stats?.total ?? '?'} | annotations=${annotationCount}`
+        );
+        if (annotationCount === 0 && (stats?.total ?? 0) > 0) {
+            apiLogger.warn(
+                '[Zephyr] prism.apply succeeded but produced 0 rule annotations.',
+                'Check that .prism.yaml files use $prepend/$append DSL syntax.',
+            );
+        }
+    }).catch((err) => {
+        apiLogger.warn('[Zephyr] prism.apply failed (non-fatal, rules page may be empty):', err);
+    });
+
+    // 5c. Apply all enabled overrides (JS + Prism YAML).
+    invoke(COMMANDS.OVERRIDE.APPLY_ALL).then((logs) => {
+        const successCount = logs?.filter((/** @type {{success: boolean}} */ l) => l.success).length ?? 0;
+        const failCount = logs?.filter((/** @type {{success: boolean}} */ l) => !l.success).length ?? 0;
+        if (logs && logs.length > 0) {
+            apiLogger.info(`[Zephyr] override_apply_all: ${successCount} succeeded, ${failCount} failed (${logs.length} total)`);
+        }
+    }).catch((err) => {
+        apiLogger.warn('[Zephyr] override_apply_all failed (non-fatal):', err);
+    });
+  } catch (err) {
+    const message = err?.toString?.() || 'Core start failed';
+    apiLogger.error('Failed to start core', err);
+    sendOSNotification('Zephyr', message).catch(() => {});
+    alert(message);
+    return false;
+  }
+  return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+//  Helper: Auto-check for updates on startup
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Check for core and client updates after a short delay.
+ * Non-blocking — all errors are caught and logged.
+ */
+/** Normalize a version string: trim whitespace and strip leading 'v'/'V' prefix.
+ * @param {string} v
+ * @returns {string}
+ */
+function normalizeVersion(v) {
+  return String(v).trim().replace(/^[vV]/, '');
+}
+
+/** Check if a core update is available. @returns {Promise<boolean>} */
+async function hasCoreUpdate() {
+  try {
+    const latest = await invoke(COMMANDS.GET_LATEST_VERSION);
+    const currentVersion = await invoke(COMMANDS.GET_CORE_VERSION);
+    return normalizeVersion(latest.version) !== normalizeVersion(currentVersion);
+  } catch (e) {
+    apiLogger.warn('Auto core update check failed', e);
+    return false;
+  }
+}
+
+/** Check if a client update is available. @returns {Promise<boolean>} */
+async function hasClientUpdate() {
+  try {
+    if (await invoke(COMMANDS.GET_PORTABLE_MODE)) return false;
+    const info = await invoke(COMMANDS.GET_LATEST_CLIENT_VERSION);
+    const currentVersion = await invoke(COMMANDS.GET_APP_VERSION);
+    return normalizeVersion(info.version) !== normalizeVersion(currentVersion);
+  } catch (e) {
+    apiLogger.warn('Auto client update check failed', e);
+    return false;
+  }
+}
+
+function scheduleAutoUpdateCheck() {
+  setTimeout(async () => {
+    try {
+      const settings = await invoke(COMMANDS.GET_SETTINGS);
+      const lang = localStorage.getItem('lang') || 'en';
+      /** @type {Record<string, string>} */
+      const t = /** @type {Record<string, string>} */ (
+        /** @type {any} */ (translations)[lang] || /** @type {any} */ (translations).en
+      );
+
+      const coreHasUpdate = settings.auto_update ? await hasCoreUpdate() : false;
+      const clientHasUpdate = settings.auto_update_client ? await hasClientUpdate() : false;
+
+      // Notify the user about available updates
+      if (coreHasUpdate && clientHasUpdate) {
+        showNotification(
+          t.bothUpdateAvailable || 'Both core and client have updates',
+          'warning',
+          t.recommendFullVersion || 'Recommend installing Full version'
+        );
+      } else if (coreHasUpdate) {
+        showNotification(
+          t.coreUpdateAvailable || 'Core update available',
+          'warning'
+        );
+      } else if (clientHasUpdate) {
+        showNotification(
+          t.clientUpdateAvailable || 'Update Available',
+          'warning'
+        );
+      }
+    } catch (e) {
+      apiLogger.warn('Auto update check failed', e);
+    }
+  }, 5000);
+}
+
+// ═══════════════════════════════════════════════════════════════════
 //  initApp — Main initialization sequence
 // ═══════════════════════════════════════════════════════════════════
 
@@ -242,91 +426,7 @@ async function initApp() {
   }, 50);
 
   // 5. Start core and configure endpoints
-  /** @type {string|null} */
-  let secret = null;
-  try {
-    const tGetSettings = performance.now();
-    const settings = await invoke(COMMANDS.GET_SETTINGS);
-    apiLogger.info(`[Zephyr] get_settings: +${(performance.now() - tGetSettings).toFixed(0)}ms`);
-
-    // Apply saved UI scale early (before UI renders)
-    if (settings.ui_scale && settings.ui_scale > 0 && settings.ui_scale !== 1) {
-      document.documentElement.style.setProperty('--ui-scale', String(settings.ui_scale));
-    }
-
-    const tStartCore = performance.now();
-    const configPath = settings.last_config || 'config.yaml';
-    const customArgs = settings.custom_args || [];
-    apiLogger.info(`[Zephyr] calling start_core (config=${configPath})`);
-    const coreResult = await invoke(COMMANDS.START_CORE, {
-      configPath,
-      test: false,
-      customArgs,
-      secret: null,
-    });
-    apiLogger.info(`[Zephyr] start_core: +${(performance.now() - tStartCore).toFixed(0)}ms`);
-
-    // 如果 start_core 发生了静默回退（请求的配置文件不存在），
-    // 用实际加载的配置名纠正 last_config，避免下次冷启动仍然指向已不存在的文件。
-    if (coreResult.active_config && coreResult.active_config !== configPath) {
-      apiLogger.info(`[Zephyr] config fallback detected: requested "${configPath}" but loaded "${coreResult.active_config}", updating last_config`);
-      try {
-        await invoke(COMMANDS.UPDATE_LAST_CONFIG, { configName: coreResult.active_config });
-      } catch (e) {
-        apiLogger.warn(`[Zephyr] failed to update last_config after fallback: ${e}`);
-      }
-    }
-
-    secret = coreResult.secret;
-    const port = coreResult.port;
-
-    setBaseUrl(`http://127.0.0.1:${port}`);
-    setWsBaseUrl(`ws://127.0.0.1:${port}`);
-    setSecret(secret || '');
-    setWsSecret(secret || '');
-    setCoreReachable(true);
-
-    // 5b. Initialize Prism engine — compile patches and populate rule annotations.
-    // mihomo already started with run_config.yaml (previous compile output), so rules
-    // are already active. This apply() runs in the background to refresh annotations
-    // for the "Active Rules" tab. Non-blocking: UI renders immediately.
-    const tPrism = performance.now();
-    prism.apply().then((applyResult) => {
-        const elapsed = (performance.now() - tPrism).toFixed(0);
-        const stats = applyResult?.stats;
-        const annotationCount = applyResult?.rule_annotations?.length ?? 0;
-        apiLogger.info(
-            `[Zephyr] prism.apply: +${elapsed}ms | patches=${stats?.succeeded ?? '?'}/${stats?.total ?? '?'} | annotations=${annotationCount}`
-        );
-        if (annotationCount === 0 && (stats?.total ?? 0) > 0) {
-            apiLogger.warn(
-                '[Zephyr] prism.apply succeeded but produced 0 rule annotations.',
-                'Check that .prism.yaml files use $prepend/$append DSL syntax.',
-            );
-        }
-    }).catch((err) => {
-        apiLogger.warn('[Zephyr] prism.apply failed (non-fatal, rules page may be empty):', err);
-    });
-
-    // 5c. Apply all enabled overrides (JS + Prism YAML).
-    // Runs independently of prism.apply so overrides are always applied on startup,
-    // even if Prism compilation fails.
-    invoke(COMMANDS.OVERRIDE.APPLY_ALL).then((logs) => {
-        const successCount = logs?.filter((/** @type {{success: boolean}} */ l) => l.success).length ?? 0;
-        const failCount = logs?.filter((/** @type {{success: boolean}} */ l) => !l.success).length ?? 0;
-        if (logs && logs.length > 0) {
-            apiLogger.info(`[Zephyr] override_apply_all: ${successCount} succeeded, ${failCount} failed (${logs.length} total)`);
-        }
-    }).catch((err) => {
-        apiLogger.warn('[Zephyr] override_apply_all failed (non-fatal):', err);
-    });
-  } catch (err) {
-    const message = err?.toString?.() || 'Core start failed';
-    apiLogger.error('Failed to start core', err);
-    sendOSNotification('Zephyr', message).catch(() => {});
-    alert(message);
-    return;
-  }
+  if (!(await startCoreAndConfigure())) return;
 
   // 6. Initialize all UI modules
   const tUI = performance.now();
@@ -335,6 +435,8 @@ async function initApp() {
     onProxies: () => { renderProxies(); },
     onAdvanced: () => { import('./ui/advanced.js').then(m => m.renderAdvancedSettings?.()).catch(() => {}); },
     onHome: () => { updateSysProxyUI(); },
+    onConsole: () => { activateConsole(); },
+    onLeaveConsole: () => { deactivateConsole(); },
     onRuleLibrary: () => { import('./ui/rule-library.js').then(m => m.initRuleLibraryPage()).catch(() => {}); },
     onConnections: () => { initConnectionsPage(); },
     onLogs: () => { import('./ui/logs.js').then(m => m.initLogsPage()).catch(() => {}); },
@@ -405,66 +507,66 @@ async function initApp() {
     apiLogger.warn('Initial sync failed', err);
   }
 
-  // 8b. Auto-check for updates on startup if enabled
-  setTimeout(async () => {
-    try {
-      const settings = await invoke(COMMANDS.GET_SETTINGS);
-      const lang = localStorage.getItem('lang') || 'en';
-      /** @type {Record<string, string>} */
-      const t = /** @type {Record<string, string>} */ (/** @type {any} */ (translations)[lang]);
-
-      let coreHasUpdate = false;
-      let clientHasUpdate = false;
-
-      // Check core update if auto_update is enabled
-      if (settings.auto_update) {
-        try {
-          const latest = await invoke(COMMANDS.GET_LATEST_VERSION);
-          const currentVersion = await invoke(COMMANDS.GET_CORE_VERSION);
-          if (latest.version !== currentVersion) {
-            coreHasUpdate = true;
-          }
-        } catch (e) {
-          apiLogger.warn('Auto core update check failed', e);
-        }
+  // 8b. Activate console home page (if enabled and still visible)
+  try {
+    if (appStore.get('homePageMode') === 'console') {
+      const consolePage = document.querySelector('[data-page="console"]');
+      const isConsoleVisible = consolePage && !consolePage.classList.contains('hidden');
+      // initConsoleHome() is idempotent (guarded by isInitialized).
+      initConsoleHome();
+      // Only activate if the console page is still visible - the user may
+      // have navigated to another page during the async startup steps.
+      if (isConsoleVisible) {
+        activateConsole();
       }
-
-      // Check client update if auto_update_client is enabled (skip in portable mode)
-      const isPortable = await invoke('get_portable_mode');
-      if (!isPortable && settings.auto_update_client) {
-        try {
-          const info = await invoke(COMMANDS.GET_LATEST_CLIENT_VERSION);
-          const currentVersion = await invoke(COMMANDS.GET_APP_VERSION);
-          if (info.version !== currentVersion) {
-            clientHasUpdate = true;
-          }
-        } catch (e) {
-          apiLogger.warn('Auto client update check failed', e);
-        }
-      }
-
-      // If both have updates, show special notification recommending Full version
-      if (coreHasUpdate && clientHasUpdate) {
-        showNotification(
-          t.bothUpdateAvailable || 'Both core and client have updates',
-          'warning',
-          t.recommendFullVersion || 'Recommend installing Full version'
-        );
-      }
-    } catch (e) {
-      apiLogger.warn('Auto update check failed', e);
     }
-  }, 5000);
+  } catch (err) {
+    apiLogger.warn('Failed to init console home', err);
+  }
+
+  // 8c. Auto-check for updates on startup if enabled
+  scheduleAutoUpdateCheck();
 
   // 9. Traffic WebSocket
   _trafficWsHandle = connectTraffic((/** @type {any} */ data) => {
-    updateTrafficData(data);
+    // Skip the minimal-home traffic pipeline when console mode is active -
+    // the console dashboard subscribes to TRAFFIC_UPDATE directly.
+    if (appStore.get('homePageMode') !== 'console') {
+      updateTrafficData(data);
+    }
+    Bus.emit(Events.TRAFFIC_UPDATE, data);
   });
 
   // 9b. Reconnect traffic stream when core restarts
-  const _unsubCoreRestarted = Bus.on(Events.CORE_RESTARTED, () => {
-    if (_trafficWsHandle) {
+  const _unsubCoreRestarted = Bus.on(Events.CORE_RESTARTED, (/** @type {{ handle?: any }} */ { handle } = {}) => {
+    // If forceReconnect() returned a new handle (fallback path), adopt it.
+    if (handle) {
+      _trafficWsHandle = handle;
+    } else if (_trafficWsHandle) {
       _trafficWsHandle.reconnect();
+    }
+  });
+
+  // 10b. Apply home page mode changes immediately when the user toggles
+  //      the setting, so the visible page switches without requiring a
+  //      manual navigation away and back.
+  const _unsubHomePageMode = Bus.on(Events.HOME_PAGE_MODE_CHANGED, (/** @type {{ mode?: string, previous?: string }} */ { mode } = {}) => {
+    if (!mode) return;
+    // Update the store first so navigateToInternal() sees the new mode
+    // and does not short-circuit on stale state.
+    appStore.set('homePageMode', mode);
+    // Only switch if the home or console page is currently visible.
+    const homePage = document.querySelector('[data-page="home"]');
+    const consolePage = document.querySelector('[data-page="console"]');
+    const isHomeVisible = homePage && !homePage.classList.contains('hidden');
+    const isConsoleVisible = consolePage && !consolePage.classList.contains('hidden');
+    if (!isHomeVisible && !isConsoleVisible) return;
+
+    if (mode === 'console') {
+      try { initConsoleHome(); } catch (err) { apiLogger.warn('Console init failed on mode switch', err); }
+      navigateTo('console');
+    } else {
+      navigateTo('home');
     }
   });
 
@@ -477,6 +579,9 @@ async function initApp() {
   });
   registerCleanup(() => {
     _unsubCoreRestarted();
+  });
+  registerCleanup(() => {
+    _unsubHomePageMode();
   });
   registerCleanup(() => {
     if (_trafficWsHandle) {

--- a/apps/desktop/src/modules/backend-events.js
+++ b/apps/desktop/src/modules/backend-events.js
@@ -9,6 +9,9 @@
 
 import { listen } from '../api.js';
 import { showNotification } from '../ui/notifications.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('backend-events');
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -24,8 +27,8 @@ let _prismEventUnlisten = null;
 /** @type {(() => void) | null} */
 let _backendEventUnlisten = null;
 
-/** @type {((entry: { type: string, message: string, timestamp: string, source?: string }) => void) | null} */
-let _onNewEvent = null;
+/** @type {Set<(entry: { type: string, message: string, timestamp: string, source?: string }) => void>} */
+const _eventSubscribers = new Set();
 
 // ── Internal Helpers ─────────────────────────────────────────────────────────
 
@@ -51,10 +54,13 @@ function _pushEvent(entry) {
     if (_extLogEvents.length > 500) {
         _extLogEvents = _extLogEvents.slice(-500);
     }
-    try {
-        _onNewEvent?.(entry);
-    } catch {
-        // Subscriber failure should not block event ingestion or toast handling
+    for (const cb of _eventSubscribers) {
+        try {
+            cb(entry);
+        } catch (e) {
+            // Subscriber failure should not block event ingestion or toast handling
+            logger.warn('Event subscriber threw', e);
+        }
     }
 }
 
@@ -223,18 +229,22 @@ function _handlePrismEvent(event) {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
- * Subscribe to new events. Called by logs page when it mounts.
+ * Subscribe to new events. Multiple subscribers can coexist.
+ * Returns an unsubscribe function for clean teardown.
  * @param {(entry: { type: string, message: string, timestamp: string, source?: string }) => void} callback
+ * @returns {() => void}
  */
 export function subscribeToEvents(callback) {
-    _onNewEvent = callback;
+    _eventSubscribers.add(callback);
+    return () => { _eventSubscribers.delete(callback); };
 }
 
 /**
- * Unsubscribe from new events. Called by logs page when it unmounts.
+ * Unsubscribe a specific callback from new events.
+ * @param {(entry: { type: string, message: string, timestamp: string, source?: string }) => void} callback
  */
-export function unsubscribeFromEvents() {
-    _onNewEvent = null;
+export function unsubscribeFromEvents(callback) {
+    _eventSubscribers.delete(callback);
 }
 
 /**

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -274,6 +274,19 @@ html.dark {
   --dialog-shadow-color: rgba(0, 0, 0, 0.55);
 }
 
+/* Clip the root element to the window's overlay radius, preventing
+   WebView2's rectangular dark edge from showing at the corners.
+   Reset to 0 when the window is maximized to avoid rounding the
+   OS rectangular frame. */
+html {
+  clip-path: inset(0 round var(--zephyr-radius-overlay, 24px));
+}
+html.is-maximized {
+  --zephyr-radius-overlay: 0px;
+
+  clip-path: none;
+}
+
 /* 隐藏数字输入框默认的上下箭头 */
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
@@ -1162,6 +1175,16 @@ button:focus-visible:not(:disabled, [disabled]),
 }
 
 /* ============================================
+   Proxies Page — Auto-fill grid
+   Columns are added/removed automatically based on
+   available width. Minimum card width 180px.
+   Unlimited max columns.
+   ============================================ */
+#proxies-list {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+}
+
+/* ============================================
    Logs Page Styles
    ============================================ */
 
@@ -1372,5 +1395,183 @@ html.dark #fullscreen-editor-output {
 /* Icon draw animation */
 @keyframes sr-draw {
     to { stroke-dashoffset: 0; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Console Dashboard (dz-* prefix — self-contained layout for the console home page)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.dz-content { flex: 1; min-width: 0; overflow-y: auto; overflow-x: hidden; padding: 16px 32px 32px; display: flex; flex-direction: column; gap: 20px; }
+
+/* ── Page header: title + view switch ── */
+.dz-header { display: flex; align-items: flex-end; justify-content: space-between; flex-shrink: 0; min-width: 0; }
+.dz-header h1 { font-size: 24px; font-weight: 300; color: var(--zephyr-text-primary); margin: 0; letter-spacing: -0.01em; }
+.dz-header .dz-sub { display: flex; align-items: center; gap: 8px; margin-top: 6px; font-size: 11px; color: var(--zephyr-text-muted); font-weight: 500; white-space: nowrap; }
+.dz-live-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--zephyr-color-success); box-shadow: 0 0 8px var(--zephyr-color-success); animation: dz-pulse 2s ease-in-out infinite; }
+@keyframes dz-pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+
+/* ── KPI indicator strip ── */
+.dz-kpis { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; flex-shrink: 0; min-width: 0; }
+.dz-kpi { padding: 14px 16px 12px; display: flex; flex-direction: column; gap: 6px; position: relative; overflow: hidden; transition: transform .21s ease-out; }
+.dz-kpi:hover { transform: translateY(-2px); }
+.dz-kpi-top { display: flex; align-items: center; justify-content: space-between; }
+.dz-kpi-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--zephyr-text-muted); display: flex; align-items: center; gap: 6px; }
+.dz-kpi-icon { width: 22px; height: 22px; border-radius: 7px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.dz-kpi-icon svg { width: 12px; height: 12px; }
+.dz-kpi-value { display: flex; align-items: baseline; gap: 4px; }
+.dz-kpi-value b { font-size: 24px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.03em; line-height: 1.1; }
+.dz-kpi-value span { font-size: 10px; font-weight: 600; color: var(--zephyr-text-muted); text-transform: uppercase; }
+.dz-kpi-foot { font-size: 10px; color: var(--zephyr-text-tertiary); font-weight: 500; display: flex; align-items: center; gap: 4px; white-space: nowrap; }
+.dz-spark { position: absolute; right: 0; bottom: 0; width: 72px; height: 28px; opacity: .55; pointer-events: none; }
+
+/* ── Main grid ── */
+.dz-grid-main { display: grid; grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr); gap: 12px; flex-shrink: 0; min-width: 0; }
+.dz-grid-main > .glass-card { min-width: 0; overflow: hidden; }
+.dz-card-pad { padding: 18px 20px; }
+.dz-card-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
+.dz-card-title { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--zephyr-text-muted); }
+.dz-card-title .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); animation: dz-pulse 2s ease-in-out infinite; }
+.dz-legend { display: flex; align-items: center; gap: 14px; }
+.dz-legend-item { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--zephyr-text-muted); text-transform: uppercase; letter-spacing: .05em; }
+.dz-legend-swatch { width: 8px; height: 8px; border-radius: 3px; }
+.dz-chart-wrap { height: 216px; position: relative; overflow: hidden; }
+.dz-chart-wrap canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
+.dz-chart-meta { display: flex; flex-wrap: wrap; gap: 16px 24px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--zephyr-border-subtle); overflow: hidden; }
+.dz-chart-meta div { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.dz-chart-meta span, .dz-chart-meta b { white-space: nowrap; }
+.dz-chart-meta span { font-size: 10px; color: var(--zephyr-text-tertiary); text-transform: uppercase; letter-spacing: .06em; font-weight: 600; }
+.dz-chart-meta b { font-size: 13px; font-weight: 600; color: var(--zephyr-text-secondary); font-variant-numeric: tabular-nums; }
+
+/* Sidebar card stack */
+.dz-side { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+
+/* Current node card */
+.dz-node-name-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.dz-node-name { font-size: 15px; font-weight: 600; color: var(--zephyr-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dz-node-sub { font-size: 11px; color: var(--zephyr-text-muted); margin-top: 3px; display: flex; align-items: center; gap: 6px; }
+.dz-node-latency { display: flex; align-items: center; gap: 10px; margin-top: 14px; }
+.dz-latency-num { font-size: 28px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+.dz-latency-num small { font-size: 11px; color: var(--zephyr-text-muted); font-weight: 600; margin-left: 2px; }
+.dz-test-btn { margin-left: auto; }
+
+/* Node card */
+.dz-node-wrap { position: relative; }
+.dz-node-sub span { cursor: copy; transition: color .21s ease-out; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.dz-node-sub span:hover { color: var(--color-accent); }
+.dz-switch-node-btn { display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: var(--zephyr-radius-full); border: 1px solid var(--zephyr-border-subtle); background: var(--zephyr-bg-muted); color: var(--zephyr-text-secondary); font-size: 10px; font-weight: 600; cursor: pointer; transition: all .21s ease-out; white-space: nowrap; }
+.dz-switch-node-btn:hover, .dz-switch-node-btn.open { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 25%, transparent); background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+.dz-switch-node-btn svg { width: 10px; height: 10px; transition: transform .21s ease-out; }
+.dz-switch-node-btn.open svg { transform: rotate(180deg); }
+
+/* Node picker panel */
+.dz-node-picker { position: absolute; top: calc(100% + 8px); left: 0; right: 0; z-index: 40; display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: var(--zephyr-radius-md); background: var(--zephyr-bg-elevated); border: 1px solid var(--zephyr-border-default); box-shadow: var(--zephyr-shadow-dialog); animation: dz-pop .28s cubic-bezier(0.16,1,0.3,1); }
+html:not(.dark) .dz-node-picker { background: rgba(255,255,255,.97); }
+@keyframes dz-pop { from { opacity: 0; transform: translateY(-6px) scale(.98); } to { opacity: 1; transform: none; } }
+.dz-picker-subs { display: flex; flex-wrap: wrap; gap: 6px; }
+.dz-picker-sub { padding: 5px 12px; border-radius: var(--zephyr-radius-full); font-size: 10.5px; font-weight: 600; color: var(--zephyr-text-secondary); background: var(--zephyr-bg-muted); border: 1px solid var(--zephyr-border-subtle); cursor: pointer; transition: all .21s ease-out; white-space: nowrap; }
+.dz-picker-sub.active { color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 12%, transparent); border-color: color-mix(in srgb, var(--color-accent) 25%, transparent); }
+.dz-picker-list { display: flex; flex-direction: column; max-height: 216px; overflow-y: auto; }
+.dz-picker-node { display: flex; align-items: center; gap: 10px; padding: 8px; border-radius: var(--zephyr-radius-control); cursor: pointer; transition: background .15s; }
+.dz-picker-node:hover { background: var(--zephyr-bg-subtle); }
+.dz-picker-node.active { background: color-mix(in srgb, var(--color-accent) 8%, transparent); }
+.dz-picker-node-main { flex: 1; min-width: 0; }
+.dz-picker-node-name { font-size: 12px; font-weight: 600; color: var(--zephyr-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dz-picker-node-meta { font-size: 10px; color: var(--zephyr-text-tertiary); font-family: var(--font-mono); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dz-picker-check { width: 14px; height: 14px; color: var(--color-accent); flex-shrink: 0; visibility: hidden; }
+.dz-picker-node.active .dz-picker-check { visibility: visible; }
+.dz-picker-sub-count { opacity: .55; font-weight: 500; margin-left: 2px; }
+
+/* Connection sort button */
+.dz-sort-btn { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; color: var(--zephyr-text-tertiary); font-weight: 600; background: none; border: none; cursor: pointer; padding: 3px 8px; border-radius: 6px; transition: all .21s ease-out; white-space: nowrap; }
+.dz-sort-btn:hover { color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 8%, transparent); }
+.dz-sort-btn svg { width: 10px; height: 10px; }
+
+/* Connection chain colors */
+.dz-chain-direct { color: var(--zephyr-color-success); }
+.dz-chain-proxy { color: var(--color-accent); }
+
+/* Keyboard focus */
+.dz-mode-seg button:focus-visible,
+.dz-sort-btn:focus-visible, .dz-mini-btn:focus-visible,
+.dz-switch-node-btn:focus-visible, .dz-picker-sub:focus-visible,
+.dz-picker-node:focus-visible {
+    outline: 2px solid var(--color-accent); outline-offset: 1px;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .dz-live-dot, .dz-card-title .dot, .dz-progress-fill::after { animation: none !important; }
+    .dz-node-picker { animation: none; }
+}
+
+/* Quick controls card */
+.dz-quick-rows { display: flex; flex-direction: column; gap: 10px; margin-top: 12px; }
+.dz-quick-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 10px; border-radius: var(--zephyr-radius-md); background: var(--zephyr-bg-subtle); border: 1px solid var(--zephyr-border-subtle); }
+.dz-quick-row-label { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--zephyr-text-secondary); }
+.dz-quick-row-label svg { width: 14px; height: 14px; color: var(--zephyr-text-muted); }
+.dz-mode-seg { position: relative; display: grid; grid-template-columns: repeat(3, 1fr); padding: 4px; background: var(--zephyr-bg-muted); border: 1px solid var(--zephyr-border-subtle); border-radius: var(--radius-lg); height: 36px; width: 100%; margin-top: 12px; }
+.dz-mode-slider { position: absolute; top: 4px; bottom: 4px; left: 4px; width: calc((100% - 8px)/3); border-radius: var(--radius-lg); box-shadow: var(--zephyr-shadow-sm); border: 1px solid var(--zephyr-border-default); transition: transform .3s cubic-bezier(0.16,1,0.3,1); }
+html.dark .dz-mode-slider { background: rgba(255,255,255,.09); }
+html:not(.dark) .dz-mode-slider { background: #fff; }
+.dz-mode-seg button { position: relative; z-index: 1; font-size: 10px; font-weight: 700; letter-spacing: .04em; color: var(--zephyr-text-secondary); background: none; border: none; cursor: pointer; transition: color .21s; white-space: nowrap; overflow: hidden; }
+.dz-mode-seg button.active { color: var(--color-accent); }
+
+/* ── Bottom three-column grid ── */
+.dz-grid-bottom { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr); gap: 12px; flex: 1; min-height: 230px; min-width: 0; }
+.dz-grid-bottom > .glass-card { min-width: 0; overflow: hidden; }
+
+/* Active connections */
+.dz-conn-list { display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; min-height: 0; min-width: 0; margin: 0 -6px; padding: 0 6px; }
+.dz-conn-row { display: flex; align-items: center; gap: 10px; padding: 8px 8px; border-radius: var(--zephyr-radius-control); transition: background .15s; min-width: 0; }
+.dz-conn-row:hover { background: var(--zephyr-bg-subtle); }
+.dz-conn-proc { width: 26px; height: 26px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 800; color: #fff; flex-shrink: 0; letter-spacing: 0; }
+.dz-conn-info { flex: 1; min-width: 0; }
+.dz-conn-host { font-size: 12px; font-weight: 600; color: var(--zephyr-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dz-conn-chain { font-size: 10px; color: var(--zephyr-text-tertiary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: var(--font-mono); margin-top: 1px; }
+.dz-conn-speed { font-size: 11px; font-weight: 700; color: var(--zephyr-text-secondary); font-variant-numeric: tabular-nums; text-align: right; flex-shrink: 0; }
+.dz-conn-speed small { display: block; font-size: 9px; color: var(--zephyr-text-tertiary); font-weight: 500; }
+
+/* Subscription traffic */
+.dz-sub-used { display: flex; align-items: baseline; gap: 6px; margin-top: 2px; }
+.dz-sub-used b { font-size: 26px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+.dz-sub-used span { font-size: 11px; color: var(--zephyr-text-muted); font-weight: 500; }
+.dz-progress { height: 6px; border-radius: 3px; background: var(--zephyr-bg-muted); overflow: hidden; margin-top: 14px; }
+.dz-progress-fill { height: 100%; width: 65%; border-radius: 3px; background: linear-gradient(90deg, var(--color-accent), rgba(56,189,248,.85)); position: relative; }
+.dz-progress-fill::after { content: ''; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, rgba(255,255,255,.35), transparent); animation: dz-shimmer 2.6s ease-in-out infinite; }
+@keyframes dz-shimmer { 0% { transform: translateX(-100%); } 60%,100% { transform: translateX(100%); } }
+.dz-sub-rows { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.dz-sub-row { display: flex; justify-content: space-between; align-items: center; font-size: 11px; min-width: 0; }
+.dz-sub-row span { color: var(--zephyr-text-tertiary); font-weight: 500; flex-shrink: 0; white-space: nowrap; }
+.dz-sub-row b { color: var(--zephyr-text-secondary); font-weight: 600; font-variant-numeric: tabular-nums; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; text-align: right; }
+.dz-sub-actions { display: flex; gap: 8px; margin-top: 16px; }
+.dz-mini-btn { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 6px 0; border-radius: var(--zephyr-radius-md); font-size: 11px; font-weight: 600; cursor: pointer; transition: all .21s ease-out; border: 1px solid color-mix(in srgb, var(--color-accent) 12%, transparent); background: color-mix(in srgb, var(--color-accent) 8%, transparent); color: var(--zephyr-text-primary); white-space: nowrap; }
+.dz-mini-btn:hover { background: color-mix(in srgb, var(--color-accent) 15%, transparent); }
+.dz-mini-btn.accent { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 25%, transparent); background: color-mix(in srgb, var(--color-accent) 15%, transparent); }
+.dz-mini-btn svg { width: 12px; height: 12px; flex-shrink: 0; }
+
+/* Log stream */
+.dz-log-list { display: flex; flex-direction: column; overflow-y: auto; overflow-x: auto; min-height: 0; min-width: 0; font-family: var(--font-mono); }
+.dz-log-line { display: flex; align-items: baseline; gap: 8px; padding: 5px 4px; border-bottom: 1px solid var(--zephyr-border-subtle); font-size: 10.5px; line-height: 1.5; min-width: max-content; }
+.dz-log-line:last-child { border-bottom: none; }
+.dz-log-time { color: var(--zephyr-text-tertiary); flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.dz-log-level { flex-shrink: 0; font-weight: 800; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; padding: 1px 5px; border-radius: 4px; }
+.dz-log-level.info { color: var(--zephyr-color-info); background: color-mix(in srgb, var(--zephyr-color-info) 12%, transparent); }
+.dz-log-level.warn { color: var(--zephyr-color-warning); background: color-mix(in srgb, var(--zephyr-color-warning) 12%, transparent); }
+.dz-log-level.error { color: var(--zephyr-color-danger); background: color-mix(in srgb, var(--zephyr-color-danger) 12%, transparent); }
+.dz-log-level.debug { color: var(--zephyr-text-muted); background: var(--zephyr-bg-muted); }
+.dz-log-msg { color: var(--zephyr-text-secondary); white-space: nowrap; }
+
+
+.dz-hidden { display: none !important; }
+
+/* Responsive - switch to single-column on narrow viewports */
+@media (max-width: 1080px) {
+    .dz-kpis { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    .dz-grid-main, .dz-grid-bottom { grid-template-columns: minmax(0, 1fr); }
+    /* Single-column: let sections take natural height, cap inner lists */
+    .dz-grid-main { flex-shrink: 1; }
+    .dz-grid-bottom { flex: 0 0 auto; min-height: 0; }
+    .dz-conn-list { max-height: 200px; }
+    .dz-log-list { max-height: 200px; }
 }
 

--- a/apps/desktop/src/ui/advanced.js
+++ b/apps/desktop/src/ui/advanced.js
@@ -161,25 +161,25 @@ async function handleConfigUpdate(path, value) {
         if (!persisted) {
             const { translations, currentLang } = await import('../i18n.js').then(m => m);
             const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-            const t = /** @type {Record<string, string>} */(translations[langKey]);
-            showNotification(`${t.errorPrefix || 'Error'}: Config validation failed, changes not persisted`, 'error');
+            const t = /** @type {Record<string, unknown>} */(translations[langKey]);
+            showNotification(`${String(t.errorPrefix || 'Error')}: Config validation failed, changes not persisted`, 'error');
             renderAdvancedSettings();
             return;
         }
 
         const { translations, currentLang } = await import('../i18n.js').then(m => m);
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey]);
-        showNotification(t.configSuccess || 'Configuration saved', 'success');
+        const t = /** @type {Record<string, unknown>} */(translations[langKey]);
+        showNotification(String(t.configSuccess || 'Configuration saved'), 'success');
 
         import('./proxies.js').then(m => m.syncCoreConfig());
     } catch (err) {
         advancedLogger.error('Failed to update config', err);
         const { translations, currentLang } = await import('../i18n.js').then(m => m);
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey]);
+        const t = /** @type {Record<string, unknown>} */(translations[langKey]);
         const errorObj = toError(err);
-        showNotification(`${t.errorPrefix || 'Error'}: ${errorObj.message}`, 'error');
+        showNotification(`${String(t.errorPrefix || 'Error')}: ${errorObj.message}`, 'error');
         renderAdvancedSettings();
     }
 }

--- a/apps/desktop/src/ui/console-home.js
+++ b/apps/desktop/src/ui/console-home.js
@@ -1,0 +1,1804 @@
+// @ts-check
+/**
+ * @module ui/console-home
+ *
+ * Console Dashboard Home Page — a detailed, information-dense alternative
+ * to the minimal home page.  Ported from console-draft.html and wired to
+ * real backend data (traffic WS, connections polling, proxy state, logs).
+ *
+ * Layout:
+ *  ┌──────────────────────────────────────────────────────────────────┐
+ *  │ Header (title + uptime + view-switch)                            │
+ *  ├──────────────────────────────────────────────────────────────────┤
+ *  │ KPI strip (5 cards: DL / UL / total / conns / latency)           │
+ *  ├───────────────────────────────┬──────────────────────────────────┤
+ *  │ Real-time traffic chart       │ Node card + Quick controls       │
+ *  ├──────────────┬────────────────┴──────┬───────────────────────────┤
+ *  │ Connections  │ Subscription usage    │ Recent logs               │
+ *  └──────────────┴───────────────────────┴───────────────────────────┘
+ *
+ * A "minimal" sub-view (condensed homepage) is also available via the
+ * view-switch in the header — mirrors the original homepage layout.
+ */
+
+import { getConnections, testProxy, switchProxy, getConfig, invoke, closeAllConnections } from '../api.js';
+import { appStore } from './state.js';
+
+/** Map app language code to BCP-47 locale tag for Intl APIs. */
+const LOCALE_TAGS = { en: 'en', zh: 'zh-CN', ja: 'ja-JP', ko: 'ko-KR' };
+
+/** Resolve the current app language to a BCP-47 locale tag. @returns {string} */
+function uiLocale() {
+    const lang = /** @type {keyof typeof LOCALE_TAGS} */ (appStore.get('currentLang'));
+    return LOCALE_TAGS[lang] || 'en';
+}
+import { Bus, Events } from './events.js';
+import { bind } from './bind.js';
+
+import { subscribeToEvents, unsubscribeFromEvents, getExtLogEvents } from '../modules/backend-events.js';
+import { registerCleanup } from '../utils/cleanup-registry.js';
+import { createLogger } from '../utils/logger.js';
+import { showNotification } from './notifications.js';
+import { t, applyTranslations } from '../i18n.js';
+import { COMMANDS } from '@zephyr/shared';
+import { syncCoreConfig } from './proxies.js';
+import { switchToConfig } from './lifecycle.js';
+import { fetchProxyGroups } from './proxy-groups.js';
+import { saveProxySelection } from './proxy-memory.js';
+import { invalidateProxiesCache, invalidateSettingsCache, invalidateConfigsCache, getSettingsCached } from './cache.js';
+import { getRunConfigCached, invalidateRunConfigCache } from './run-config-cache.js';
+import { getSubscriptionUserAgent } from './settings.js';
+import { setSysProxyEnabled } from './sysproxy.js';
+
+const consoleLogger = createLogger('Console', 'warn');
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** @param {string} id */
+const $ = (id) => document.getElementById(id);
+
+/**
+ * Format bytes/s → { val, unit } for display.
+ * @param {number} bytesPerSec
+ * @returns {{ val: string, unit: string }}
+ */
+function fmtSpeed(bytesPerSec) {
+    if (!bytesPerSec || bytesPerSec < 1) return { val: '0', unit: 'KB/s' };
+    if (bytesPerSec >= 1048576) return { val: (bytesPerSec / 1048576).toFixed(2), unit: 'MB/s' };
+    return { val: Math.round(bytesPerSec / 1024).toString(), unit: 'KB/s' };
+}
+
+/**
+ * Format bytes → human-readable string.
+ * @param {number} bytes
+ * @returns {string}
+ */
+function fmtBytes(bytes) {
+    if (!bytes || bytes < 1) return '0 B';
+    if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(2) + ' GB';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    return Math.round(bytes / 1024) + ' KB';
+}
+
+/** @param {string} name */
+function cssVar(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+/** @param {number} v */
+function latBadge(v) {
+    return v > 0 && v < 80 ? ['latency-badge--fast', t('consoleLatencyExcellent')]
+        : v > 0 && v < 160 ? ['latency-badge--medium', t('consoleLatencyFair')]
+        : ['latency-badge--slow', t('consoleLatencyHigh')];
+}
+
+// ── State ────────────────────────────────────────────────────────────────
+
+/** @type {Array<{ up: number, down: number, time: number }>} */
+let trafficHistory = [];
+/** @type {{ down: number, up: number, downPeak: number, upPeak: number, sessDown: number, sessUp: number, totalDown: number, totalUp: number, conns: number, latency: number }} */
+const state = { down: 0, up: 0, downPeak: 0, upPeak: 0, sessDown: 0, sessUp: 0, totalDown: 0, totalUp: 0, conns: 0, latency: 0 };
+
+/** @type {ReturnType<typeof setInterval> | null} */
+let connPollTimer = null;
+/** @type {ReturnType<typeof setInterval> | null} */
+let uptimeTimer = null;
+/** @type {ReturnType<typeof setTimeout> | null} */
+let nodeRetryTimer = null;
+/**
+ * Core uptime in seconds, fetched from the backend (real mihomo spawn time).
+ * Null until the first successful fetch.
+ * @type {number | null}
+ */
+/** @type {number | null | undefined} undefined=not-fetched, null=core-stopped, number=running uptime in seconds. */
+let coreUptimeSec;
+let isInitialized = false;
+let isActive = false;
+/** @type {number | null} Timestamp (ms) of the last traffic sample for lifetime totals (never reset). */
+let lastTrafficTsMsTotal = null;
+/** @type {number | null} Timestamp (ms) of the last traffic sample for session totals (reset on activate). */
+let lastTrafficTsMsSession = null;
+/** @type {number} Counter for periodic uptime re-sync. */
+let uptimeSyncCounter = 0;
+
+/** @type {Function[]} */
+const _cleanups = [];
+/** @type {Function[]} Unregister functions for global registry entries. */
+const _globalUnregs = [];
+
+// ── Canvas Chart (ported from draft) ─────────────────────────────────────
+
+/**
+ * @param {HTMLCanvasElement} canvas
+ * @returns {{ ctx: CanvasRenderingContext2D, w: number, h: number }}
+ */
+function setupCanvas(canvas) {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.round(rect.width * dpr));
+    canvas.height = Math.max(1, Math.round(rect.height * dpr));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return { ctx: /** @type {any} */ (null), w: 0, h: 0 };
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return { ctx, w: rect.width, h: rect.height };
+}
+
+/**
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} w
+ * @param {number} h
+ * @param {Array<{ up: number, down: number }>} data
+ * @param {'up' | 'down'} key
+ * @param {number} max
+ * @param {string} rgb
+ * @param {string} fillTop
+ */
+function drawSeries(ctx, w, h, data, key, max, rgb, fillTop) {
+    const n = data.length;
+    if (n < 2) return;
+    const step = w / (n - 1);
+    ctx.beginPath();
+    ctx.moveTo(0, h);
+    for (let i = 0; i < n; i++) {
+        const x = i * step;
+        const y = h - (data[i][key] / max) * (h - 8);
+        if (i === 0) ctx.lineTo(x, y);
+        else {
+            const px = (i - 1) * step;
+            const py = h - (data[i - 1][key] / max) * (h - 8);
+            ctx.quadraticCurveTo((px + x) / 2, py, x, (py + y) / 2);
+        }
+    }
+    ctx.lineTo(w, h);
+    ctx.closePath();
+    const g = ctx.createLinearGradient(0, 0, 0, h);
+    g.addColorStop(0, fillTop);
+    g.addColorStop(1, `rgba(${rgb},0)`);
+    ctx.fillStyle = g;
+    ctx.fill();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+        const x = i * step;
+        const y = h - (data[i][key] / max) * (h - 8);
+        if (i === 0) ctx.moveTo(x, y);
+        else {
+            const px = (i - 1) * step;
+            const py = h - (data[i - 1][key] / max) * (h - 8);
+            ctx.quadraticCurveTo((px + x) / 2, py, x, (py + y) / 2);
+        }
+    }
+    ctx.strokeStyle = `rgba(${rgb},0.9)`;
+    ctx.lineWidth = 1.6;
+    ctx.stroke();
+}
+
+/** @param {HTMLElement | null} canvas */
+function drawChart(canvas) {
+    if (!canvas || !canvas.isConnected) return;
+    const { ctx, w, h } = setupCanvas(/** @type {HTMLCanvasElement} */ (canvas));
+    if (!ctx || w < 10 || h < 10) return;
+    const max = Math.max(1024, ...trafficHistory.flatMap((p) => [p.down, p.up])) * 1.15;
+    ctx.strokeStyle = cssVar('--zephyr-border-subtle') || 'rgba(128,128,128,.1)';
+    ctx.lineWidth = 1;
+    for (let i = 1; i <= 3; i++) {
+        const y = (h / 4) * i;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(w, y); ctx.stroke();
+    }
+    // Fixed palette — does NOT follow theme accent (speed colors must be stable)
+    drawSeries(ctx, w, h, trafficHistory, 'up', max, '56,189,248', 'rgba(56,189,248,0.14)');
+    drawSeries(ctx, w, h, trafficHistory, 'down', max, '175,82,222', 'rgba(175,82,222,0.20)');
+}
+
+/** @param {HTMLElement | null} canvas @param {'up' | 'down'} key @param {string} rgb */
+function drawSpark(canvas, key, rgb) {
+    if (!canvas) return;
+    const { ctx, w, h } = setupCanvas(/** @type {HTMLCanvasElement} */ (canvas));
+    if (!ctx || w < 4 || h < 4) return;
+    const data = trafficHistory.slice(-24);
+    if (data.length < 2) return;
+    const max = Math.max(...data.map((p) => p[key])) * 1.1 || 1;
+    ctx.beginPath();
+    data.forEach((p, i) => {
+        const x = (i / (data.length - 1)) * w;
+        const y = h - (p[key] / max) * (h - 3);
+        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = `rgba(${rgb},0.85)`;
+    ctx.lineWidth = 1.4;
+    ctx.stroke();
+}
+
+// ── Number rendering ─────────────────────────────────────────────────────
+
+/**
+ * Format a speed value into a display string (value + unit).
+ * @param {number} bps - bytes per second
+ * @returns {string}
+ */
+function fmtSpeedStr(bps) {
+    const s = fmtSpeed(bps);
+    return `${s.val} ${s.unit}`;
+}
+
+/** @param {string} id @param {string} value */
+function setText(id, value) {
+    const el = $(id);
+    if (el) el.textContent = value;
+}
+
+function renderSpeeds() {
+    const d = fmtSpeed(state.down), u = fmtSpeed(state.up);
+    setText('dz-down-val', d.val);
+    setText('dz-down-unit', d.unit);
+    setText('dz-up-val', u.val);
+    setText('dz-up-unit', u.unit);
+}
+
+function renderPeaks() {
+    // Always write peak values so a reset (CORE_RESTARTED) clears old display
+    setText('dz-down-peak', state.downPeak > 0 ? fmtSpeedStr(state.downPeak) : '-');
+    setText('dz-up-peak', state.upPeak > 0 ? fmtSpeedStr(state.upPeak) : '-');
+    const avg = trafficHistory.length > 0
+        ? trafficHistory.reduce((s, p) => s + p.down, 0) / trafficHistory.length
+        : 0;
+    setText('dz-avg-down', fmtSpeedStr(avg) + ' ↓');
+}
+
+function renderTotals() {
+    // KPI: Lifetime traffic (accumulated since core start)
+    setText('dz-total-val', ((state.totalDown + state.totalUp) / 1073741824).toFixed(2));
+    setText('dz-total-down', (state.totalDown / 1073741824).toFixed(2));
+    setText('dz-total-up', (state.totalUp / 1073741824).toFixed(2));
+}
+
+function renderSessionTotals() {
+    // Chart meta: Session traffic
+    setText('dz-sess-down', fmtBytes(state.sessDown));
+    setText('dz-sess-up', fmtBytes(state.sessUp));
+}
+
+function renderNumbers() {
+    renderSpeeds();
+    renderPeaks();
+    renderTotals();
+    renderSessionTotals();
+}
+
+function renderUptime() {
+    if (coreUptimeSec === undefined) {
+        // Not yet fetched — show neutral placeholder until first successful response
+        const el0 = $('dz-uptime');
+        if (el0) el0.textContent = '—';
+        return;
+    }
+    if (coreUptimeSec === null) {
+        // Core is not running
+        const el0 = $('dz-uptime');
+        if (el0) el0.textContent = t('consoleUptimeStopped');
+        return;
+    }
+    const s = coreUptimeSec;
+    const days = Math.floor(s / 86400);
+    const hh = String(Math.floor((s % 86400) / 3600)).padStart(2, '0');
+    const mm = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+    const ss = String(s % 60).padStart(2, '0');
+    const el = $('dz-uptime');
+    if (el) el.textContent = t('consoleUptimeFmt', { days: String(days), time: `${hh}:${mm}:${ss}` });
+}
+
+/** Advance the local uptime counter by one second and re-render. */
+function tickUptime() {
+    // Re-sync with backend every 30 ticks to detect core stop/crash.
+    // This runs even when coreUptimeSec is null so we can detect recovery.
+    if (++uptimeSyncCounter >= 30) {
+        uptimeSyncCounter = 0;
+        fetchCoreUptime();
+    }
+    if (coreUptimeSec === null || coreUptimeSec === undefined) return;
+    coreUptimeSec++;
+    renderUptime();
+}
+
+function renderLatency(/** @type {number} */ v) {
+    state.latency = v;
+    const latEl = $('dz-lat-val');
+    if (latEl) latEl.textContent = v > 0 ? String(v) : '—';
+    const nodeLat = $('dz-node-lat');
+    if (nodeLat) nodeLat.textContent = v > 0 ? String(v) : '—';
+    if (v <= 0) {
+        // Clear badges on failure so stale class/text don't persist
+        for (const id of ['dz-lat-badge', 'dz-node-lat-badge']) {
+            const b = $(id);
+            if (b) { b.className = 'latency-badge'; b.textContent = '—'; }
+        }
+        return;
+    }
+    const [cls, txt] = latBadge(v);
+    for (const id of ['dz-lat-badge', 'dz-node-lat-badge']) {
+        const b = $(id);
+        if (b) {
+            b.className = 'latency-badge ' + cls;
+            b.textContent = txt;
+        }
+    }
+}
+
+// ── Connections ──────────────────────────────────────────────────────────
+
+/**
+ * @typedef {{ proc: string, host: string, chain: string, tcp: boolean, speed: number, total: number, color: string }} ConnRow
+ */
+
+/** Connection sort modes
+ * @type {Array<{ key: string, labelKey: string, cmp: (a: ConnRow, b: ConnRow) => number }>}
+ */
+const SORT_MODES = [
+    { key: 'speed', labelKey: 'consoleSortBySpeed', cmp: (a, b) => b.speed - a.speed },
+    { key: 'total', labelKey: 'consoleSortByTraffic', cmp: (a, b) => b.total - a.total },
+    { key: 'proc',  labelKey: 'consoleSortByProcess', cmp: (a, b) => a.proc.localeCompare(b.proc) },
+];
+let sortIdx = 0;
+
+/**
+ * Previous snapshot of per-connection upload/download for speed calculation.
+ * Keyed by connection ID → { up, down, ts }.
+ * @type {Map<string, { up: number, down: number, ts: number }>}
+ */
+let prevConnStats = new Map();
+
+/** @param {Array<any>} rawConns */
+function processConnections(rawConns) {
+    const now = Date.now();
+    const rows = rawConns.map((c) => {
+        const md = c.metadata || {};
+        const proc = md.process || md.processPath || t('unknown');
+        const host = md.host ? md.host + ':' + (md.destinationPort || '') : (md.destinationIP || t('unknown'));
+        const chain = (c.chains && c.chains.length > 0) ? c.chains.join(' → ') : 'DIRECT';
+        const upload = c.upload || 0;
+        const download = c.download || 0;
+        const id = /** @type {string} */ (c.id || '');
+
+        // Compute actual speed (bytes/sec) from delta against previous snapshot
+        let speed = 0;
+        const prev = prevConnStats.get(id);
+        if (prev) {
+            const dt = (now - prev.ts) / 1000;
+            if (dt > 0) {
+                const dUp = Math.max(0, upload - prev.up);
+                const dDown = Math.max(0, download - prev.down);
+                speed = (dUp + dDown) / dt;
+            }
+        }
+
+        return {
+            proc: proc,
+            host: host,
+            chain: chain,
+            tcp: (md.network || 'tcp').toLowerCase() === 'tcp',
+            speed: speed,
+            total: (upload + download) / 1024 / 1024, // MB
+            color: procColor(proc),
+        };
+    });
+
+    // Save snapshot for next poll
+    const next = new Map();
+    for (const c of rawConns) {
+        const id = /** @type {string} */ (c.id || '');
+        if (id) next.set(id, { up: c.upload || 0, down: c.download || 0, ts: now });
+    }
+    prevConnStats = next;
+
+    const total = rawConns.length;
+    const tcpTotal = rawConns.filter((c) => ((c.metadata?.network || 'tcp').toLowerCase() === 'tcp')).length;
+    return { rows, total, tcpTotal };
+}
+
+/** Generate a stable color from a process name. @param {string} name */
+function procColor(name) {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    const hue = Math.abs(hash) % 360;
+    return `hsl(${hue}, 65%, 55%)`;
+}
+
+function renderConns(/** @type {ReturnType<typeof processConnections>} */ data) {
+    const conns = data.rows;
+    conns.sort(SORT_MODES[sortIdx].cmp);
+    const el = $('dz-conn-list');
+    if (!el) return;
+    el.replaceChildren();
+    const top = conns.slice(0, 5);
+    for (const c of top) {
+        const s = fmtSpeed(c.speed);
+        const row = document.createElement('div');
+        row.className = 'dz-conn-row';
+        const procEl = document.createElement('span');
+        procEl.className = 'dz-conn-proc';
+        procEl.style.background = c.color;
+        procEl.textContent = c.proc.slice(0, 1).toUpperCase();
+        const info = document.createElement('div');
+        info.className = 'dz-conn-info';
+        const hostEl = document.createElement('div');
+        hostEl.className = 'dz-conn-host';
+        hostEl.textContent = c.host;
+        const chainEl = document.createElement('div');
+        chainEl.className = 'dz-conn-chain';
+        chainEl.textContent = `${c.proc} · ${c.tcp ? 'TCP' : 'UDP'} · `;
+        const chainSpan = document.createElement('span');
+        chainSpan.className = c.chain === 'DIRECT' ? 'dz-chain-direct' : 'dz-chain-proxy';
+        chainSpan.textContent = c.chain;
+        chainEl.appendChild(chainSpan);
+        info.append(hostEl, chainEl);
+        const speedEl = document.createElement('div');
+        speedEl.className = 'dz-conn-speed';
+        speedEl.textContent = `${s.val} ${s.unit}`;
+        const totalSmall = document.createElement('small');
+        totalSmall.textContent = c.total.toFixed(1) + ' MB';
+        speedEl.appendChild(totalSmall);
+        row.append(procEl, info, speedEl);
+        el.appendChild(row);
+    }
+    state.conns = data.total;
+    const connVal = $('dz-conn-val');
+    if (connVal) connVal.textContent = String(data.total);
+    const tcpEl = $('dz-conn-tcp');
+    if (tcpEl) tcpEl.textContent = String(data.tcpTotal);
+    const udpEl = $('dz-conn-udp');
+    if (udpEl) udpEl.textContent = String(data.total - data.tcpTotal);
+
+}
+
+/** @type {boolean} In-flight guard for pollConnections. */
+let _pollInFlight = false;
+
+async function pollConnections() {
+    if (!isActive || _pollInFlight) return;
+    _pollInFlight = true;
+    try {
+        const data = await getConnections();
+        const conns = processConnections(data.connections || []);
+        renderConns(conns);
+    } catch (e) {
+        consoleLogger.warn('Failed to poll connections', e);
+    } finally {
+        _pollInFlight = false;
+    }
+}
+
+// ── Node card ────────────────────────────────────────────────────────────
+
+/** @type {Array<{ name: string, type: string, host: string, lat: number }>} */
+let pickerNodes = [];
+let activeNodeIdx = 0;
+/** @type {Array<{ name: string, file: string, active: boolean }>} */
+let subConfigs = [];
+
+/**
+ * Retry delays for refreshNodeData (ms). Handles transient failures:
+ * mihomo not ready, proxy-providers still downloading, network timing.
+ * Stops retrying once data is successfully rendered.
+ */
+const NODE_RETRY_DELAYS = [800, 2000, 4000];
+let nodeRetryCount = 0;
+/** @type {boolean} In-flight guard to prevent concurrent refreshNodeData executions. */
+let _refreshInFlight = false;
+/** @type {boolean} Whether a refresh was requested during an in-flight call. */
+let _refreshQueued = false;
+/** @type {boolean} Whether the queued request needs forceInvalidate. */
+let _refreshQueuedForce = false;
+
+/**
+ * Fetch subscription configs for picker tabs.
+ * @returns {Promise<Array<{ name: string, file: string, active: boolean }>>}
+ */
+async function loadSubConfigs() {
+    try {
+        const settings = await getSettingsCached();
+        const currentConfig = settings?.last_config || '';
+        const allConfigs = await invoke(COMMANDS.LIST_CONFIGS);
+        return (allConfigs || [])
+            .filter((/** @type {any} */ c) => c.url_display)
+            .map((/** @type {any} */ c) => ({
+                name: (c.name || '').replace(/\.(yaml|yml)$/i, ''),
+                file: c.name,
+                active: c.name === currentConfig,
+            }));
+    } catch (subErr) {
+        consoleLogger.warn('Failed to fetch subscription configs', subErr);
+        return [];
+    }
+}
+
+/**
+ * Build a server/port lookup from run_config.yaml's `proxies:` array.
+ * @param {any} runConfig
+ * @returns {Record<string, {server?: string, port?: number|string}>}
+ */
+function buildHostMap(runConfig) {
+    /** @type {Record<string, {server?: string, port?: number|string}>} */
+    const hostMap = {};
+    if (Array.isArray(runConfig?.proxies)) {
+        for (const p of runConfig.proxies) {
+            if (p?.name) hostMap[p.name] = { server: p.server, port: p.port };
+        }
+    }
+    return hostMap;
+}
+
+/**
+ * Build picker nodes, host map, and current node name from proxy groups result.
+ * @param {any} proxyGroupsResult
+ * @returns {Promise<{ currentNodeName: string, proxyMap: Record<string, any>, hostMap: Record<string, {server?: string, port?: number|string}> }>}
+ */
+async function buildPickerFromProxyGroups(proxyGroupsResult) {
+    const proxyMap = /** @type {Record<string, any>} */ (/** @type {any} */ (proxyGroupsResult.data)?.proxies || {});
+    let currentNodeName = proxyGroupsResult.current || '';
+    const uiGroupName = proxyGroupsResult.uiGroupName || proxyGroupsResult.mainGroup || '';
+    if (uiGroupName && proxyMap[uiGroupName]) {
+        currentNodeName = proxyMap[uiGroupName].now || currentNodeName;
+    }
+    // Persist the resolved group so the picker click handler can use it
+    // even when the user has not visited the Proxies page yet.
+    if (uiGroupName) appStore.set('uiGroupName', uiGroupName);
+
+    // Fetch subscription configs for picker tabs
+    subConfigs = await loadSubConfigs();
+
+    // Build host map from run_config.yaml
+    const runConfig = await getRunConfigCached();
+    const hostMap = buildHostMap(runConfig);
+
+    // Build the flat node list for the picker
+    const activeGroupAll = proxyMap[uiGroupName]?.all || [];
+    pickerNodes = activeGroupAll.map((/** @type {string} */ name) => ({
+        name,
+        type: proxyMap[name]?.type || 'Unknown',
+        host: hostMap[name]?.server ? `${hostMap[name].server}:${hostMap[name].port || ''}` : '',
+        lat: 0,
+    }));
+    activeNodeIdx = pickerNodes.findIndex(n => n.name === currentNodeName);
+
+    return { currentNodeName, proxyMap, hostMap };
+}
+
+/**
+ * Refresh node data from the backend.
+ * @param {{ forceInvalidate?: boolean }} [opts] - pass forceInvalidate:true after
+ *   subscription switch or CONFIG_UPDATED to bypass cache TTL.
+ */
+async function refreshNodeData({ forceInvalidate = false } = {}) {
+    if (!isActive) return;
+    if (_refreshInFlight) {
+        // Record this request so it can be replayed after the current one settles.
+        _refreshQueued = true;
+        _refreshQueuedForce = _refreshQueuedForce || forceInvalidate;
+        return;
+    }
+    _refreshInFlight = true;
+    try {
+    // Cancel any pending retry — this call supersedes it
+    if (nodeRetryTimer) { clearTimeout(nodeRetryTimer); nodeRetryTimer = null; }
+
+    let success = false;
+    try {
+        // Only invalidate caches when explicitly requested (subscription switch,
+        // CONFIG_UPDATED). Normal refreshes rely on cache TTL/coalescing to
+        // avoid redundant IPC/API churn.
+        if (forceInvalidate) {
+            invalidateProxiesCache();
+            invalidateRunConfigCache();
+        }
+
+        // 1. Reuse syncCoreConfig() — the same function the home page uses
+        //    to sync mode, TUN, and #current-node-name.
+        await syncCoreConfig();
+
+        // 2. Fetch proxy data for latency + picker
+        const preferredGroupName = appStore.get('uiGroupName') || null;
+        const proxyGroupsResult = await fetchProxyGroups({ preferredGroupName });
+        const configData = await getConfig();
+
+        // Update version info
+        const ver = /** @type {any} */ (configData)?.version;
+        if (ver) {
+            const verEl = $('dz-version');
+            if (verEl) verEl.textContent = 'mihomo ' + ver;
+        }
+
+        if (!proxyGroupsResult) {
+            scheduleNodeRetry();
+            return;
+        }
+
+        const { currentNodeName, proxyMap, hostMap } = await buildPickerFromProxyGroups(proxyGroupsResult);
+
+        // Update node card
+        renderNodeCard(currentNodeName, proxyMap, hostMap);
+
+        // Consider success only if we got a real node name to display
+        success = !!currentNodeName;
+
+        // If proxy-providers are still loading (no nodes yet), retry to
+        // populate the picker once they finish downloading.
+        if (!success && proxyGroupsResult.hasProxyProviders) {
+            scheduleNodeRetry();
+            return;
+        }
+    } catch (e) {
+        consoleLogger.warn('Failed to refresh node data', e);
+    }
+
+    if (success) {
+        nodeRetryCount = 0;
+    } else {
+        scheduleNodeRetry();
+    }
+    } finally {
+        _refreshInFlight = false;
+        // Replay a queued request if one came in during the in-flight call.
+        // This must be inside finally so early returns don't skip it.
+        if (_refreshQueued) {
+            _refreshQueued = false;
+            const force = _refreshQueuedForce;
+            _refreshQueuedForce = false;
+            refreshNodeData({ forceInvalidate: force });
+        }
+    }
+}
+
+/**
+ * Schedule a retry for refreshNodeData with exponential backoff.
+ * Resets retry count on deactivate / successful activate.
+ */
+function scheduleNodeRetry() {
+    if (!isActive) return;
+    if (nodeRetryCount >= NODE_RETRY_DELAYS.length) {
+        nodeRetryCount = 0;
+        return; // exhausted retries — give up silently
+    }
+    const delay = NODE_RETRY_DELAYS[nodeRetryCount++];
+    nodeRetryTimer = setTimeout(() => {
+        nodeRetryTimer = null;
+        refreshNodeData();
+    }, delay);
+}
+
+/**
+ * Resolve a proxy/group name to its leaf node, following nested `now` chains.
+ * Mirrors the logic in proxies.js resolveLeafNode().
+ * @param {string} name
+ * @param {Record<string, any>} proxyMap
+ * @param {Set<string>} [visited]
+ * @returns {string|null}
+ */
+function resolveLeafNode(name, proxyMap, visited = new Set()) {
+    if (!name || !proxyMap) return null;
+    if (visited.has(name)) return null;
+    visited.add(name);
+    const entry = proxyMap[name];
+    if (!entry) return name;
+    if (entry.now) {
+        return proxyMap[entry.now] ? resolveLeafNode(entry.now, proxyMap, visited) : entry.now;
+    }
+    return name;
+}
+
+/**
+ * @param {string} nodeName
+ * @param {Record<string, any>} proxies
+ * @param {Record<string, {server?: string, port?: number|string}>} [hostMap]
+ */
+function renderNodeCard(nodeName, proxies, hostMap = {}) {
+    // Resolve to leaf node (nodeName may be a group like "♻️ 自动选择")
+    const leafName = resolveLeafNode(nodeName, proxies) || nodeName;
+    const node = proxies[leafName] || proxies[nodeName];
+    const host = hostMap[leafName] || hostMap[nodeName];
+    const nameEl = $('dz-node-name');
+    const hostEl = $('dz-node-host');
+    const typeEl = $('dz-node-type');
+    if (nameEl) {
+        nameEl.textContent = (leafName && leafName !== nodeName) ? `${nodeName} - ${leafName}` : (leafName || nodeName || '—');
+        nameEl.dataset.leaf = leafName || nodeName || '';
+    }
+    if (hostEl) hostEl.textContent = host?.server ? `${host.server}:${host.port || ''}` : '';
+    if (typeEl) typeEl.textContent = node?.type || '—';
+
+    // dz-node-host already shows server:port — no separate exit-IP row (mihomo doesn't expose real exit IP)
+
+    // Extract latency from proxy history (mihomo /proxies → history[].delay)
+    const history = node?.history;
+    const lastDelay = (history && history.length > 0) ? history[history.length - 1].delay : 0;
+    renderLatency(lastDelay || 0);
+
+    // Render node picker
+    renderPicker();
+}
+
+function renderPicker() {
+    const subsEl = $('dz-picker-subs');
+    const listEl = $('dz-picker-list');
+    if (!subsEl || !listEl) return;
+
+    // Tabs: subscription configs (same data source as the subscriptions page)
+    subsEl.replaceChildren();
+    for (const sub of subConfigs) {
+        const btn = document.createElement('button');
+        btn.className = 'dz-picker-sub' + (sub.active ? ' active' : '');
+        btn.textContent = sub.active ? `${sub.name} · ${pickerNodes.length}` : sub.name;
+        if (!sub.active) {
+            btn.addEventListener('click', async () => {
+                if (appStore.get('isNetworkUpdating')) return;
+                appStore.set('isNetworkUpdating', true);
+                btn.disabled = true;
+                btn.textContent = sub.name + ' …';
+                try {
+                    const cfgSettings = await getSettingsCached();
+                    await switchToConfig(sub.file, cfgSettings?.custom_args || []);
+                    // Keep picker open — user may want to select a node in the
+                    // newly loaded subscription, or verify the switch succeeded.
+                    // Caches are invalidated by postRestartRecovery, and CONFIG_UPDATED
+                    // event will trigger refreshNodeData + refreshSubscriptionData.
+                    // But also refresh explicitly in case the event was already handled
+                    // or the console is the active page.
+                    invalidateProxiesCache();
+                    invalidateRunConfigCache();
+                    invalidateSettingsCache();
+                    invalidateConfigsCache();
+                    await refreshNodeData({ forceInvalidate: true });
+                    await refreshSubscriptionData();
+                } catch (e) {
+                    consoleLogger.warn('Failed to switch subscription', e);
+                    btn.disabled = false;
+                    btn.textContent = sub.name;
+                } finally {
+                    appStore.set('isNetworkUpdating', false);
+                }
+            });
+        }
+        subsEl.appendChild(btn);
+    }
+
+    // Node list: nodes from the currently active subscription
+    listEl.replaceChildren();
+    if (pickerNodes.length === 0) return;
+    for (let i = 0; i < pickerNodes.length; i++) {
+        const n = pickerNodes[i];
+        const row = document.createElement('div');
+        row.className = 'dz-picker-node' + (i === activeNodeIdx ? ' active' : '');
+        row.setAttribute('role', 'option');
+        row.setAttribute('aria-selected', String(i === activeNodeIdx));
+        row.tabIndex = 0;
+        const main = document.createElement('div');
+        main.className = 'dz-picker-node-main';
+        const nameDiv = document.createElement('div');
+        nameDiv.className = 'dz-picker-node-name';
+        nameDiv.textContent = n.name;
+        const metaDiv = document.createElement('div');
+        metaDiv.className = 'dz-picker-node-meta';
+        metaDiv.textContent = `${n.host || n.type} · ${n.type}`;
+        main.append(nameDiv, metaDiv);
+        const badge = document.createElement('span');
+        badge.className = 'type-badge';
+        badge.textContent = n.type;
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('class', 'dz-picker-check');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2.5');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', 'M20 6 9 17l-5-5');
+        svg.appendChild(path);
+        row.append(main, badge, svg);
+        const selectNode = async () => {
+            if (i === activeNodeIdx) {
+                setPicker(false);
+                return;
+            }
+            try {
+                // Switch via the active proxy group (appStore.uiGroupName),
+                // same as home page.
+                const targetGroup = appStore.get('uiGroupName') || '';
+                const success = await switchProxy(targetGroup, n.name);
+                if (success) {
+                    // Only mark active after switch succeeds
+                    activeNodeIdx = i;
+                    // Mirror home page handleWheelProxySwitch: invalidate cache,
+                    // close connections, persist selection, then syncCoreConfig.
+                    invalidateProxiesCache();
+                    await closeAllConnections();
+
+                    try {
+                        const settings = await getSettingsCached();
+                        const profileName = settings?.last_config;
+                        if (profileName) {
+                            await saveProxySelection(profileName, { node: n.name, group: targetGroup });
+                        }
+                    } catch (_) { /* non-critical */ }
+
+                    Bus.emit(Events.PROXY_SELECTED, { node: n.name, group: targetGroup });
+                    // syncCoreConfig() will update #current-node-name (home page capsule)
+                    await syncCoreConfig();
+                } else {
+                    showNotification(t('notifSwitchFailed'), 'error');
+                }
+            } catch (e) {
+                consoleLogger.warn('Failed to switch node', e);
+                showNotification(t('notifSwitchFailed'), 'error');
+            }
+            renderPicker();
+            setPicker(false);
+        };
+        row.addEventListener('click', selectNode);
+        row.addEventListener('keydown', (/** @type {KeyboardEvent} */ ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+                ev.preventDefault();
+                selectNode();
+            }
+        });
+        listEl.appendChild(row);
+    }
+}
+
+// ── Picker open/close ────────────────────────────────────────────────────
+
+/** @param {boolean} open */
+function setPicker(open) {
+    const pickerEl = $('dz-node-picker');
+    const pickerBtn = $('dz-node-picker-btn');
+    if (pickerEl) pickerEl.classList.toggle('dz-hidden', !open);
+    if (pickerBtn) {
+        pickerBtn.classList.toggle('open', open);
+        pickerBtn.setAttribute('aria-expanded', String(open));
+    }
+}
+
+// ── Subscription card ────────────────────────────────────────────────────
+
+/** @type {any} */
+let _subConfig = null;
+
+async function refreshSubscriptionData() {
+    if (!isActive) return;
+    try {
+        const settings = await getSettingsCached();
+        const currentConfig = settings?.last_config || '';
+        const configs = await invoke(COMMANDS.LIST_CONFIGS);
+        const subscriptionConfigs = (configs || []).filter((/** @type {any} */ c) => c.url_display);
+        // Show the currently active subscription, not just the first one
+        _subConfig = subscriptionConfigs.find((/** @type {any} */ c) => c.name === currentConfig)
+            || subscriptionConfigs[0]
+            || null;
+        renderSubscriptionCard();
+    } catch (e) {
+        consoleLogger.warn('Failed to fetch subscription data', e);
+    }
+}
+
+/**
+ * Format a relative time string for the last update.
+ * @param {number | null | undefined} timestamp - Unix timestamp in seconds
+ * @returns {string}
+ */
+function fmtRelativeTime(timestamp) {
+    if (!timestamp) return t('consoleSubNever');
+    const diff = Math.floor(Date.now() / 1000) - timestamp;
+    if (diff < 60) return t('consoleSubJustNow');
+    if (diff < 3600) return t('consoleSubMinAgo', { m: String(Math.floor(diff / 60)) });
+    if (diff < 86400) return t('consoleSubHoursAgo', { h: String(Math.floor(diff / 3600)) });
+    return t('consoleSubDaysAgo', { d: String(Math.floor(diff / 86400)) });
+}
+
+/**
+ * Parse subscription info string into { upload, download, total, expire }.
+ * @param {string | undefined} subInfo
+ * @returns {{ upload: number, download: number, total: number, expire: number }}
+ */
+function parseSubInfo(subInfo) {
+    if (!subInfo) return { upload: 0, download: 0, total: 0, expire: 0 };
+    let upload = 0, download = 0, total = 0, expire = 0;
+    for (const p of subInfo.split(';')) {
+        const s = p.trim();
+        if (s.startsWith('upload=')) upload = Number.parseInt(s.slice(7), 10) || 0;
+        else if (s.startsWith('download=')) download = Number.parseInt(s.slice(9), 10) || 0;
+        else if (s.startsWith('total=')) total = Number.parseInt(s.slice(6), 10) || 0;
+        else if (s.startsWith('expire=')) expire = Number.parseInt(s.slice(7), 10) || 0;
+    }
+    return { upload, download, total, expire };
+}
+
+/**
+ * Render quota (used / total) into the card elements.
+ * @param {number} used
+ * @param {number} total
+ */
+function renderQuota(used, total) {
+    const usedValEl = $('dz-sub-used-val');
+    const usedLabelEl = $('dz-sub-used-label');
+    const progressEl = $('dz-sub-progress');
+    if (total > 0) {
+        const pct = Math.min(100, Math.max(0, (used / total) * 100));
+        if (usedValEl) usedValEl.textContent = (used / 1073741824).toFixed(1);
+        if (usedLabelEl) usedLabelEl.textContent = '/ ' + (total / 1073741824).toFixed(0) + ' GB ' + t('consoleSubUsed');
+        if (progressEl) progressEl.style.width = pct + '%';
+    } else {
+        if (usedValEl) usedValEl.textContent = '—';
+        if (usedLabelEl) usedLabelEl.textContent = '';
+        if (progressEl) progressEl.style.width = '0%';
+    }
+}
+
+/**
+ * Render expiry date into the card element.
+ * @param {number} expireTs - Unix timestamp in seconds
+ */
+function renderExpiry(expireTs) {
+    const expiryEl = $('dz-sub-expiry');
+    if (!expiryEl) return;
+    if (expireTs > 0) {
+        const d = new Date(expireTs * 1000);
+        const dateStr = new Intl.DateTimeFormat(uiLocale(), {
+            year: 'numeric', month: '2-digit', day: '2-digit',
+        }).format(d);
+        const diffDays = Math.floor((expireTs - Date.now() / 1000) / 86400);
+        expiryEl.textContent = diffDays > 0 ? `${dateStr} · ${t('consoleSubDaysLeft', diffDays, { d: String(diffDays) })}` : dateStr;
+    } else {
+        expiryEl.textContent = '—';
+    }
+}
+
+/**
+ * Render next auto-update time into the card element.
+ * @param {{ last_updated?: number, auto_update_interval?: number }} cfg
+ */
+function renderNextUpdate(cfg) {
+    const nextEl = $('dz-sub-next');
+    if (!nextEl) return;
+    const interval = cfg.auto_update_interval || 0;
+    if (interval > 0 && cfg.last_updated) {
+        const nextTs = (cfg.last_updated + interval) * 1000;
+        const nextDate = new Date(nextTs);
+        const now = new Date();
+        const isSameDay = nextDate.getFullYear() === now.getFullYear()
+            && nextDate.getMonth() === now.getMonth()
+            && nextDate.getDate() === now.getDate();
+        /** @type {Intl.DateTimeFormatOptions} */
+        const timeOpts = { hour: '2-digit', minute: '2-digit' };
+        nextEl.textContent = isSameDay
+            ? new Intl.DateTimeFormat(uiLocale(), timeOpts).format(nextDate)
+            : new Intl.DateTimeFormat(uiLocale(), { month: 'numeric', day: 'numeric', ...timeOpts }).format(nextDate);
+    } else {
+        nextEl.textContent = '—';
+    }
+}
+
+/**
+ * Render the empty-state placeholder for the subscription card.
+ * @param {HTMLElement | null} nameEl
+ * @param {HTMLElement | null} updatedEl
+ * @param {HTMLButtonElement | null} updateBtn
+ */
+function renderEmptySubscriptionCard(nameEl, updatedEl, updateBtn) {
+    if (nameEl) nameEl.textContent = t('consoleSubNoSub');
+    const usedValEl = $('dz-sub-used-val');
+    const usedLabelEl = $('dz-sub-used-label');
+    const progressEl = $('dz-sub-progress');
+    const nextEl = $('dz-sub-next');
+    const expiryEl = $('dz-sub-expiry');
+    if (usedValEl) usedValEl.textContent = '—';
+    if (usedLabelEl) usedLabelEl.textContent = '';
+    if (progressEl) progressEl.style.width = '0%';
+    if (updatedEl) updatedEl.textContent = '—';
+    if (nextEl) nextEl.textContent = '—';
+    if (expiryEl) expiryEl.textContent = '—';
+    if (updateBtn) updateBtn.disabled = true;
+}
+
+function renderSubscriptionCard() {
+    const nameEl = $('dz-sub-name');
+    const updatedEl = $('dz-sub-updated');
+    const updateBtn = /** @type {HTMLButtonElement | null} */ ($('dz-sub-update-btn'));
+
+    // Empty state
+    if (!_subConfig) {
+        renderEmptySubscriptionCard(nameEl, updatedEl, updateBtn);
+        return;
+    }
+
+    if (updateBtn) updateBtn.disabled = false;
+    if (nameEl) nameEl.textContent = _subConfig.name.replace(/\.(yaml|yml)$/i, '');
+
+    // Parse sub_info once
+    const { upload, download, total, expire } = parseSubInfo(_subConfig.sub_info);
+    renderQuota(upload + download, total);
+
+    // Last update time + node count
+    if (updatedEl) {
+        const timeStr = fmtRelativeTime(_subConfig.last_updated);
+        const nodeCount = _subConfig.node_count || _subConfig.proxy_count || 0;
+        updatedEl.textContent = nodeCount > 0 ? `${timeStr} · ${t('consoleSubNodes', nodeCount, { count: String(nodeCount) })}` : timeStr;
+    }
+
+    renderExpiry(expire);
+    renderNextUpdate(_subConfig);
+}
+
+async function updateSubscription() {
+    if (!_subConfig) return;
+    try {
+        const results = await invoke(COMMANDS.DOWNLOAD_SUB_BATCH, {
+            items: [{ name: _subConfig.name }],
+            userAgent: getSubscriptionUserAgent(),
+        });
+        if (Array.isArray(results) && results.length > 0 && results[0].success) {
+            consoleLogger.info('Subscription updated successfully');
+            // Invalidate caches so refreshSubscriptionData reads fresh data
+            invalidateConfigsCache();
+            invalidateSettingsCache();
+            // If the updated subscription is the active config, reload the core
+            // so the new node list takes effect immediately.
+            const cfgSettings = await getSettingsCached();
+            if (cfgSettings?.last_config === _subConfig.name) {
+                await switchToConfig(_subConfig.name, cfgSettings?.custom_args || []);
+            }
+            showNotification(t('consoleSubUpdateOk'), 'success');
+        } else {
+            const err = results && Array.isArray(results) && results[0]?.error ? results[0].error : 'Unknown error';
+            consoleLogger.warn('Subscription update failed:', err);
+            showNotification(t('consoleSubUpdateFail') + ': ' + err, 'error');
+        }
+    } catch (e) {
+        consoleLogger.warn('Subscription update error', e);
+        showNotification(t('consoleSubUpdateFail') + ': ' + String(e), 'error');
+    }
+}
+
+// ── Log stream ───────────────────────────────────────────────────────────
+
+const MAX_LOG_LINES = 15;
+
+/**
+ * @param {{ type: string, message: string, timestamp: string, source?: string }} entry
+ */
+function pushLog(entry) {
+    const el = $('dz-log-list');
+    if (!el) return;
+    const line = document.createElement('div');
+    line.className = 'dz-log-line';
+    const time = entry.timestamp || new Date().toLocaleTimeString(uiLocale(), { hour12: false });
+    const rawLevel = (entry.type || 'info').toLowerCase();
+    // Normalize PrismEvent types (ConfigReloaded, PatchApplied, etc.) to 'info'
+    const knownLevels = ['info', 'warn', 'error', 'debug'];
+    const level = knownLevels.includes(rawLevel) ? rawLevel : 'info';
+    const tag = entry.source || t('consoleSystem');
+    const timeSpan = document.createElement('span');
+    timeSpan.className = 'dz-log-time';
+    timeSpan.textContent = time;
+    const levelSpan = document.createElement('span');
+    levelSpan.className = `dz-log-level ${level}`;
+    levelSpan.textContent = level;
+    const msgSpan = document.createElement('span');
+    msgSpan.className = 'dz-log-msg';
+    msgSpan.textContent = `[${tag}] ${entry.message}`;
+    line.append(timeSpan, levelSpan, msgSpan);
+    el.prepend(line);
+    while (el.children.length > MAX_LOG_LINES) {
+        const last = el.lastElementChild;
+        if (last) last.remove(); else break;
+    }
+    // Keep the newest event visible — scroll to top since newest is prepended
+    el.scrollTop = 0;
+    el.scrollLeft = 0;
+}
+
+function loadInitialLogs() {
+    const events = getExtLogEvents();
+    // pushLog prepends, so iterate oldest→newest to leave the newest on top.
+    const recent = events.slice(-MAX_LOG_LINES);
+    for (const e of recent) pushLog(e);
+}
+
+// ── Mode selector sync ───────────────────────────────────────────────────
+
+/** @type {Array<{ seg: HTMLElement | null, slider: HTMLElement | null }>} */
+const MODE_SEGS = [
+    { seg: null, slider: null },
+];
+
+function initModeSegs() {
+    MODE_SEGS[0].seg = $('dz-mode-seg');
+    MODE_SEGS[0].slider = $('dz-mode-slider');
+}
+
+function syncModeSegs(/** @type {string} */ mode) {
+    const modes = ['rule', 'global', 'direct'];
+    const idx = modes.indexOf(mode.toLowerCase());
+    if (idx === -1) return;
+    for (const { seg, slider } of MODE_SEGS) {
+        if (!seg) continue;
+        seg.querySelectorAll('button').forEach((/** @type {HTMLButtonElement} */ b, /** @type {number} */ j) => b.classList.toggle('active', j === idx));
+        if (slider) slider.style.transform = `translateX(${idx * 100}%)`;
+    }
+}
+
+// ── HTML Template ────────────────────────────────────────────────────────
+
+const TEMPLATE = `
+<div class="dz-content custom-scrollbar">
+    <header class="dz-header">
+        <div>
+            <h1 id="dz-page-title" data-i18n="consoleTitle">控制台</h1>
+            <div class="dz-sub">
+                <span class="dz-live-dot"></span>
+                <span id="dz-uptime" data-i18n="consoleUptimeRunning">核心已运行 —</span>
+                <span style="color:var(--zephyr-text-tertiary)">·</span>
+                <span id="dz-version" style="font-family:var(--font-mono)">mihomo</span>
+            </div>
+        </div>
+    </header>
+
+    <!-- KPI strip -->
+    <div class="dz-kpis">
+        <div class="glass-card dz-kpi">
+            <div class="dz-kpi-top">
+                <span class="dz-kpi-label" data-i18n="consoleDownSpeed">下载速度</span>
+                <span class="dz-kpi-icon" style="background:rgba(175,82,222,.12);color:#af52de;">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0 5-5m-5 5-5-5"/><path d="M4 21h16"/></svg>
+                </span>
+            </div>
+            <div class="dz-kpi-value"><b id="dz-down-val">0</b><span id="dz-down-unit">KB/s</span></div>
+            <div class="dz-kpi-foot"><span data-i18n="consolePeak">峰值</span> <span id="dz-down-peak">0 KB/s</span></div>
+            <canvas class="dz-spark" id="dz-spark-down"></canvas>
+        </div>
+        <div class="glass-card dz-kpi">
+            <div class="dz-kpi-top">
+                <span class="dz-kpi-label" data-i18n="consoleUpSpeed">上传速度</span>
+                <span class="dz-kpi-icon" style="background:rgba(56,189,248,.12);color:#38bdf8;">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 21V9m0 0 5 5m-5-5-5 5"/><path d="M4 3h16"/></svg>
+                </span>
+            </div>
+            <div class="dz-kpi-value"><b id="dz-up-val">0</b><span id="dz-up-unit">KB/s</span></div>
+            <div class="dz-kpi-foot"><span data-i18n="consolePeak">峰值</span> <span id="dz-up-peak">0 KB/s</span></div>
+            <canvas class="dz-spark" id="dz-spark-up"></canvas>
+        </div>
+        <div class="glass-card dz-kpi">
+            <div class="dz-kpi-top">
+                <span class="dz-kpi-label" data-i18n="consoleTotalTraffic">总流量</span>
+                <span class="dz-kpi-icon" style="background:rgba(74,222,128,.12);color:var(--zephyr-color-success);">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12a9 9 0 1 1-9-9"/><path d="M21 3 12 12"/><path d="M16 3h5v5"/></svg>
+                </span>
+            </div>
+            <div class="dz-kpi-value"><b id="dz-total-val">0.00</b><span>GB</span></div>
+            <div class="dz-kpi-foot">↓ <span id="dz-total-down">0.00</span> GB · ↑ <span id="dz-total-up">0.00</span> GB</div>
+        </div>
+        <div class="glass-card dz-kpi">
+            <div class="dz-kpi-top">
+                <span class="dz-kpi-label" data-i18n="consoleActiveConn">活动连接</span>
+                <span class="dz-kpi-icon" style="background:rgba(245,158,11,.12);color:var(--zephyr-color-warning);">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="5" cy="12" r="2.5"/><circle cx="19" cy="12" r="2.5"/><path d="M7.5 12h9"/></svg>
+                </span>
+            </div>
+            <div class="dz-kpi-value"><b id="dz-conn-val">0</b><span data-i18n="consoleConnUnit">个</span></div>
+            <div class="dz-kpi-foot">TCP <span id="dz-conn-tcp">0</span> · UDP <span id="dz-conn-udp">0</span></div>
+        </div>
+        <div class="glass-card dz-kpi">
+            <div class="dz-kpi-top">
+                <span class="dz-kpi-label" data-i18n="consoleNodeLatency">节点延迟</span>
+                <span class="dz-kpi-icon" style="background:rgba(175,82,222,.12);color:#af52de;">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+                </span>
+            </div>
+            <div class="dz-kpi-value"><b id="dz-lat-val">—</b><span>ms</span></div>
+            <div class="dz-kpi-foot"><span class="latency-badge latency-badge--fast" id="dz-lat-badge">—</span></div>
+        </div>
+    </div>
+
+    <!-- Main grid: chart + sidebar -->
+    <div class="dz-grid-main">
+        <div class="glass-card dz-card-pad" style="display:flex;flex-direction:column;">
+            <div class="dz-card-head">
+                <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleRealtimeTraffic">实时流量</span></div>
+                <div class="dz-legend">
+                    <div class="dz-legend-item"><span class="dz-legend-swatch" style="background:rgba(175,82,222,.8)"></span><span data-i18n="consoleDownload">下载</span></div>
+                    <div class="dz-legend-item"><span class="dz-legend-swatch" style="background:rgba(56,189,248,.8)"></span><span data-i18n="consoleUpload">上传</span></div>
+                </div>
+            </div>
+            <div class="dz-chart-wrap"><canvas id="dz-chart"></canvas></div>
+            <div class="dz-chart-meta">
+                <div><span data-i18n="consoleAvgMin">1 分钟平均</span><b id="dz-avg-down">0 KB/s ↓</b></div>
+                <div><span data-i18n="consoleSessionDown">会话总下载</span><b id="dz-sess-down">0 B</b></div>
+                <div><span data-i18n="consoleSessionUp">会话总上传</span><b id="dz-sess-up">0 B</b></div>
+                <div><span data-i18n="consoleSampleInterval">采样间隔</span><b data-i18n="consoleSampleValue">1s · 60 点滚动窗</b></div>
+            </div>
+        </div>
+
+        <div class="dz-side">
+            <div class="dz-node-wrap">
+                <div class="glass-card dz-card-pad">
+                    <div class="dz-card-head" style="margin-bottom:10px;">
+                        <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleCurrentNode">当前节点</span></div>
+                        <div style="display:flex;align-items:center;gap:8px;">
+                            <span class="type-badge" id="dz-node-type">—</span>
+                            <button class="dz-switch-node-btn" id="dz-node-picker-btn" aria-haspopup="listbox" aria-expanded="false" aria-controls="dz-picker-list">
+                                <span data-i18n="consoleSwitch">切换</span>
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="dz-node-name-row">
+                        <span class="dz-node-name" id="dz-node-name">—</span>
+                    </div>
+                    <div class="dz-node-sub">
+                        <span style="font-family:var(--font-mono)" id="dz-node-host"></span>
+                    </div>
+                    <div class="dz-node-latency">
+                        <span class="dz-latency-num"><span id="dz-node-lat">—</span><small>ms</small></span>
+                        <span class="latency-badge latency-badge--fast" id="dz-node-lat-badge">—</span>
+                        <button class="btn-ghost dz-test-btn" id="dz-test-btn" style="padding:5px 12px;font-size:11px;">
+                            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:12px;height:12px;"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+                            <span data-i18n="consoleTestLatency">测速</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="dz-node-picker dz-hidden" id="dz-node-picker">
+                    <div class="dz-picker-subs" id="dz-picker-subs"></div>
+                    <div class="dz-picker-list custom-scrollbar" id="dz-picker-list" role="listbox" aria-label="Node picker"></div>
+                </div>
+            </div>
+
+            <div class="glass-card dz-card-pad" style="flex:1;">
+                <div class="dz-card-head" style="margin-bottom:0;">
+                    <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleQuickControl">快捷控制</span></div>
+                </div>
+                <div class="dz-mode-seg" id="dz-mode-seg">
+                    <div class="dz-mode-slider" id="dz-mode-slider"></div>
+                    <button type="button" data-mode="rule" data-i18n="rule">分流规则</button>
+                    <button type="button" data-mode="global" data-i18n="global">全局代理</button>
+                    <button type="button" data-mode="direct" data-i18n="direct">直接连接</button>
+                </div>
+                <div class="dz-quick-rows">
+                    <div class="dz-quick-row">
+                        <span class="dz-quick-row-label">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                            <span id="dz-sys-toggle-label" data-i18n="consoleSysProxy">系统代理</span>
+                        </span>
+                        <label class="ios-switch switch-lg"><input type="checkbox" id="dz-sys-toggle" aria-labelledby="dz-sys-toggle-label"><span class="switch-slider"></span></label>
+                    </div>
+                    <div class="dz-quick-row">
+                        <span class="dz-quick-row-label">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                            <span id="dz-tun-toggle-label" data-i18n="consoleTunAdapter">TUN 虚拟网卡</span>
+                        </span>
+                        <label class="ios-switch switch-lg"><input type="checkbox" id="dz-tun-toggle" aria-labelledby="dz-tun-toggle-label"><span class="switch-slider"></span></label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bottom three-column grid -->
+    <div class="dz-grid-bottom">
+        <div class="glass-card dz-card-pad" style="display:flex;flex-direction:column;min-height:0;">
+            <div class="dz-card-head">
+                <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleActiveConn">活跃连接</span></div>
+                <button class="dz-sort-btn" id="dz-sort-btn">
+                    <span id="dz-sort-label" data-i18n="consoleSortBySpeed">按速率排序</span>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5M7 9l5-5 5 5"/></svg>
+                </button>
+            </div>
+            <div class="dz-conn-list custom-scrollbar" id="dz-conn-list"></div>
+        </div>
+
+        <div class="glass-card dz-card-pad" style="display:flex;flex-direction:column;overflow:visible;">
+            <div class="dz-card-head">
+                <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleSubUsage">订阅用量</span></div>
+            </div>
+            <div style="font-size:13px;font-weight:600;color:var(--zephyr-text-primary);" id="dz-sub-name">—</div>
+            <div class="dz-sub-used"><b id="dz-sub-used-val">—</b><span id="dz-sub-used-label"> / —</span></div>
+            <div class="dz-progress"><div class="dz-progress-fill" id="dz-sub-progress" style="width:0%"></div></div>
+            <div class="dz-sub-rows">
+                <div class="dz-sub-row"><span data-i18n="consoleSubExpiry">到期时间</span><b id="dz-sub-expiry">—</b></div>
+                <div class="dz-sub-row"><span data-i18n="consoleSubLastUpdate">最近更新</span><b id="dz-sub-updated">—</b></div>
+                <div class="dz-sub-row"><span data-i18n="consoleSubNextUpdate">下次自动更新</span><b id="dz-sub-next">—</b></div>
+            </div>
+            <div class="dz-sub-actions">
+                <button class="dz-mini-btn accent" id="dz-sub-update-btn">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+                    <span data-i18n="consoleSubUpdateNow">立即更新</span>
+                </button>
+                <button class="dz-mini-btn" id="dz-sub-manage-btn" data-i18n="consoleSubManage">管理订阅</button>
+            </div>
+        </div>
+
+        <div class="glass-card dz-card-pad" style="display:flex;flex-direction:column;min-height:0;">
+            <div class="dz-card-head">
+                <div class="dz-card-title"><span class="dot"></span><span data-i18n="consoleRecentEvents">最近事件</span></div>
+                <button class="dz-mini-btn" id="dz-all-logs-btn" style="flex:0;padding:4px 10px;" data-i18n="consoleAllLogs">全部日志</button>
+            </div>
+            <div class="dz-log-list custom-scrollbar" id="dz-log-list"></div>
+        </div>
+    </div>
+</div>
+`;
+
+// ── Initialization ───────────────────────────────────────────────────────
+
+/**
+ * Initialize the console home page.
+ * Injects HTML, binds events, starts polling.
+ * Should be called once during app init.
+ */
+export function initConsoleHome() {
+    if (isInitialized) return;
+    const container = document.querySelector('[data-page="console"]');
+    if (!container) return;
+
+    // A previous failed attempt may have registered subscribers before
+    // throwing. Release them so a retry does not create duplicates.
+    _runPendingCleanups();
+
+    try {
+        _buildConsoleHome(container);
+    } catch (err) {
+        // Undo every registration made by the failed attempt.
+        _runPendingCleanups();
+        throw err;
+    }
+}
+
+/** Run and discard every pending cleanup. */
+function _runPendingCleanups() {
+    for (const fn of _cleanups.splice(0)) {
+        try { fn(); } catch { /* cleanup must not throw */ }
+    }
+    for (const unreg of _globalUnregs.splice(0)) {
+        try { unreg(); } catch { /* unregister must not throw */ }
+    }
+}
+
+/**
+ * Build the console home page — injects HTML, binds events, starts polling.
+ * @param {Element} container
+ */
+function _buildConsoleHome(container) {
+    // Inject template
+    // TEMPLATE is a static string with no user input — safe for innerHTML
+    // eslint-disable-next-line no-unsanitized/property
+    container.innerHTML = TEMPLATE;
+
+    // Translate all data-i18n elements in the injected template
+    applyTranslations();
+
+    // Set aria-labels and titles (not handled by applyTranslations)
+    const pickerListInit = $('dz-picker-list');
+    if (pickerListInit) pickerListInit.setAttribute('aria-label', t('consoleNodePicker'));
+    const hostInit = $('dz-node-host');
+    if (hostInit) hostInit.title = t('consoleCopyHint');
+
+    // Init mode segments
+    initModeSegs();
+
+    // ── Mode selector: delegate to home page's data-mode buttons ──
+    // The home page's initModeSelector() in modes.js binds the actual
+    // patchConfig + node inheritance logic. Console buttons are injected
+    // dynamically, so we delegate clicks to the corresponding home page button.
+    const consoleModeSeg = $('dz-mode-seg');
+    consoleModeSeg?.querySelectorAll('button[data-mode]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const mode = /** @type {HTMLElement} */ (btn).dataset.mode;
+            if (!mode) return;
+            // Find the home page's corresponding data-mode button and click it
+            const homeBtn = document.querySelector(`[data-page="home"] button[data-mode="${mode}"]`);
+            if (homeBtn instanceof HTMLElement) {
+                homeBtn.click();
+            }
+        });
+    });
+
+    // ── Connection sort ──
+    const sortBtn = $('dz-sort-btn');
+    if (sortBtn) sortBtn.title = t('consoleSortHint');
+    sortBtn?.addEventListener('click', () => {
+        sortIdx = (sortIdx + 1) % SORT_MODES.length;
+        const label = $('dz-sort-label');
+        if (label) label.textContent = t(SORT_MODES[sortIdx].labelKey);
+        pollConnections();
+    });
+
+    // ── Node picker ──
+    const pickerBtn = $('dz-node-picker-btn');
+    pickerBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const pickerEl = $('dz-node-picker');
+        if (pickerEl) setPicker(pickerEl.classList.contains('dz-hidden'));
+    });
+
+    // Close picker when clicking anywhere outside the picker element itself.
+    // Uses capture phase so it fires before any other handler can stopPropagation.
+    const _docClickClose = (/** @type {Event} */ e) => {
+        const pickerEl = $('dz-node-picker');
+        if (!pickerEl || pickerEl.classList.contains('dz-hidden')) return;
+        const target = /** @type {Element | null} */ (e.target);
+        if (!target) return;
+        // Close if the click is outside the picker dropdown AND not on the toggle button
+        if (!target.closest('#dz-node-picker') && !target.closest('#dz-node-picker-btn')) {
+            setPicker(false);
+        }
+    };
+    document.addEventListener('click', _docClickClose, true); // ← capture phase
+    _cleanups.push(() => document.removeEventListener('click', _docClickClose, true));
+
+    // ── Node host click-to-copy ──
+    const hostCopyEl = $('dz-node-host');
+    if (hostCopyEl) {
+        hostCopyEl.setAttribute('role', 'button');
+        hostCopyEl.tabIndex = 0;
+        const copyHost = () => {
+            const text = hostCopyEl.textContent || '';
+            if (!text) return;
+            const done = () => {
+                const orig = hostCopyEl.style.color;
+                hostCopyEl.style.color = 'var(--zephyr-color-success)';
+                setTimeout(() => { hostCopyEl.style.color = orig; }, 1200);
+            };
+            if (navigator.clipboard?.writeText) {
+                navigator.clipboard.writeText(text).then(done).catch(done);
+            } else done();
+        };
+        hostCopyEl.addEventListener('click', copyHost);
+        hostCopyEl.addEventListener('keydown', (/** @type {KeyboardEvent} */ ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+                ev.preventDefault();
+                copyHost();
+            }
+        });
+    }
+    const _docKeydown = (/** @type {KeyboardEvent} */ e) => {
+        if (e.key === 'Escape') setPicker(false);
+    };
+    document.addEventListener('keydown', _docKeydown);
+    _cleanups.push(() => document.removeEventListener('keydown', _docKeydown));
+
+    // ── Test latency button ──
+    const testBtn = /** @type {HTMLButtonElement | null} */ ($('dz-test-btn'));
+    testBtn?.addEventListener('click', async () => {
+        const btn = testBtn;
+        const leafName = $('dz-node-name')?.dataset.leaf;
+        if (!leafName) return;
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+        try {
+            const delay = await testProxy(leafName, 5000);
+            renderLatency(delay);
+        } catch {
+            renderLatency(-1);
+        } finally {
+            btn.removeAttribute('aria-busy');
+            btn.disabled = false;
+        }
+    });
+
+    // ── Sys proxy / TUN toggle bindings ──
+    // Two-way: store → DOM via bind(), DOM → store via change handler
+    const sysToggle = /** @type {HTMLInputElement|null} */ ($('dz-sys-toggle'));
+    const tunToggle = /** @type {HTMLInputElement|null} */ ($('dz-tun-toggle'));
+
+    if (sysToggle) {
+        _cleanups.push(bind(appStore, sysToggle, 'isSysProxyEnabled', 'checked'));
+        sysToggle.addEventListener('change', async () => {
+            const enabled = sysToggle.checked;
+            // Call the backend directly instead of dispatching a DOM event,
+            // which may have no listener if console initialized before sysproxy.js.
+            try {
+                await setSysProxyEnabled(enabled);
+            } catch {
+                sysToggle.checked = !enabled;
+                appStore.set('isSysProxyEnabled', !enabled);
+            }
+            // Sync the minimal-home toggle so both UIs stay in sync.
+            const mainToggle = /** @type {HTMLInputElement | null} */ (document.getElementById('sys-proxy-toggle'));
+            if (mainToggle) mainToggle.checked = sysToggle.checked;
+        });
+    }
+    if (tunToggle) {
+        _cleanups.push(bind(appStore, tunToggle, 'isTunEnabled', 'checked'));
+        tunToggle.addEventListener('change', () => {
+            const enabled = tunToggle.checked;
+            appStore.set('isTunEnabled', enabled);
+            const mainToggle = /** @type {HTMLInputElement | null} */ (document.getElementById('tun-proxy-toggle'));
+            if (mainToggle) mainToggle.checked = enabled;
+            // Call onchange directly (set by initTunToggle). Unlike dispatchEvent,
+            // this is a no-op when the handler is not yet attached, avoiding
+            // silent failures if console initializes before tun.js.
+            if (mainToggle && typeof mainToggle.onchange === 'function') {
+                mainToggle.onchange(new Event('change'));
+            }
+        });
+    }
+
+    // Update proxy/TUN status text
+
+    // ── Mode selector sync ──
+    _cleanups.push(appStore.subscribe('currentOutboundMode', (/** @type {string} */ mode) => syncModeSegs(mode)));
+    syncModeSegs(appStore.get('currentOutboundMode') || 'rule');
+
+    // ── Traffic data via Bus ──
+    _cleanups.push(Bus.on(Events.TRAFFIC_UPDATE, (/** @type {any} */ data) => {
+        const raw = data?.raw;
+        if (!raw) return;
+        state.down = raw.down || 0;
+        state.up = raw.up || 0;
+
+        // Integrate rates into totals (raw.up/down are bytes/sec)
+        // totalDown/totalUp are lifetime counters — always accumulate.
+        // sessDown/sessUp are session-scoped — only when console is active.
+        const now = Date.now();
+        // Lifetime totals — always accumulate, never reset
+        if (lastTrafficTsMsTotal) {
+            const dtSec = Math.max(0, Math.min(5, (now - lastTrafficTsMsTotal) / 1000));
+            state.totalDown += state.down * dtSec;
+            state.totalUp += state.up * dtSec;
+        }
+        lastTrafficTsMsTotal = now;
+        // Session totals — only accumulate while console is active
+        if (isActive) {
+            if (lastTrafficTsMsSession) {
+                const dtSec = Math.max(0, Math.min(5, (now - lastTrafficTsMsSession) / 1000));
+                state.sessDown += state.down * dtSec;
+                state.sessUp += state.up * dtSec;
+            }
+            lastTrafficTsMsSession = now;
+        }
+
+        state.downPeak = Math.max(state.downPeak, state.down);
+        state.upPeak = Math.max(state.upPeak, state.up);
+        trafficHistory.push({ up: state.up, down: state.down, time: now });
+        if (trafficHistory.length > 60) trafficHistory.shift();
+
+        if (!isActive) return;
+
+        renderNumbers();
+        drawChart($('dz-chart'));
+        drawSpark($('dz-spark-down'), 'down', '175,82,222');
+        drawSpark($('dz-spark-up'), 'up', '56,189,248');
+    }));
+
+    // ── Log stream ──
+    loadInitialLogs();
+    const _logCb = (/** @type {{ type: string, message: string, timestamp: string, source?: string }} */ entry) => { if (isActive) pushLog(entry); };
+    subscribeToEvents(_logCb);
+    _cleanups.push(() => unsubscribeFromEvents(_logCb));
+
+    // ── Proxy events ──
+    _cleanups.push(Bus.on(Events.PROXY_SELECTED, () => {
+        refreshNodeData();
+    }));
+
+    // ── Core restart: reset traffic counters ──
+    // CORE_RESTARTED fires when mihomo just started. We reset counters here
+    // (not on CONFIG_UPDATED) because CONFIG_UPDATED also fires on non-restart
+    // settings changes (restore defaults, node-scroll toggle, etc.).
+    const _coreRestartedUnsub = Bus.on(Events.CORE_RESTARTED, () => {
+        state.totalDown = 0;
+        state.totalUp = 0;
+        state.downPeak = 0;
+        state.upPeak = 0;
+        state.sessDown = 0;
+        state.sessUp = 0;
+        trafficHistory.length = 0;
+        lastTrafficTsMsTotal = 0;
+        lastTrafficTsMsSession = 0;
+    });
+    _cleanups.push(() => _coreRestartedUnsub());
+
+    // ── Config update: refresh all console data ──
+    // Listen to CONFIG_UPDATED (emitted after full postRestartRecovery:
+    // overrides applied, proxy selection restored, caches invalidated).
+    // Also fires on non-restart settings changes — that's fine for data refresh.
+    const _configUpdatedUnsub = Bus.on(Events.CONFIG_UPDATED, () => {
+        if (!isActive) return; // skip IPC calls when console page is hidden
+        nodeRetryCount = 0; // core fully restarted - give retry budget back
+        fetchCoreUptime(); // uptime resets after restart
+        refreshNodeData({ forceInvalidate: true });
+        refreshSubscriptionData();
+    });
+    _cleanups.push(() => _configUpdatedUnsub());
+
+    // ── Resize handler (coalesced with requestAnimationFrame) ──
+    let resizeRaf = 0;
+    const resizeHandler = () => {
+        if (resizeRaf) return;
+        resizeRaf = requestAnimationFrame(() => {
+            resizeRaf = 0;
+            drawChart($('dz-chart'));
+        });
+    };
+    window.addEventListener('resize', resizeHandler);
+    _cleanups.push(() => window.removeEventListener('resize', resizeHandler));
+
+    // ── Uptime ── Fetch real uptime from backend, then tick locally every second.
+    // NOTE: fetchCoreUptime() is called from activateConsole(), not here,
+    // to avoid showing a transient "core stopped" state during early init
+    // when the core hasn't started yet.
+    _cleanups.push(() => { if (uptimeTimer) clearInterval(uptimeTimer); });
+
+    // ── Connection polling ──
+    _cleanups.push(() => { if (connPollTimer) clearInterval(connPollTimer); });
+
+    // ── Subscription update button ──
+    const subUpdateBtn = /** @type {HTMLButtonElement | null} */ ($('dz-sub-update-btn'));
+    /**
+     * Rebuild the sub-update button content via DOM methods (avoids innerHTML).
+     * @param {HTMLButtonElement} btn
+     * @param {boolean} loading
+     */
+    const setSubUpdateBtnState = (btn, loading) => {
+        btn.replaceChildren();
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        if (loading) svg.setAttribute('class', 'animate-spin');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2.5');
+        svg.setAttribute('style', 'width:12px;height:12px;');
+        const p1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        p1.setAttribute('d', 'M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8');
+        const p2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        p2.setAttribute('d', 'M21 3v5h-5');
+        svg.append(p1, p2);
+        const span = document.createElement('span');
+        span.textContent = loading ? t('consoleSubUpdating') : t('consoleSubUpdateNow');
+        btn.append(svg, span);
+    };
+    subUpdateBtn?.addEventListener('click', async () => {
+        const btn = subUpdateBtn;
+        setSubUpdateBtnState(btn, true);
+        btn.disabled = true;
+        try {
+            await updateSubscription();
+        } finally {
+            setSubUpdateBtnState(btn, false);
+            btn.disabled = false;
+            refreshSubscriptionData();
+        }
+    });
+
+    // ── Manage subscription button ──
+    const subManageBtn = $('dz-sub-manage-btn');
+    subManageBtn?.addEventListener('click', () => {
+        const navBtn = document.querySelector('[data-nav="subscriptions"]');
+        if (navBtn instanceof HTMLElement) navBtn.click();
+    });
+
+    // ── All logs button ──
+    const allLogsBtn = $('dz-all-logs-btn');
+    allLogsBtn?.addEventListener('click', () => {
+        const navBtn = document.querySelector('[data-nav="logs"]');
+        if (navBtn instanceof HTMLElement) navBtn.click();
+    });
+
+    // ── i18n: re-render dynamic content on language change ──
+    _cleanups.push(Bus.on(Events.I18N_APPLIED, () => {
+        // Sort label and tooltip
+        const sortLabel = $('dz-sort-label');
+        if (sortLabel) sortLabel.textContent = t(SORT_MODES[sortIdx].labelKey);
+        const sortBtnEl = $('dz-sort-btn');
+        if (sortBtnEl) sortBtnEl.title = t('consoleSortHint');
+
+        // Aria-labels and titles
+        const pickerListI18n = $('dz-picker-list');
+        if (pickerListI18n) pickerListI18n.setAttribute('aria-label', t('consoleNodePicker'));
+        const hostEl = $('dz-node-host');
+        if (hostEl) hostEl.title = t('consoleCopyHint');
+
+        // Re-render uptime, picker, subscription, and latency badge
+        renderUptime();
+        renderPicker();
+        renderSubscriptionCard();
+        if (state.latency > 0) renderLatency(state.latency);
+    }));
+
+    // Register all cleanups (after all _cleanups pushes are done)
+    _cleanups.forEach(fn => _globalUnregs.push(registerCleanup(/** @type {() => void} */ (fn))));
+
+    // Initial render
+    renderNumbers();
+    renderUptime();
+    requestAnimationFrame(() => drawChart($('dz-chart')));
+
+    // Start data refresh
+
+    // Mark initialization as complete — must be the last step so that
+    // a throw in any earlier setup step leaves isInitialized false and
+    // allows a retry on the next initConsoleHome() call.
+    isInitialized = true;
+    consoleLogger.info('Console home page initialized');
+}
+
+/**
+ * Activate the console page (called when navigating to it).
+ * Starts data polling and triggers initial data fetch.
+ */
+export function activateConsole() {
+    // Lazy-initialize the console DOM if not yet done (e.g., user switched
+    // to console mode from settings after startup with minimal mode).
+    // initConsoleHome() is idempotent — guarded by isInitialized.
+    initConsoleHome();
+    isActive = true;
+    nodeRetryCount = 0;
+    uptimeSyncCounter = 0; // prevent immediate re-fetch duplicate
+    prevConnStats.clear(); // reset so first poll doesn't compute bogus speed from stale snapshot
+    state.sessDown = 0; // reset session traffic on new session
+    state.sessUp = 0;
+    lastTrafficTsMsSession = null; // reset session timestamp so first sample integrates correctly
+    renderSessionTotals(); // immediately reflect reset in the DOM
+    // Reload logs from buffer so the panel is fresh after navigating away and back
+    const logList = $('dz-log-list');
+    if (logList) logList.replaceChildren();
+    loadInitialLogs();
+    if (!uptimeTimer) uptimeTimer = setInterval(tickUptime, 1000);
+    if (!connPollTimer) connPollTimer = setInterval(pollConnections, 2000);
+    fetchCoreUptime(); // re-sync real uptime from backend
+    refreshNodeData();
+    pollConnections();
+    refreshSubscriptionData();
+    requestAnimationFrame(() => {
+        drawChart($('dz-chart'));
+    });
+}
+
+/**
+ * Deactivate the console page (called when navigating away).
+ */
+export function deactivateConsole() {
+    isActive = false;
+    if (uptimeTimer) { clearInterval(uptimeTimer); uptimeTimer = null; }
+    if (connPollTimer) { clearInterval(connPollTimer); connPollTimer = null; }
+    if (nodeRetryTimer) { clearTimeout(nodeRetryTimer); nodeRetryTimer = null; }
+    nodeRetryCount = 0;
+    prevConnStats.clear(); // discard stale snapshot to avoid huge fake speed on re-activate
+}
+
+/**
+ * Fetch the real mihomo uptime (seconds since spawn) from the Rust backend.
+ * The backend records Instant::now() when the process is spawned and
+ * returns the elapsed duration.  We then increment locally every second
+ * via renderUptime() to avoid continuous IPC polling.
+ */
+async function fetchCoreUptime() {
+    try {
+        const uptime = await invoke(COMMANDS.GET_CORE_UPTIME);
+        // undefined=not-fetched, null=core-stopped, number=running
+        coreUptimeSec = typeof uptime === 'number' ? uptime : null;
+        renderUptime();
+    } catch (e) {
+        // Log the failure but do NOT reset coreUptimeSec — keep displaying
+        // the last known uptime while we retry fetching. If the core truly stopped,
+        // the next successful fetch will return null and we'll reset then.
+        consoleLogger.warn('Failed to fetch core uptime', e);
+        renderUptime();
+    }
+}

--- a/apps/desktop/src/ui/events.js
+++ b/apps/desktop/src/ui/events.js
@@ -209,6 +209,8 @@ export const Events = Object.freeze({
     CONFIG_UPDATED: 'config-updated',
     CORE_RESTARTED: 'core-restarted',
     RULES_CHANGED: 'rules-changed',
+    HOME_PAGE_MODE_CHANGED: 'home-page-mode-changed',
+    TRAFFIC_UPDATE: 'traffic-update',
     CONNECTIONS_FLUSHED: 'connections-flushed',
     TRAY_MENU_UPDATE: 'tray-menu-update',
     NOTIFICATION: 'notification',

--- a/apps/desktop/src/ui/logs.js
+++ b/apps/desktop/src/ui/logs.js
@@ -148,6 +148,9 @@ let _extAutoScroll = true;
 /** @type {ReturnType<typeof createVirtualScroll>|null} */
 let _vs = null;
 
+/** @type {((entry: { type: string, message: string, timestamp: string, source?: string }) => void) | null} */
+let _extLogCb = null;
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /**
@@ -193,7 +196,10 @@ export function destroyLogsPage() {
     stopPolling();
     _vs?.destroy();
     _vs = null;
-    unsubscribeFromEvents();
+    if (_extLogCb) {
+        unsubscribeFromEvents(_extLogCb);
+        _extLogCb = null;
+    }
 }
 
 // ── State Management ───────────────────────────────────────────────────────
@@ -252,8 +258,9 @@ function startPolling() {
 /** @param {string} key */
 function t(key) {
     const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */ (currentLang);
-    const dict = /** @type {Record<string, string>} */ (translations[langKey]) || /** @type {Record<string, string>} */ (translations.en);
-    return dict[key] || key;
+    const dict = /** @type {Record<string, unknown>} */ (translations[langKey]) || /** @type {Record<string, unknown>} */ (translations.en);
+    const val = dict[key];
+    return typeof val === 'string' ? val : key;
 }
 
 function buildPageHTML() {
@@ -376,9 +383,13 @@ function bindEvents() {
     tabExt?.addEventListener('click', switchToExtTab);
 
     // Subscribe to new events from global listener
-    subscribeToEvents((entry) => {
+    if (_extLogCb) {
+        unsubscribeFromEvents(_extLogCb);
+    }
+    _extLogCb = (entry) => {
         renderExtLogEntry(entry);
-    });
+    };
+    subscribeToEvents(_extLogCb);
 
     // Rebuild ext-log DOM from accumulated events (if any)
     rebuildExtLogDOM();

--- a/apps/desktop/src/ui/navigation.js
+++ b/apps/desktop/src/ui/navigation.js
@@ -7,10 +7,11 @@
  */
 
 import { setup3DEffect } from './3d-effect.js';
+import { appStore } from './state.js';
 
 /**
  * Switch the visible page by pageId.
- * Direct hidden toggle — no opacity transition to prevent flicker.
+ * Direct hidden toggle - no opacity transition to prevent flicker.
  * Also toggles the shared background glow layer.
  *
  * @param {string} pageId - The data-page attribute value of the target page
@@ -34,6 +35,43 @@ export function switchPage(pageId) {
 /** Store leave-timeout IDs without polluting DOM element types. */
 const leaveTimeouts = new WeakMap();
 
+/** @type {((page: string) => void) | null} Reference set by initNavigation for programmatic use. */
+let _navigateToRef = null;
+
+/**
+ * Programmatic navigation that fires leave/enter callbacks and updates
+ * internal currentPage state, just like a sidebar click.
+ * Must be called after initNavigation().
+ *
+ * @param {string} pageId - The target page (e.g. 'home', 'console', 'proxies')
+ */
+export function navigateTo(pageId) {
+    if (_navigateToRef) {
+        _navigateToRef(pageId);
+    } else {
+        // Fallback: just switch the page without callbacks
+        switchPage(pageId);
+    }
+}
+
+/** @type {Record<string, string>} Map page id to callback name. */
+const PAGE_CALLBACK_MAP = {
+    'proxies': 'onProxies',
+    'advanced': 'onAdvanced',
+    'home': 'onHome',
+    'console': 'onConsole',
+    'rule-library': 'onRuleLibrary',
+    'connections': 'onConnections',
+    'logs': 'onLogs',
+};
+
+/** @type {Record<string, string>} Map page id to leave-callback name. */
+const PAGE_LEAVE_MAP = {
+    'logs': 'onLeaveLogs',
+    'proxies': 'onLeaveProxies',
+    'console': 'onLeaveConsole',
+};
+
 /**
  * Initialize sidebar navigation.
  * Sets up click handlers on [data-nav] items and applies 3D hover effects.
@@ -51,6 +89,8 @@ const leaveTimeouts = new WeakMap();
  * @param {Function} [callbacks.onLogs] - Called when navigating to logs page
  * @param {Function} [callbacks.onLeaveLogs] - Called when navigating away from logs page
  * @param {Function} [callbacks.onLeaveProxies] - Called when navigating away from proxies page
+ * @param {Function} [callbacks.onConsole] - Called when navigating to console page
+ * @param {Function} [callbacks.onLeaveConsole] - Called when navigating away from console page
  */
 export function initNavigation(callbacks = {}) {
     const navItems = document.querySelectorAll('[data-nav]');
@@ -59,65 +99,108 @@ export function initNavigation(callbacks = {}) {
     setup3DEffect(navItems);
 
     /** @type {string|null} Track the current page for leave callbacks */
+    // Detect which page is initially visible (main.js may have already switched to console)
     let currentPage = null;
+    const initialVisible = document.querySelector('[data-page]:not(.hidden)');
+    if (initialVisible) {
+        const initialPage = /** @type {HTMLElement} */ (initialVisible).dataset.page ?? null;
+        // If console mode redirected home to console, treat it as 'console' not 'home'
+        currentPage = (initialPage === 'home' && appStore.get('homePageMode') === 'console')
+            ? 'console'
+            : initialPage;
+    }
+
+    /**
+     * Update nav-item active/leaving styling for the target page.
+     * @param {string} targetPage
+     */
+    function updateNavStyling(targetPage) {
+        // When target is 'console', the sidebar item is 'home' (console reuses home slot)
+        const navSelector = targetPage === 'console' ? '[data-nav="home"]' : `[data-nav="${targetPage}"]`;
+        const targetNav = document.querySelector(navSelector);
+        // Pages without a sidebar item (e.g. 'advanced') keep the current
+        // active item highlighted instead of clearing the whole sidebar.
+        if (!targetNav) return;
+        const oldActive = document.querySelector('.nav-btn.is-active');
+        if (oldActive && oldActive !== targetNav) {
+            oldActive.classList.add('is-leaving');
+            oldActive.classList.remove('is-active');
+            const prevTimer = leaveTimeouts.get(oldActive);
+            if (prevTimer) clearTimeout(prevTimer);
+            const timer = setTimeout(() => {
+                oldActive.classList.remove('is-leaving');
+                leaveTimeouts.delete(oldActive);
+            }, 500);
+            leaveTimeouts.set(oldActive, timer);
+        }
+        const itemTimer = leaveTimeouts.get(targetNav);
+        if (itemTimer) {
+            clearTimeout(itemTimer);
+            leaveTimeouts.delete(targetNav);
+        }
+        navItems.forEach(i => {
+            i.classList.remove('is-active', 'bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
+            i.classList.add('text-[var(--text-muted)]');
+            i.removeAttribute('aria-current');
+        });
+        targetNav.classList.add('is-active', 'bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
+        targetNav.classList.remove('text-[var(--text-muted)]', 'is-leaving');
+        targetNav.setAttribute('aria-current', 'page');
+    }
+
+    /**
+     * Fire leave callback for the previous page if leaving.
+     * @param {string} targetPage
+     */
+    function fireLeaveCallback(targetPage) {
+        const leaveKey = PAGE_LEAVE_MAP[currentPage ?? ''];
+        if (leaveKey && targetPage !== currentPage) {
+            const fn = /** @type {(() => void) | undefined} */ (/** @type {Record<string, unknown>} */ (callbacks)[leaveKey]);
+            if (fn) fn();
+        }
+    }
+
+    /**
+     * Fire enter callback for the target page.
+     * @param {string} targetPage
+     */
+    function fireEnterCallback(targetPage) {
+        const enterKey = PAGE_CALLBACK_MAP[targetPage];
+        if (enterKey) {
+            const fn = /** @type {(() => void) | undefined} */ (/** @type {Record<string, unknown>} */ (callbacks)[enterKey]);
+            if (fn) fn();
+        }
+    }
+
+    /**
+     * Internal navigation function shared by click handler and navigateTo().
+     * @param {string} targetPage
+     */
+    function navigateToInternal(targetPage) {
+        // Normalize 'home' to 'console' when console mode is enabled, so
+        // programmatic navigation follows the same redirect rule as sidebar clicks.
+        const normalizedPage = (targetPage === 'home' && appStore.get('homePageMode') === 'console')
+            ? 'console'
+            : targetPage;
+
+        // Short-circuit: no-op when navigating to the already-current page
+        if (normalizedPage === currentPage) return;
+
+        fireLeaveCallback(normalizedPage);
+        updateNavStyling(normalizedPage);
+        switchPage(normalizedPage);
+        currentPage = normalizedPage;
+        fireEnterCallback(normalizedPage);
+    }
+
+    // Expose for programmatic navigation (e.g. HOME_PAGE_MODE_CHANGED handler)
+    _navigateToRef = navigateToInternal;
 
     navItems.forEach(item => {
         item.addEventListener('click', () => {
-            const targetPage = item.getAttribute('data-nav');
-
-            // Fire leave callback for the previous page
-            if (currentPage === 'logs' && targetPage !== 'logs' && callbacks.onLeaveLogs) {
-                callbacks.onLeaveLogs();
-            }
-            if (currentPage === 'proxies' && targetPage !== 'proxies' && callbacks.onLeaveProxies) {
-                callbacks.onLeaveProxies();
-            }
-
-            // Update nav item active styling — visual (UnoCSS) + animation (is-active/is-leaving)
-            const oldActive = document.querySelector('.nav-btn.is-active');
-            if (oldActive && oldActive !== item) {
-                oldActive.classList.add('is-leaving');
-                oldActive.classList.remove('is-active');
-                const prevTimer = leaveTimeouts.get(oldActive);
-                if (prevTimer) clearTimeout(prevTimer);
-                const timer = setTimeout(() => {
-                    oldActive.classList.remove('is-leaving');
-                    leaveTimeouts.delete(oldActive);
-                }, 500);
-                leaveTimeouts.set(oldActive, timer);
-            }
-            const itemTimer = leaveTimeouts.get(item);
-            if (itemTimer) {
-                clearTimeout(itemTimer);
-                leaveTimeouts.delete(item);
-            }
-            navItems.forEach(i => {
-                i.classList.remove('is-active', 'bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
-                i.classList.add('text-[var(--text-muted)]');
-                i.removeAttribute('aria-current');
-            });
-            item.classList.add('is-active', 'bg-[var(--zephyr-bg-muted)]', 'text-[var(--text-primary)]', 'shadow-lg', 'ring-1', 'ring-[var(--zephyr-border-strong)]');
-            item.classList.remove('text-[var(--text-muted)]', 'is-leaving');
-            item.setAttribute('aria-current', 'page');
-
-            // Switch page
-            if (targetPage) switchPage(targetPage);
-            currentPage = targetPage;
-
-            // Trigger page-specific callbacks
-            if (targetPage === 'proxies' && callbacks.onProxies) {
-                callbacks.onProxies();
-            } else if (targetPage === 'advanced' && callbacks.onAdvanced) {
-                callbacks.onAdvanced();
-            } else if (targetPage === 'home' && callbacks.onHome) {
-                callbacks.onHome();
-            } else if (targetPage === 'rule-library' && callbacks.onRuleLibrary) {
-                callbacks.onRuleLibrary();
-            } else if (targetPage === 'connections' && callbacks.onConnections) {
-                callbacks.onConnections();
-            } else if (targetPage === 'logs' && callbacks.onLogs) {
-                callbacks.onLogs();
-            }
+            // navigateToInternal() applies the home → console redirect.
+            const targetPage = /** @type {HTMLElement} */ (item).dataset.nav ?? null;
+            if (targetPage) navigateToInternal(targetPage);
         });
     });
 }

--- a/apps/desktop/src/ui/node-wheel.js
+++ b/apps/desktop/src/ui/node-wheel.js
@@ -67,8 +67,8 @@ async function handleWheelProxySwitch(trigger, mainGroup, name, isSelected) {
     const nameEl = trigger.querySelector('#current-node-name');
     if (nameEl) {
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey]);
-        nameEl.textContent = t.switching || "Switching...";
+        const t = /** @type {Record<string, unknown>} */(translations[langKey]);
+        nameEl.textContent = String(t.switching || "Switching...");
     }
     closeWheel();
     abortLatencyTests();
@@ -150,10 +150,10 @@ async function populateAndShowWheel(trigger, dropdown, scrollContainer, list, up
         // a brief loading hint instead of an empty dropdown.
         if (proxies.length === 0) {
             const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-            const tObj = /** @type {Record<string, string>} */(translations[langKey]);
+            const tObj = /** @type {Record<string, unknown>} */(translations[langKey]);
             const hint = document.createElement('div');
             hint.className = 'px-3 py-2 text-xs text-[var(--text-muted)] text-center';
-            hint.textContent = tObj?.loadingNodes || 'Loading nodes...';
+            hint.textContent = String(tObj?.loadingNodes || 'Loading nodes...');
             /** @type {any} */ (list)._virtObserver?.disconnect();
             list.replaceChildren();
             list.appendChild(hint);

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -2163,7 +2163,7 @@ const _renderExplanationBarFromStore = debounce(async () => {
     const proxiesPage = document.querySelector('[data-page="proxies"]');
     if (proxiesPage && !proxiesPage.classList.contains('hidden')) {
         try {
-            const data = await getProxiesCached();
+            const data = await getProxiesCached().then(getProxiesMerged);
             const uiGroupName = appStore.get('uiGroupName');
             const effectiveGroupName = appStore.get('effectiveGroupName');
             const observedGroupName = appStore.get('observedGroupName');
@@ -2202,7 +2202,7 @@ const updateCapsuleDisplay = () => {
     const currentGroupName = currentNodeEl.dataset.group;
     if (!currentGroupName) return;
 
-    getProxiesCached().then(data => {
+    getProxiesCached().then(getProxiesMerged).then(data => {
         // Verify the group hasn't changed during the async API call to prevent race conditions
         if (currentNodeEl.dataset.group !== currentGroupName) return;
 

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -24,8 +24,7 @@ import {
     setSecret,
     setBaseUrl,
 } from '../api.js';
-import { setWsSecret, setWsBaseUrl, connectTraffic } from '../websocket.js';
-import { updateTrafficData } from '../modules/traffic-chart.js';
+import { setWsSecret, setWsBaseUrl, forceReconnect } from '../websocket.js';
 import { translations, setLanguage } from '../i18n.js';
 import { debounce } from '../utils/debounce.js';
 import { settingsLogger } from '../utils/logger.js';
@@ -55,8 +54,9 @@ import * as prism from './prism.js';
 // The following modules have not yet been extracted from ui.js.
 // We import them from ui.js for now; when they are extracted, these
 // imports will be updated to point to their own files.
-import { switchPage } from './navigation.js';
+import { navigateTo } from './navigation.js';
 import { initCustomDropdown } from './dropdown.js';
+import { registerCleanup } from '../utils/cleanup-registry.js';
 import { syncCoreConfig, startSmartAutoTest, stopSmartAutoTest } from './proxies.js';
 
 // Settings submodules
@@ -862,7 +862,7 @@ function initFakeClient() {
 // ---------------------------------------------------------------------------
 export async function initSettings() {
     // Portable mode: hide unsupported options
-    const isPortable = await invoke('get_portable_mode');
+    const isPortable = await invoke(COMMANDS.GET_PORTABLE_MODE);
     if (isPortable) {
         const autostartRow = document.getElementById('row-autostart');
         const clientUpdateRow = document.getElementById('row-client-update');
@@ -917,21 +917,22 @@ export async function initSettings() {
 
     // ---- Subscription & Config management (delegated to settings/subscriptions.js) ----
     // Initialized early so renderConfigs is available for language dropdown and drag-drop listeners.
-    const subApi = initSubscriptionSettings({
-        subAddBtn: document.getElementById('add-sub-btn'),
-        updateAllSubBtn: document.getElementById('update-all-sub-btn'),
-        configsList,
-    });
-    const renderConfigs = subApi.renderConfigs;
+const subApi = initSubscriptionSettings({
+subAddBtn: document.getElementById('add-sub-btn'),
+updateAllSubBtn: document.getElementById('update-all-sub-btn'),
+configsList,
+});
+const renderConfigs = subApi.renderConfigs;
+/** Store destroy for cleanup during settings reset/teardown. */
+const _destroySubscriptionSettings = subApi.destroy;
+if (typeof _destroySubscriptionSettings === 'function') {
+    registerCleanup(_destroySubscriptionSettings);
+}
 
     // ---- Advanced settings navigation ----
     if (gotoAdvancedBtn) {
         gotoAdvancedBtn.onclick = () => {
-            switchPage('advanced');
-            // renderAdvancedSettings lives in ui.js (or its future module);
-            // it is called via the navigation handler in initNavigation.
-            // We import it lazily to avoid circular deps.
-            import('./advanced.js').then(m => m.renderAdvancedSettings?.()).catch(() => {});
+            navigateTo('advanced');
         };
     }
 
@@ -945,7 +946,7 @@ export async function initSettings() {
 
     if (backSettingsBtn) {
         backSettingsBtn.onclick = () => {
-            switchPage('settings');
+            navigateTo('settings');
         };
     }
 
@@ -1069,6 +1070,56 @@ export async function initSettings() {
     if (settings.ui_scale && settings.ui_scale > 0) {
         applyUiScale(settings.ui_scale);
     }
+
+    // ---- Home page mode ----
+    const homeModeSlider = document.getElementById('setting-home-mode-slider');
+    const homeModeButtons = document.querySelectorAll('[data-home-mode]');
+    /** @param {string} mode */
+    const setHomeModeUI = (mode) => {
+        const isConsole = mode === 'console';
+        if (homeModeSlider) homeModeSlider.style.transform = isConsole ? 'translateX(100%)' : 'translateX(0)';
+        homeModeButtons.forEach((btn) => {
+            const btnMode = /** @type {HTMLElement} */ (btn).dataset.homeMode;
+            const isSelected = btnMode === mode;
+            btn.setAttribute('aria-pressed', String(isSelected));
+            if (isSelected) {
+                btn.classList.remove('text-[var(--text-secondary)]');
+                btn.classList.add('text-[var(--text-primary)]');
+            } else {
+                btn.classList.add('text-[var(--text-secondary)]');
+                btn.classList.remove('text-[var(--text-primary)]');
+            }
+        });
+    };
+    const savedHomePageMode = settings.home_page_mode === 'console' ? 'console' : 'minimal';
+    setHomeModeUI(savedHomePageMode);
+    appStore.set('homePageMode', savedHomePageMode);
+    /** @type {boolean} In-flight guard for home-mode PATCH_SETTINGS. */
+    let homeModeBusy = false;
+    homeModeButtons.forEach((btn) => {
+        btn.addEventListener('click', async () => {
+            const mode = /** @type {HTMLElement} */ (btn).dataset.homeMode;
+            if (!mode || homeModeBusy) return;
+            const previous = appStore.get('homePageMode') || 'minimal';
+            if (mode === previous) return; // no-op: skip network round trip
+            homeModeBusy = true;
+            // Optimistically update UI, revert on failure
+            setHomeModeUI(mode);
+            appStore.set('homePageMode', mode);
+            try {
+                await invoke(COMMANDS.PATCH_SETTINGS, { patch: { home_page_mode: mode } });
+                invalidateSettingsCache();
+                Bus.emit(Events.HOME_PAGE_MODE_CHANGED, { mode, previous });
+            } catch (err) {
+                settingsLogger.error('Failed to save home_page_mode', err);
+                setHomeModeUI(previous);
+                appStore.set('homePageMode', previous);
+                showNotification(toError(err).message, 'error');
+            } finally {
+                homeModeBusy = false;
+            }
+        });
+    });
 
     // ---- Theme + Opacity (delegated to settings/theme.js) ----
     const _themeApi = initThemeSettings({
@@ -1250,10 +1301,20 @@ export async function initSettings() {
                 }
                 successItems.push('themeColor');
 
-                await trackResult('appSettings', async () => {
+                const appSettingsSaved = await trackResult('appSettings', async () => {
+                    settings.home_page_mode = 'minimal';
                     await invoke(COMMANDS.SAVE_SETTINGS, { settings });
                 });
                 invalidateSettingsCache();
+                if (appSettingsSaved) {
+                    const previousHomeMode = appStore.get('homePageMode') || 'minimal';
+                    appStore.set('homePageMode', 'minimal');
+                    setHomeModeUI('minimal');
+                    // Emit event so main.js switches the visible page if needed
+                    if (previousHomeMode !== 'minimal') {
+                        Bus.emit(Events.HOME_PAGE_MODE_CHANGED, { mode: 'minimal', previous: previousHomeMode });
+                    }
+                }
 
                 // Re-render proxy list after settings are persisted (node_scroll CSS class depends on backend value)
                 const proxyContainer = document.getElementById('proxies-list');
@@ -1881,10 +1942,16 @@ appStore.set('isNetworkUpdating', false);
             setSecret(coreResult.secret);
             setWsSecret(coreResult.secret);
 
-            // Reconnect traffic WebSocket to the new core instance
-            connectTraffic((/** @type {any} */ data) => {
-                updateTrafficData(data);
-            });
+            // Reconnect traffic WebSocket to the new core instance.
+            // Use forceReconnect() instead of connectTraffic() to preserve
+            // the original callback (which emits TRAFFIC_UPDATE for the
+            // console dashboard). Store the returned handle so callers can
+            // close the new connection during teardown.
+            const newHandle = forceReconnect();
+            if (newHandle) {
+                // Dispatch a CORE_RESTARTED event so main.js updates _trafficWsHandle
+                Bus.emit(Events.CORE_RESTARTED, { handle: newHandle });
+            }
 
             showNotification(t.notifUpdateSuccess, 'success');
             await loadCoreVersion();

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -20,6 +20,7 @@ import { rulesLogger } from '../../utils/logger.js';
 import { showNotification, showModal, showConfirmModal } from '../notifications.js';
 import { appStore } from '../state.js';
 import { getSettingsCached, getConfigsCached, invalidateSettingsCache, invalidateConfigsCache } from '../cache.js';
+import { Bus, Events } from '../events.js';
 import { formatFileSize } from '../../utils/format.js';
 import { escapeHtml, escapeAttr } from '../../utils/sanitize.js';
 import { removeContextMenu, createContextMenuContainer, attachContextMenuCloseHandlers } from '../../utils/context-menu.js';
@@ -1439,10 +1440,22 @@ export function initSubscriptionSettings({
     // Initial render
     renderConfigs();
 
+    // Auto-refresh when config changes (e.g. subscription switch from console).
+    // Skip the expensive re-render when the settings list is not visible,
+    // but still invalidate caches so data is fresh when the user returns.
+    const _configUpdatedUnsub = Bus.on(Events.CONFIG_UPDATED, () => {
+        invalidateSettingsCache();
+        invalidateConfigsCache();
+        const isVisible = configsList && !configsList.closest('.hidden');
+        if (!isVisible) return;
+        renderConfigs().catch((e) => rulesLogger.warn('[settings] renderConfigs failed after CONFIG_UPDATED', e));
+    });
+
     // Set module-level reference for use by showEditPanel
     moduleRenderConfigs = renderConfigs;
 
     return {
         renderConfigs,
+        destroy: () => { _configUpdatedUnsub(); },
     };
 }

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -387,6 +387,7 @@ export const appStore = createStore('zephyr.app', {
     currentTheme: lsGet('appTheme') || 'purple',
     currentLang: lsGet('lang') || detectSystemLanguage(),
     currentPage: 'home',
+    homePageMode: 'minimal', // 'minimal' or 'console' — synced from settings.json
     currentThemeMode: 'auto', // Actual value synced from settings.json in initSettings()
 
     // Proxy state

--- a/apps/desktop/src/ui/sysproxy.js
+++ b/apps/desktop/src/ui/sysproxy.js
@@ -41,6 +41,32 @@ export async function updateSysProxyUI() {
     }
 }
 
+/**
+ * Apply sys-proxy enable/disable to the backend and sync appStore.
+ * Extracted from the toggle change handler so console-home can call it
+ * directly without relying on DOM event dispatching.
+ * @param {boolean} enabled
+ * @throws {unknown} Re-throws the backend error so callers can handle
+ *   notification and UI rollback.
+ */
+export async function setSysProxyEnabled(enabled) {
+    /** @type {Record<string, any>} */
+    const currentConfig = await getConfig();
+    const currentPort = currentConfig?.['mixed-port'] || currentConfig?.port || currentConfig?.['socks-port'] || 7890;
+
+    if (enabled) {
+        await invoke(COMMANDS.ENABLE_SYSPROXY, {
+            server: `127.0.0.1:${currentPort}`,
+            bypass: null,
+        });
+    } else {
+        await invoke(COMMANDS.DISABLE_SYSPROXY);
+    }
+
+    appStore.set('isSysProxyEnabled', enabled);
+    updateSysProxyUI();
+}
+
 export async function initProxyToggle() {
     const toggle = /** @type {HTMLInputElement|null} */ (document.getElementById('sys-proxy-toggle'));
     const statusText = document.getElementById('proxy-status-text');
@@ -62,28 +88,13 @@ export async function initProxyToggle() {
         const enabled = target.checked;
 
         try {
-            /** @type {Record<string, any>} */
-            const currentConfig = await getConfig();
-            const currentPort = currentConfig?.['mixed-port'] || currentConfig?.port || currentConfig?.['socks-port'] || 7890;
-
-            if (enabled) {
-                await invoke(COMMANDS.ENABLE_SYSPROXY, {
-                    server: `127.0.0.1:${currentPort}`,
-                    bypass: null,
-                });
-            } else {
-                await invoke(COMMANDS.DISABLE_SYSPROXY);
-            }
-
-            appStore.set('isSysProxyEnabled', enabled);
-            // Reactive: bind() and subscribe() in initReactiveBindings() handle UI updates
+            await setSysProxyEnabled(enabled);
         } catch (err) {
             sysproxyLogger.error('Failed to set sys proxy', err);
             const t = /** @type {Record<string, string>} */ (/** @type {any} */ (translations)[currentLang]);
             showNotification(`${t.errorPrefix || 'Error'}: ${err}`, 'error');
-            toggle.checked = !enabled;
+            target.checked = !enabled;
             appStore.set('isSysProxyEnabled', !enabled);
-            // Reactive: subscribe() in initReactiveBindings() handles tray updates
         }
     });
 }

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -53,7 +53,7 @@ export async function updateTrayMenu(forceRefresh = false) {
     const useCache = !forceRefresh && (now - trayMenuCache.lastUpdate) < TRAY_CACHE_TTL;
 
     const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-    const t = /** @type {Record<string, string>} */(translations[langKey]);
+    const t = /** @type {Record<string, unknown>} */(translations[langKey]);
 
     const sysProxyEnabled = appStore.get('isSysProxyEnabled');
     const tunEnabled = appStore.get('isTunEnabled');
@@ -226,7 +226,7 @@ export async function initTrayEventListeners() {
         const ev = event;
         const subName = ev.payload;
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey]);
+        const t = /** @type {Record<string, unknown>} */(translations[langKey]);
 
         try {
             /** @type {any} */
@@ -294,8 +294,8 @@ export async function initTrayEventListeners() {
     // Rust now handles the clipboard write via arboard, so we just show the notification.
     const unlisten6 = await listen('tray-copy-env-done', async () => {
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey] || {});
-        showNotification(t.trayCopyEnvSuccess || 'Proxy env vars copied', 'info');
+        const t = /** @type {Record<string, unknown>} */(translations[langKey] || {});
+        showNotification(String(t.trayCopyEnvSuccess || 'Proxy env vars copied'), 'info');
     });
     _trayEventUnlisteners.push(unlisten6);
 
@@ -304,7 +304,7 @@ export async function initTrayEventListeners() {
         /** @type {any} */
         const ev = event;
         const langKey = /** @type {'en'|'zh'|'ja'|'ko'} */(currentLang);
-        const t = /** @type {Record<string, string>} */(translations[langKey] || {});
+        const t = /** @type {Record<string, unknown>} */(translations[langKey] || {});
         showNotification(`${t.trayCopyEnvFailed || 'Failed to copy proxy env'}: ${ev.payload}`, 'error');
     });
     _trayEventUnlisteners.push(unlisten7);

--- a/apps/desktop/src/ui/window-controls.js
+++ b/apps/desktop/src/ui/window-controls.js
@@ -6,7 +6,8 @@
  * @module ui/window-controls
  */
 
-import { getCurrentWindow } from '../api.js';
+import { getCurrentWindow, invoke, listen } from '../api.js';
+import { registerCleanup } from '../utils/cleanup-registry.js';
 
 /**
  * Initialize window control event listeners.
@@ -35,4 +36,30 @@ export function initWindowControls() {
             /** @type {HTMLImageElement} */ (this).src = 'app-icon.png';
         }, { once: true });
     }
+
+    // Sync the is-maximized class on <html> so CSS can disable the
+    // overlay clip-path rounding when the window is maximized.
+    // Tauri's window-state plugin restores maximized state on startup,
+    // so we check immediately and listen for future changes.
+    const syncMaximized = async () => {
+        try {
+            const isMaximized = await invoke('plugin:window|is_maximized', { label: getCurrentWindow().label });
+            document.documentElement.classList.toggle('is-maximized', !!isMaximized);
+        } catch { /* non-Tauri environment */ }
+    };
+    syncMaximized();
+    // Listen for Tauri resize events (fires on maximize/unmaximize/restore and
+    // repeatedly during a drag-resize, so coalesce bursts into one check).
+    /** @type {number|null} */
+    let syncTimer = null;
+    const scheduleSync = () => {
+        if (syncTimer !== null) clearTimeout(syncTimer);
+        syncTimer = setTimeout(() => { syncTimer = null; syncMaximized(); }, 120);
+    };
+    listen('tauri://resize', scheduleSync).then((unlisten) => {
+        registerCleanup(() => {
+            if (syncTimer !== null) clearTimeout(syncTimer);
+            unlisten();
+        });
+    }).catch(() => {});
 }

--- a/apps/desktop/src/websocket.js
+++ b/apps/desktop/src/websocket.js
@@ -54,6 +54,9 @@ let _connectionState = ConnectionState.DISCONNECTED;
 /** @type {{close: Function, reconnect: Function, isMaxRetriesReached: Function} | null} */
 let globalConnectionHandle = null;
 
+/** @type {Function | null} Stored callback so forceReconnect() can re-create the stream. */
+let _trafficCallback = null;
+
 /** @type {Function | null} */
 let connectionLostCallback = null;
 
@@ -99,11 +102,20 @@ export function onConnectionLost(callback) {
 /**
  * Programmatically trigger a reconnection attempt.
  * Resets retry counters and aborts the current stream.
+ * If the handle was released by close(), creates a new connection with the
+ * stored callback and returns the new handle. The caller must replace its
+ * own handle reference with the returned value.
+ * @returns {ReturnType<typeof connectTraffic> | null}
  */
 export function forceReconnect() {
   if (globalConnectionHandle) {
     globalConnectionHandle.reconnect();
+    return globalConnectionHandle;
+  } else if (_trafficCallback) {
+    // Handle was lost — re-create the stream with the stored callback.
+    return connectTraffic(_trafficCallback);
   }
+  return null;
 }
 
 /**
@@ -172,11 +184,15 @@ function setState(newState) {
  * @returns {{ close: Function, reconnect: Function, isMaxRetriesReached: Function }}
  */
 export function connectTraffic(callback) {
-  // Close any existing connection to prevent resource leaks
+  // Close any existing connection to prevent resource leaks.
+  // Must happen before storing the callback, because close() clears
+  // _trafficCallback when it releases the global handle.
   if (globalConnectionHandle) {
     globalConnectionHandle.close();
     globalConnectionHandle = null;
   }
+  // Store callback so forceReconnect() can re-create the stream if the handle is lost.
+  _trafficCallback = callback;
 
   /** @type {AbortController} */
   let abortController = new AbortController();
@@ -429,6 +445,7 @@ export function connectTraffic(callback) {
       setState(ConnectionState.DISCONNECTED);
       if (globalConnectionHandle === handle) {
         globalConnectionHandle = null;
+        _trafficCallback = null;
       }
     },
 

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -17,6 +17,7 @@ export const CORE = Object.freeze({
     START_CORE: "start_core",
     STOP_CORE: "stop_core",
     GET_CORE_VERSION: "get_core_version",
+    GET_CORE_UPTIME: "get_core_uptime",
     READ_CONFIG: "read_config",
     UPDATE_CONFIG: "update_config",
     READ_LOG: "read_core_log",
@@ -138,6 +139,7 @@ export const SETTINGS = Object.freeze({
 
 export const MISC = Object.freeze({
     GET_APP_VERSION: "get_app_version",
+    GET_PORTABLE_MODE: "get_portable_mode",
     SHOW_MAIN_WINDOW: "show_main_window",
     SEND_NOTIFICATION: "rate_limited_send_notification",
     EXEMPT_UWP_APPS: "exempt_uwp_apps",


### PR DESCRIPTION
## Console Dashboard Home Page

Adds a new console-style home dashboard with real-time traffic, node controls, subscription info, and quick settings toggles.

### Changes vs main:
- **Console home page** (`console-home.js`): Real-time traffic chart, connection list (top 5), node latency, subscription card, quick controls (mode selector, sys proxy, TUN toggle), log stream, and event feed
- **Navigation refactor** (`navigation.js`): Export `navigateTo()` for programmatic page switching with lifecycle callbacks; early return in `updateNavStyling` when target page has no sidebar item; normalize home to console redirect in `navigateToInternal`; type-safe dynamic callback indexing
- **Settings integration** (`settings.js`): Use `navigateTo()` instead of `switchPage()`; initialize `appStore.homePageMode` from loaded settings; use `COMMANDS.GET_PORTABLE_MODE` constant
- **Backend uptime** (`core_process.rs`): Monotonic `Instant`-based uptime tracking; clear stale ports on process exit; `clear_stopped_core_state` helper takes process before clearing state to prevent Child handle loss
- **WebSocket fix** (`websocket.js`): `forceReconnect()` falls back to `connectTraffic()` when handle is lost; `close()` clears `_trafficCallback`
- **Window controls** (`window-controls.js`): Sync `is-maximized` class with debounced resize listener and `registerCleanup` teardown
- **Capabilities** (`default.json`): Add `core:window:allow-is-maximized` permission
- **i18n** (`i18n.js`): Add all console keys + homePageMode + coreUpdateAvailable to en/zh/ja/ko dictionaries
- **main.js**: Extract `startCoreAndConfigure()` and `scheduleAutoUpdateCheck()`; use `COMMANDS.GET_PORTABLE_MODE`; check `auto_update_client` before portable mode probe; notify on single-update availability
- **Accessibility**: `aria-labelledby` on toggle switches; `Intl.DateTimeFormat` with app locale
- **Safety**: `isInitialized` moved to end of `initConsoleHome()` with cleanup rollback on failure; `fetchCoreUptime()` deferred to `activateConsole()`; `registerCleanup` unregister functions retained for proper teardown
- **Pre-existing fixes**: `styles.css` clip-path rounding disabled for maximized windows; `lib.rs` Settings construction uses `..Default::default()`; `home_page_mode` validated to only accept 'minimal' or 'console'; duplicate `renderAdvancedSettings()` call removed

## Summary by Sourcery

Introduce a console-style dashboard home page with real-time traffic, node controls, subscription usage, and integrate it into navigation, settings, backend uptime tracking, and i18n.

New Features:
- Add a console dashboard home page with traffic chart, connection list, node latency card, quick controls, and log/event feeds.
- Provide a user-selectable home page mode toggle between minimal and console dashboard views.
- Expose core uptime over IPC for use by the console dashboard and UI.
- Add per-language i18n strings for the console dashboard, home page mode, and core update notifications.

Bug Fixes:
- Ensure WebSocket traffic reconnection recovers from lost handles and preserves callbacks.
- Fix maximized window visual artifacts by syncing an is-maximized class and adjusting clip-path styling.
- Prevent duplicate or stale event subscribers by allowing multiple subscribers with safe teardown.
- Avoid stale ports and lost process handles when stopping the core by centralizing state clearing logic.
- Handle non-string translation values safely in i18n consumers across logs, tray, node wheel, and advanced config UI.

Enhancements:
- Refactor app startup to separate core startup/configuration and auto-update scheduling.
- Extend navigation with programmatic navigateTo support, lifecycle callbacks for console, and home→console normalization based on settings.
- Wire traffic, proxies, sysproxy, TUN, subscription, and events modules into a shared event bus for the console dashboard.
- Improve subscription settings lifecycle with destroy hooks and automatic refresh on config updates.
- Improve proxies layout responsiveness and auto-fill behavior and centralize proxy-merging logic with tests.

Build:
- Expose new core and misc commands (GET_CORE_UPTIME, GET_PORTABLE_MODE) in the shared command constants.

Tests:
- Add tests for SPECIAL_PROXY_NAMES and getProxiesMerged, including provider cache handling and edge cases.

Chores:
- Normalize default Settings construction using Rust struct update syntax with ..Default::default().