### PR TITLE
feat(i18n): add Japanese and Korean to language selector

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -423,11 +423,15 @@
                                         <div class="menu-scroll">
                                             <button type="button" data-lang-value="en" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">English</button>
                                             <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">简体中文</button>
+                                            <button type="button" data-lang-value="ja" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">日本語</button>
+                                            <button type="button" data-lang-value="ko" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">한국어</button>
                                         </div>
                                     </div>
                                     <select id="setting-lang" class="hidden">
                                         <option value="en">English</option>
                                         <option value="zh">简体中文</option>
+                                        <option value="ja">日本語</option>
+                                        <option value="ko">한국어</option>
                                     </select>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary

Add Japanese (鏃ユ湰瑾? and Korean (頃滉淡鞏? options to the language selector dropdown in the settings page.

## Changes

- `apps/desktop/src/index.html`: Added ja and ko options to both the custom dropdown buttons (data-lang-value) and the hidden <select> element.

The i18n.js already contains complete 	ranslations.ja and 	ranslations.ko (726 keys each). The setLanguage() function in i18n.js already supports 'ja' and 'ko' 鈥?no JS logic changes needed. The initCustomDropdown in dropdown.js auto-discovers options from HTML, so the new entries work immediately.

## Summary by Sourcery

New Features:
- Expose Japanese and Korean as selectable languages in the settings page language dropdown.