### PR TITLE
feat: full RTL infrastructure for desktop app

### DIFF
--- a/apps/desktop/src/i18n.js
+++ b/apps/desktop/src/i18n.js
@@ -3245,12 +3245,33 @@ export function t(key, optionsOrCount, extraVars) {
 /**
  * Set `lang` and `dir` attributes on the <html> element for a given language.
  * Uses BCP 47 format for the lang attribute and detects RTL/LTR direction.
+ * Also ensures CSS custom properties (--rtl-sign, --scroll-fade-dir) stay in sync.
  * @param {string} language - ISO 639-1 language code (e.g. 'en', 'zh', 'ar')
  */
 export function setHTMLAttributes(language) {
     const html = document.documentElement;
     html.setAttribute('lang', language);
     html.setAttribute('dir', isRTL(language) ? 'rtl' : 'ltr');
+}
+
+/**
+ * Get the current text direction ('ltr' or 'rtl').
+ * Reads from the <html> element's `dir` attribute, which is kept in sync
+ * by `setHTMLAttributes()` / `setLanguage()`.
+ * @returns {'ltr'|'rtl'}
+ */
+export function getDirection() {
+    return document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr';
+}
+
+/**
+ * Get the RTL sign multiplier: 1 for LTR, -1 for RTL.
+ * Use this in JS for directional math (e.g. `translateX(sign * px)`).
+ * For CSS, prefer `var(--rtl-sign)` instead — it updates automatically.
+ * @returns {number}
+ */
+export function getRTLSign() {
+    return getDirection() === 'rtl' ? -1 : 1;
 }
 
 /**

--- a/apps/desktop/src/i18n.test.js
+++ b/apps/desktop/src/i18n.test.js
@@ -6,6 +6,9 @@ import {
     setQAMode,
     isQAMode,
     getLocAttributes,
+    getDirection,
+    getRTLSign,
+    setHTMLAttributes,
     mapStatusMessage,
 } from './i18n.js';
 
@@ -120,6 +123,49 @@ describe('getLocAttributes', () => {
     it('returns only dir and lang properties', () => {
         const attrs = getLocAttributes('en-US');
         expect(Object.keys(attrs).sort()).toEqual(['dir', 'lang']);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  getDirection & getRTLSign
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('getDirection', () => {
+    afterEach(() => {
+        document.documentElement.removeAttribute('dir');
+        document.documentElement.removeAttribute('lang');
+    });
+
+    it('returns "ltr" when dir is not set', () => {
+        document.documentElement.removeAttribute('dir');
+        expect(getDirection()).toBe('ltr');
+    });
+
+    it('returns "ltr" for LTR languages', () => {
+        setHTMLAttributes('en');
+        expect(getDirection()).toBe('ltr');
+    });
+
+    it('returns "rtl" for RTL languages', () => {
+        setHTMLAttributes('ar');
+        expect(getDirection()).toBe('rtl');
+    });
+});
+
+describe('getRTLSign', () => {
+    afterEach(() => {
+        document.documentElement.removeAttribute('dir');
+        document.documentElement.removeAttribute('lang');
+    });
+
+    it('returns 1 for LTR', () => {
+        setHTMLAttributes('en');
+        expect(getRTLSign()).toBe(1);
+    });
+
+    it('returns -1 for RTL', () => {
+        setHTMLAttributes('ar');
+        expect(getRTLSign()).toBe(-1);
     });
 });
 

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN" class="bg-transparent h-screen w-screen overflow-hidden">
+<html lang="zh-CN" dir="ltr" class="bg-transparent h-screen w-screen overflow-hidden">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -20,12 +20,12 @@
         <!-- Page Background Glows (shared layer, above sidebar but below content) -->
         <div id="glow-home" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-accent/10 blur-[120px] pointer-events-none rounded-full z-0"></div>
         <div id="glow-console" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-accent/10 blur-[120px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-subscriptions" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-proxies" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-connections" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-cyan/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-rule-library" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
-        <div id="glow-logs" class="absolute top-[6%] right-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
-        <div id="glow-settings" class="absolute top-[6%] left-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
+        <div id="glow-subscriptions" class="absolute top-[6%] end-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-proxies" class="absolute top-[6%] end-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-connections" class="absolute top-[6%] start-[5%] w-[500px] h-[300px] bg-cyan/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-rule-library" class="absolute top-[6%] end-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
+        <div id="glow-logs" class="absolute top-[6%] end-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden"></div>
+        <div id="glow-settings" class="absolute top-[6%] start-[5%] w-[500px] h-[300px] bg-accent/5 blur-[100px] pointer-events-none rounded-full z-0 hidden transition-colors duration-500"></div>
         <div id="glow-advanced" class="absolute top-[6%] left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-blue-600/10 blur-[120px] pointer-events-none rounded-full z-0 hidden"></div>
 
         <!-- Sidebar -->
@@ -90,7 +90,7 @@
 
                 <div class="flex flex-col items-center justify-center py-12 relative z-10">
                     <!-- Current Node Display (Interactive Wheel) -->
-                    <div id="node-wheel-container" class="absolute top-0 left-0 right-0 flex justify-center z-[var(--z-sticky)] perspective-1000 h-8 mt-2">
+                    <div id="node-wheel-container" class="absolute top-0 inset-inline-0 flex justify-center z-[var(--z-sticky)] perspective-1000 h-8 mt-2">
                         <button type="button" id="node-wheel-trigger" class="absolute top-0 px-4 py-1.5 rounded-full bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] flex items-center gap-2 backdrop-blur-md cursor-pointer transition-[transform,color,box-shadow] duration-[var(--zephyr-time-standard)] hover:scale-[1.02] hover:bg-[var(--zephyr-bg-muted)] hover:shadow-[var(--zephyr-shadow-sm)] z-20" aria-haspopup="listbox" aria-expanded="false">
                             <span class="w-2 h-2 rounded-full bg-accent animate-pulse shadow-[var(--zephyr-shadow-glow)]" aria-hidden="true"></span>
                             <span id="current-node-name" class="text-xs text-[var(--text-primary)] font-semibold tracking-wide truncate max-w-[280px]">Loading...</span>
@@ -161,7 +161,7 @@
                             <h3 class="text-xs font-bold text-[var(--text-primary)] tracking-tight" data-i18n="mode">Proxy Mode</h3>
                         </div>
                         <div id="mode-selector-container" class="relative grid grid-cols-3 items-stretch p-1 bg-[var(--zephyr-bg-muted)] rounded-lg border border-[var(--zephyr-border-subtle)] h-9 transition-all duration-[var(--zephyr-time-standard)]">
-                            <div id="mode-slider" class="absolute top-1 bottom-1 left-1 w-[calc((100%-8px)/3)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
+                            <div id="mode-slider" class="absolute top-1 bottom-1 start-1 w-[calc((100%-8px)/3)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
                             <button data-mode="rule" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="rule">Rule</button>
                             <button data-mode="global" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="global">Global</button>
                             <button data-mode="direct" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="direct">Direct</button>
@@ -182,7 +182,7 @@
     <span class="switch-slider"></span>
 </label>
                         </div>
-                        <div class="mt-auto pl-1 flex items-center gap-2">
+                        <div class="mt-auto ps-1 flex items-center gap-2">
                             <div id="tun-spinner" class="hidden w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin transition-all"></div>
                             <p class="text-2xs text-[var(--text-muted)] font-medium transition-colors" id="tun-status-text" data-i18n="virtualAdapter">Virtual Adapter</p>
                         </div>
@@ -240,7 +240,7 @@
                     </div>
                 </header>
 
-                <div id="configs-list" class="flex-1 overflow-y-auto space-y-3 pr-2 pt-2 -mt-2 -mb-8 custom-scrollbar relative z-10">
+                <div id="configs-list" class="flex-1 overflow-y-auto space-y-3 pe-2 pt-2 -mt-2 -mb-8 custom-scrollbar relative z-10">
                     <!-- Subscriptions will be rendered here -->
                 </div>
 
@@ -268,14 +268,14 @@
                                     <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                     <span data-i18n="overrideNew">新建</span>
                                 </button>
-                                <div id="plugin-new-dropdown" class="hidden absolute right-0 mt-2 z-50 flex flex-col gap-1 bg-[var(--zephyr-bg-elevated)] border border-[var(--zephyr-border-default)] rounded-lg p-2 shadow-2xl min-w-[160px]">
-                                    <button class="text-xs text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="new-js"><span data-i18n="overrideNewJs">New JS Override</span></button>
-                                    <button class="text-xs text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="new-prism"><span data-i18n="overrideNewPrism">New Prism YAML</span></button>
+                                <div id="plugin-new-dropdown" class="hidden absolute end-0 mt-2 z-50 flex flex-col gap-1 bg-[var(--zephyr-bg-elevated)] border border-[var(--zephyr-border-default)] rounded-lg p-2 shadow-2xl min-w-[160px]">
+                                    <button class="text-xs text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="new-js"><span data-i18n="overrideNewJs">New JS Override</span></button>
+                                    <button class="text-xs text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="new-prism"><span data-i18n="overrideNewPrism">New Prism YAML</span></button>
                                     <div class="h-px bg-[var(--zephyr-border-subtle)] my-1"></div>
-                                    <button class="text-xs text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="import-url"><span data-i18n="overrideImportUrl">Import from URL</span></button>
+                                    <button class="text-xs text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="import-url"><span data-i18n="overrideImportUrl">Import from URL</span></button>
                                     <div class="h-px bg-[var(--zephyr-border-subtle)] my-1"></div>
-                                    <button class="text-xs text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="export-all"><span data-i18n="overrideExportAll">Export All</span></button>
-                                    <button class="text-xs text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="import-file"><span data-i18n="overrideImportFile">Import from File</span></button>
+                                    <button class="text-xs text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="export-all"><span data-i18n="overrideExportAll">Export All</span></button>
+                                    <button class="text-xs text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] hover:bg-[var(--zephyr-bg-muted)] text-[var(--text-secondary)]" data-action="import-file"><span data-i18n="overrideImportFile">Import from File</span></button>
                                 </div>
                             </div>
                             <button id="plugin-enable-all-btn" class="btn-ghost text-xs px-2 py-1.5" data-i18n="overrideEnableAll">启用全部</button>
@@ -306,7 +306,7 @@
                                         <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
                                         <span data-i18n="overrideFullscreen">全屏</span>
                                     </button>
-                                    <span id="plugin-script-status" class="text-2xs ml-auto"></span>
+                                    <span id="plugin-script-status" class="text-2xs ms-auto"></span>
                                 </div>
                                 <!-- Collapsible output -->
                                 <div id="plugin-script-output-wrap" class="bg-[var(--zephyr-bg-input)] border border-[var(--zephyr-border-subtle)] rounded-lg shrink-0">
@@ -384,7 +384,7 @@
                         <button type="button" id="rl-btn-import" class="px-3 py-1.5 text-sm rounded-lg bg-accent/20 text-accent hover:bg-accent/30 transition-colors duration-[var(--zephyr-time-micro)]" data-i18n="ruleLibraryImport">Import Rules</button>
                     </div>
                 </header>
-                <div id="rl-content" class="flex-1 overflow-y-auto custom-scrollbar pr-2 pt-2 -mt-2 -mb-8 space-y-4 relative z-10">
+                <div id="rl-content" class="flex-1 overflow-y-auto custom-scrollbar pe-2 pt-2 -mt-2 -mb-8 space-y-4 relative z-10">
                     <!-- Rendered by rule-library.js -->
                 </div>
             </div>
@@ -398,8 +398,8 @@
 
                     <!-- 1. Appearance -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsAppearance">Appearance</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsAppearanceDesc">Interface language, theme, color and window transparency</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsAppearance">Appearance</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsAppearanceDesc">Interface language, theme, color and window transparency</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Language -->
                             <div class="flex items-center justify-between">
@@ -419,12 +419,12 @@
                                             <path d="m6 9 6 6 6-6"></path>
                                         </svg>
                                     </button>
-                                    <div id="setting-lang-menu" class="hidden absolute right-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                                    <div id="setting-lang-menu" class="hidden absolute end-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
                                         <div class="menu-scroll">
-                                            <button type="button" data-lang-value="en" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">English</button>
-                                            <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">简体中文</button>
-                                            <button type="button" data-lang-value="ja" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">日本語</button>
-                                            <button type="button" data-lang-value="ko" class="setting-lang-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">한국어</button>
+                                            <button type="button" data-lang-value="en" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">English</button>
+                                            <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">简体中文</button>
+                                            <button type="button" data-lang-value="ja" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">日本語</button>
+                                            <button type="button" data-lang-value="ko" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">한국어</button>
                                         </div>
                                     </div>
                                     <select id="setting-lang" class="hidden">
@@ -450,7 +450,7 @@
                                     </div>
                                 </div>
                                 <div id="setting-theme-mode-container" class="relative grid grid-cols-3 items-stretch p-1 bg-[var(--zephyr-bg-muted)] rounded-lg border border-[var(--zephyr-border-subtle)] h-9 transition-all duration-[var(--zephyr-time-standard)] w-[180px]">
-                                    <div id="setting-theme-mode-slider" class="absolute top-1 bottom-1 left-1 w-[calc((100%-8px)/3)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
+                                    <div id="setting-theme-mode-slider" class="absolute top-1 bottom-1 start-1 w-[calc((100%-8px)/3)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
                                     <button data-theme-mode="light" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="themeLight">Light</button>
                                     <button data-theme-mode="auto" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-primary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="themeAuto">Auto</button>
                                     <button data-theme-mode="dark" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="themeDark">Dark</button>
@@ -537,7 +537,7 @@
                                     </div>
                                 </div>
                                 <div id="setting-home-mode-container" class="relative grid grid-cols-2 items-stretch p-1 bg-[var(--zephyr-bg-muted)] rounded-lg border border-[var(--zephyr-border-subtle)] h-9 transition-all duration-[var(--zephyr-time-standard)] w-[180px]">
-                                    <div id="setting-home-mode-slider" class="absolute top-1 bottom-1 left-1 w-[calc((100%-8px)/2)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
+                                    <div id="setting-home-mode-slider" class="absolute top-1 bottom-1 start-1 w-[calc((100%-8px)/2)] bg-[var(--zephyr-bg-muted)] rounded-lg shadow-sm border border-[var(--zephyr-border-default)] transition-all duration-[var(--zephyr-time-standard)] ease-out will-change-transform"></div>
                                     <button type="button" data-home-mode="minimal" aria-pressed="true" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-primary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="homePageMinimal">Minimal</button>
                                     <button type="button" data-home-mode="console" aria-pressed="false" class="relative z-10 h-full flex items-center justify-center text-center leading-none text-2xs font-bold text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors uppercase tracking-wider" data-i18n="homePageConsole">Console</button>
                                 </div>
@@ -547,8 +547,8 @@
 
                     <!-- 2. App Behavior -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsAppBehavior">App Behavior</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsAppBehaviorDesc">Window lifecycle, startup and runtime behavior</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsAppBehavior">App Behavior</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsAppBehaviorDesc">Window lifecycle, startup and runtime behavior</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Close Behavior -->
                             <div class="flex items-center justify-between">
@@ -647,8 +647,8 @@
 
                     <!-- 3. Proxy Behavior -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsProxyBehavior">Proxy Behavior</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsProxyBehaviorDesc">How proxy selection, testing and failover work</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsProxyBehavior">Proxy Behavior</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsProxyBehaviorDesc">How proxy selection, testing and failover work</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Unified Delay -->
                             <div class="flex items-center justify-between">
@@ -755,8 +755,8 @@
 
                     <!-- 4. Network -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsNetwork">Network</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsNetworkDesc">Local ports, DNS, LAN access and port forwarding</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsNetwork">Network</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsNetworkDesc">Local ports, DNS, LAN access and port forwarding</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- IPv6 -->
                             <div class="flex items-center justify-between">
@@ -813,7 +813,7 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <p class="text-2xs text-[var(--text-muted)] ml-9" data-i18n="dnsRewriteDesc">Force standard DNS settings to prevent leaks</p>
+                                    <p class="text-2xs text-[var(--text-muted)] ms-9" data-i18n="dnsRewriteDesc">Force standard DNS settings to prevent leaks</p>
                                 </div>
                                 <label class="ios-switch">
     <input type="checkbox" id="dns-rewrite-toggle">
@@ -900,7 +900,7 @@
                                     </div>
                                     <svg class="w-4 h-4 text-[var(--text-muted)] transition-transform duration-[var(--zephyr-time-micro)] group-open:rotate-90" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
                                 </summary>
-                                <div class="mt-4 pl-9 pr-2">
+                                <div class="mt-4 ps-9 pe-2">
                                     <div class="flex items-center justify-between mb-3">
                                         <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider" data-i18n="tunnelsList">Rules</span>
                                         <button id="add-tunnel-btn" class="text-xs text-accent hover:text-accent/80 transition-colors" data-i18n="add">Add</button>
@@ -916,8 +916,8 @@
 
                     <!-- 5. Subscription & Rules -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsSubscriptionRules">Subscription & Rules</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsSubscriptionRulesDesc">Subscription download behavior and rule file management</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsSubscriptionRules">Subscription & Rules</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsSubscriptionRulesDesc">Subscription download behavior and rule file management</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Subscription Fake Client -->
                             <div class="flex items-start justify-between flex-col gap-3">
@@ -937,7 +937,7 @@
 </label>
                                 </div>
 
-                                <div id="fake-client-options" class="w-full pl-9 pr-2 transition-all duration-[var(--zephyr-time-standard)] max-h-0 opacity-0 overflow-hidden">
+                                <div id="fake-client-options" class="w-full ps-9 pe-2 transition-all duration-[var(--zephyr-time-standard)] max-h-0 opacity-0 overflow-hidden">
                                     <div class="glass-card p-3 mt-2 space-y-3">
                                         <div>
                                             <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2">Client Type</label>
@@ -946,13 +946,13 @@
                                                     <span id="fake-client-label">Clash Verge Rev</span>
                                                     <svg class="w-3.5 h-3.5 text-[var(--text-muted)] transition-transform duration-[var(--zephyr-time-micro)] dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"></path></svg>
                                                 </button>
-                                                <div id="fake-client-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                                                <div id="fake-client-menu" class="hidden absolute inset-inline-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
                                                     <div class="menu-scroll">
-                                                        <button type="button" data-value="clash-verge/1.6.0" data-label="Clash Verge Rev" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Clash Verge Rev</button>
-                                                        <button type="button" data-value="mihomo-party/1.0.0" data-label="mihomo-party" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">mihomo-party</button>
-                                                        <button type="button" data-value="Flclash/1.0.0" data-label="Flclash" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Flclash</button>
-                                                        <button type="button" data-value="Shadowrocket/3.0.0" data-label="Shadowrocket" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Shadowrocket</button>
-                                                        <button type="button" data-value="custom" data-label="Custom..." data-i18n="custom" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Custom...</button>
+                                                        <button type="button" data-value="clash-verge/1.6.0" data-label="Clash Verge Rev" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Clash Verge Rev</button>
+                                                        <button type="button" data-value="mihomo-party/1.0.0" data-label="mihomo-party" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">mihomo-party</button>
+                                                        <button type="button" data-value="Flclash/1.0.0" data-label="Flclash" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Flclash</button>
+                                                        <button type="button" data-value="Shadowrocket/3.0.0" data-label="Shadowrocket" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Shadowrocket</button>
+                                                        <button type="button" data-value="custom" data-label="Custom..." data-i18n="custom" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Custom...</button>
                                                     </div>
                                                 </div>
                                                 <select id="fake-client-select" class="hidden">
@@ -1015,8 +1015,8 @@
 
                     <!-- 6. Security & Diagnostics -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsSecurityDiagnostics">Security & Diagnostics</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsSecurityDiagnosticsDesc">Config encryption and log diagnostics</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsSecurityDiagnostics">Security & Diagnostics</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsSecurityDiagnosticsDesc">Config encryption and log diagnostics</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Encrypt Configs -->
                             <div class="flex items-center justify-between">
@@ -1063,8 +1063,8 @@
 
                     <!-- 7. Core & Updates -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsCoreUpdates">Core & Updates</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsCoreUpdatesDesc">Core engine, client updates and Geo data maintenance</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsCoreUpdates">Core & Updates</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsCoreUpdatesDesc">Core engine, client updates and Geo data maintenance</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Version Info (Check Updates 行尾低权重) -->
                             <div class="flex items-center justify-between">
@@ -1176,8 +1176,8 @@
 
                     <!-- 8. System & Compatibility -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsSystemCompatibility">System & Compatibility</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsSystemCompatibilityDesc">System integration, platform compatibility and advanced entries</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsSystemCompatibility">System & Compatibility</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsSystemCompatibilityDesc">System integration, platform compatibility and advanced entries</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- Global Shortcuts -->
                             <div class="flex items-center justify-between">
@@ -1219,7 +1219,7 @@
                             <div class="h-px bg-[var(--zephyr-bg-muted)]"></div>
 
                             <!-- Advanced Settings (Drill-in) -->
-                            <button type="button" id="btn-goto-advanced" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-left">
+                            <button type="button" id="btn-goto-advanced" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-start">
                                 <span class="flex items-center gap-4">
                                     <span class="w-10 h-10 rounded-md bg-accent/10 border border-accent/20 flex items-center justify-center text-accent group-hover:bg-accent/20 transition-colors">
                                         <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
@@ -1236,11 +1236,11 @@
 
                     <!-- 9. About -->
                     <section>
-                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ml-1" data-i18n="settingsAbout">About</h3>
-                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ml-1" data-i18n="settingsAboutDesc">Project links and danger zone</p>
+                        <h3 class="text-2xs font-bold text-[var(--text-muted)] uppercase tracking-wider mb-1 ms-1" data-i18n="settingsAbout">About</h3>
+                        <p class="text-2xs text-[var(--text-tertiary)] mb-4 ms-1" data-i18n="settingsAboutDesc">Project links and danger zone</p>
                         <div class="glass-card p-5 space-y-4">
                             <!-- GitHub Homepage (链接行) -->
-                            <a id="btn-goto-github" href="https://github.com/Juwan-Hwang/Zephyr" target="_blank" rel="noopener noreferrer" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-left no-underline">
+                            <a id="btn-goto-github" href="https://github.com/Juwan-Hwang/Zephyr" target="_blank" rel="noopener noreferrer" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-start no-underline">
                                 <span class="flex items-center gap-4">
                                     <span class="w-10 h-10 rounded-md bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] flex items-center justify-center text-[var(--text-secondary)] group-hover:bg-[var(--zephyr-bg-muted)] group-hover:text-[var(--text-primary)] transition-colors">
                                         <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
@@ -1255,7 +1255,7 @@
 
                             <!-- Danger Zone: Restore Defaults -->
                             <div class="border-t mt-6 pt-4" style="border-color: color-mix(in srgb, var(--zephyr-color-danger) 20%, transparent);">
-                                <button type="button" id="btn-restore-defaults" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-left">
+                                <button type="button" id="btn-restore-defaults" class="w-full flex items-center justify-between cursor-pointer group bg-transparent border-0 p-0 text-start">
                                     <span class="flex items-center gap-4">
                                         <span class="w-10 h-10 rounded-md bg-red-500/10 border border-red-500/20 flex items-center justify-center text-red-500 group-hover:bg-red-500/20 transition-colors">
                                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
@@ -1313,7 +1313,7 @@
     </div>
 
     <!-- Notifications Container -->
-    <div id="notif-container" role="status" aria-live="polite" class="fixed bottom-6 right-6 z-[var(--z-toast)] flex flex-col gap-3 pointer-events-none items-end"></div>
+    <div id="notif-container" role="status" aria-live="polite" class="fixed bottom-6 end-6 z-[var(--z-toast)] flex flex-col gap-3 pointer-events-none items-end"></div>
 
     <!-- Modal Background -->
     <div id="modal-bg" role="dialog" aria-modal="true" aria-labelledby="modal-title" class="fixed inset-0 bg-[var(--zephyr-bg-overlay)] backdrop-blur-md z-[var(--z-modal)] hidden flex items-center justify-center transition-all duration-[var(--zephyr-time-standard)] opacity-0 pointer-events-auto">
@@ -1342,13 +1342,13 @@
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="dnsNameservers">Nameservers (DoH)</label>
                     <textarea id="dns-nameservers-input" rows="3" class="form-control form-control-md form-control-mono resize-none" placeholder="https://doh.pub/dns-query&#10;https://dns.alidns.com/dns-query"></textarea>
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="dnsNameserversHint">One URL per line. Used for domestic resolution.</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="dnsNameserversHint">One URL per line. Used for domestic resolution.</p>
                 </div>
                 
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="dnsFallbacks">Fallback Servers (DoH)</label>
                     <textarea id="dns-fallbacks-input" rows="3" class="form-control form-control-md form-control-mono resize-none" placeholder="https://dns.cloudflare.com/dns-query&#10;https://dns.google/dns-query"></textarea>
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="dnsFallbacksHint">One URL per line. Used as fallback for international domains.</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="dnsFallbacksHint">One URL per line. Used as fallback for international domains.</p>
                 </div>
             </div>
             
@@ -1369,25 +1369,25 @@
                 <div>
                     <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="mixedPort">Mixed Port</label>
                     <input id="port-mixed-input" type="number" min="0" max="65535" class="form-control form-control-md" placeholder="7890">
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="mixedPortHint">HTTP & SOCKS5 combined port (0 to disable)</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="mixedPortHint">HTTP & SOCKS5 combined port (0 to disable)</p>
                 </div>
 
                 <div>
-                    <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="socksPort">SOCKS5 Port</label>
+                    <label for="port-socks-input" class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="socksPort">SOCKS5 Port</label>
                     <input id="port-socks-input" type="number" min="0" max="65535" class="form-control form-control-md" placeholder="7891">
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="socksPortHint">Standalone SOCKS5 proxy port (0 to disable)</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="socksPortHint">Standalone SOCKS5 proxy port (0 to disable)</p>
                 </div>
 
                 <div>
-                    <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="redirPort">Redir Port</label>
+                    <label for="port-redir-input" class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="redirPort">Redir Port</label>
                     <input id="port-redir-input" type="number" min="0" max="65535" class="form-control form-control-md" placeholder="0">
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="redirPortHint">Transparent proxy port, Linux only (0 to disable)</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="redirPortHint">Transparent proxy port, Linux only (0 to disable)</p>
                 </div>
 
                 <div>
-                    <label class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="tproxyPort">TProxy Port</label>
+                    <label for="port-tproxy-input" class="block text-2xs text-[var(--text-muted)] uppercase tracking-wider mb-2" data-i18n="tproxyPort">TProxy Port</label>
                     <input id="port-tproxy-input" type="number" min="0" max="65535" class="form-control form-control-md" placeholder="0">
-                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ml-1" data-i18n="tproxyPortHint">TProxy port, Linux only (0 to disable)</p>
+                    <p class="text-2xs text-[var(--text-muted)] mt-1.5 ms-1" data-i18n="tproxyPortHint">TProxy port, Linux only (0 to disable)</p>
                 </div>
             </div>
 
@@ -1409,11 +1409,11 @@
                 </div>
                 <div class="flex items-center gap-2">
                     <button id="fullscreen-editor-validate-btn" class="btn-ghost text-sm">
-                        <svg class="w-4 h-4 mr-1.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 11 3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                        <svg class="w-4 h-4 me-1.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 11 3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
                         <span data-i18n="overrideValidate">验证</span>
                     </button>
                     <button id="fullscreen-editor-run-btn" class="btn-accent text-sm">
-                        <svg class="w-4 h-4 mr-1.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 3l14 9-14 9V3z"/></svg>
+                        <svg class="w-4 h-4 me-1.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 3l14 9-14 9V3z"/></svg>
                         <span data-i18n="overrideSaveAndRun">保存并执行</span>
                     </button>
                     <div class="w-px h-6 mx-2" style="background: var(--border-primary, rgba(255,255,255,0.1));"></div>
@@ -1438,7 +1438,7 @@
                 </div>
                 <!-- Resizer Handle -->
                 <div id="fullscreen-editor-resizer" class="w-1.5 cursor-col-resize hover:bg-accent/30 transition-colors flex-shrink-0 group relative" style="background: var(--bg-tertiary);">
-                    <div class="absolute inset-y-0 -left-1 -right-1"></div>
+                    <div class="absolute inset-y-0 -start-1 -end-1"></div>
                     <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-1 h-8 rounded-full opacity-0 group-hover:opacity-100 transition-opacity" style="background: var(--accent-primary, #6366f1);"></div>
                 </div>
                 <!-- Right Sidebar - Output Panel -->

--- a/apps/desktop/src/modules/connections.js
+++ b/apps/desktop/src/modules/connections.js
@@ -78,12 +78,12 @@ const PAGE_HTML = `
     <div class="flex items-center gap-3">
         <!-- Search -->
         <div class="relative group flex items-center">
-            <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+            <div class="absolute inset-y-0 start-0 ps-4 flex items-center pointer-events-none">
                 <svg class="h-4 w-4 text-[var(--text-secondary)] group-focus-within:text-[var(--text-primary)] transition-colors duration-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>
             </div>
-            <input type="text" id="connections-search-input" placeholder="Search connections..." data-i18n-placeholder="searchConnections" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 pl-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
+            <input type="text" id="connections-search-input" placeholder="Search connections..." data-i18n-placeholder="searchConnections" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 ps-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
         </div>
         <!-- Close All / Clear All Button -->
         <button id="close-all-conns-btn" class="btn-danger">
@@ -131,13 +131,13 @@ const PAGE_HTML = `
         </div>
         <!-- Table Header (clickable for sort) -->
         <div style="display:grid; grid-template-columns: 4fr 2fr 2fr 2fr 2fr 2fr 2fr; gap:0.5rem; padding:0.625rem 1rem; user-select:none;" id="conn-table-header">
-            <div class="sortable pl-1 text-[9px] font-bold text-[var(--zephyr-text-muted)] uppercase tracking-widest cursor-pointer" data-sort="host" data-i18n="hostCol">Host</div>
+            <div class="sortable ps-1 text-[9px] font-bold text-[var(--zephyr-text-muted)] uppercase tracking-widest cursor-pointer" data-sort="host" data-i18n="hostCol">Host</div>
             <div class="sortable text-[9px] font-bold text-[var(--zephyr-text-muted)] uppercase tracking-widest cursor-pointer" data-sort="rule" data-i18n="ruleCol">Rule</div>
-            <div class="sortable text-right pr-2 text-[9px] font-bold text-[var(--zephyr-text-muted)] uppercase tracking-widest cursor-pointer" data-sort="chains" data-i18n="chainsCol">Chains</div>
-            <div class="sortable text-right pr-1 text-[9px] font-bold text-purple-500/70 uppercase tracking-widest cursor-pointer hover:text-purple-400 transition-colors" data-sort="dlSpeed" data-i18n="dlSpeedCol">↓ Speed</div>
-            <div class="sortable text-right pr-1 text-[9px] font-bold text-purple-500/50 uppercase tracking-widest cursor-pointer hover:text-purple-300 transition-colors" data-sort="dlTotal" data-i18n="dlTotalCol">↓ Total</div>
-            <div class="sortable text-right pr-1 text-[9px] font-bold text-blue-500/70 uppercase tracking-widest cursor-pointer hover:text-blue-400 transition-colors" data-sort="ulSpeed" data-i18n="ulSpeedCol">↑ Speed</div>
-            <div class="sortable text-right pr-2 text-[9px] font-bold text-blue-500/50 uppercase tracking-widest cursor-pointer hover:text-blue-300 transition-colors" data-sort="ulTotal" data-i18n="ulTotalCol">↑ Total</div>
+            <div class="sortable text-end pe-2 text-[9px] font-bold text-[var(--zephyr-text-muted)] uppercase tracking-widest cursor-pointer" data-sort="chains" data-i18n="chainsCol">Chains</div>
+            <div class="sortable text-end pe-1 text-[9px] font-bold text-purple-500/70 uppercase tracking-widest cursor-pointer hover:text-purple-400 transition-colors" data-sort="dlSpeed" data-i18n="dlSpeedCol">↓ Speed</div>
+            <div class="sortable text-end pe-1 text-[9px] font-bold text-purple-500/50 uppercase tracking-widest cursor-pointer hover:text-purple-300 transition-colors" data-sort="dlTotal" data-i18n="dlTotalCol">↓ Total</div>
+            <div class="sortable text-end pe-1 text-[9px] font-bold text-blue-500/70 uppercase tracking-widest cursor-pointer hover:text-blue-400 transition-colors" data-sort="ulSpeed" data-i18n="ulSpeedCol">↑ Speed</div>
+            <div class="sortable text-end pe-2 text-[9px] font-bold text-blue-500/50 uppercase tracking-widest cursor-pointer hover:text-blue-300 transition-colors" data-sort="ulTotal" data-i18n="ulTotalCol">↑ Total</div>
         </div>
     </div>
     <!-- List Body -->
@@ -829,7 +829,7 @@ function showConnDetail(conn, mode) {
     <div class="glass-card w-full max-w-lg p-6 relative" id="conn-detail-panel">
         <!-- Header -->
         <div class="flex items-start justify-between mb-5">
-            <div class="min-w-0 flex-1 pr-4">
+            <div class="min-w-0 flex-1 pe-4">
                 <h3 class="text-lg font-light text-[var(--text-primary)] truncate">${host}</h3>
                 <p class="text-xs text-[var(--text-secondary)] mt-1 font-mono truncate">${id}</p>
             </div>
@@ -1001,8 +1001,8 @@ function renderDetailRow(label, value, rowId) {
     const idAttr = rowId ? ` id="${rowId}"` : '';
     return `
   <div class="flex items-center justify-between py-1.5 border-b border-[var(--zephyr-border-subtle)] last:border-0">
-    <span class="text-[var(--text-muted)] shrink-0 mr-4">${_esc(label)}</span>
-    <span${idAttr} class="text-[var(--text-secondary)] font-mono text-right truncate min-w-0 tabular-nums">${_esc(value)}</span>
+    <span class="text-[var(--text-muted)] shrink-0 me-4">${_esc(label)}</span>
+    <span${idAttr} class="text-[var(--text-secondary)] font-mono text-end truncate min-w-0 tabular-nums">${_esc(value)}</span>
   </div>`;
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -10,8 +10,17 @@
 @import "./tokens-variables.css";
 @import "./tokens-theme.css";
 
+/* ═══════════════════════════════════════════════════════════════
+   RTL Foundation — direction-aware CSS custom properties
+   --rtl-sign: 1 in LTR, -1 in RTL. Used for translateX flips.
+   --scroll-fade-dir: controls gradient mask direction for scrolling text.
+   ═══════════════════════════════════════════════════════════════ */
+:root[dir="rtl"] { --rtl-sign: -1; --scroll-fade-dir: left; }
+
 /* ── Font stack + Accent + 圆角系统 (原 @theme → :root) ── */
 :root {
+  --rtl-sign: 1;
+  --scroll-fade-dir: right;
   --ui-scale: 1;
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Noto Sans", "DejaVu Sans", "WenQuanYi Micro Hei",
@@ -174,9 +183,9 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
   display: inline-block;
   width: 0.75rem;
   height: 0.75rem;
-  margin-left: 0.5rem;
-  border: 2px solid currentColor;
-  border-right-color: transparent;
+  margin-inline-start: 0.5rem;
+  border: 2px solid currentcolor;
+  border-inline-end-color: transparent;
   border-radius: 50%;
   animation: btn-spin 0.6s linear infinite;
   flex-shrink: 0;
@@ -187,8 +196,8 @@ html:not(.dark) ::-webkit-scrollbar-thumb:hover {
 @keyframes text-scroll {
     0% { transform: translateX(0); }
     15% { transform: translateX(0); }
-    85% { transform: translateX(calc(-100% + 120px)); }
-    100% { transform: translateX(calc(-100% + 120px)); }
+    85% { transform: translateX(calc(var(--rtl-sign, 1) * (-100% + 120px))); }
+    100% { transform: translateX(calc(var(--rtl-sign, 1) * (-100% + 120px))); }
 }
 
 button,
@@ -201,8 +210,8 @@ input[type="range"],
 
 .scrolling-text-container {
     overflow: hidden;
-    mask-image: linear-gradient(to right, black 80%, transparent 100%);
-    -webkit-mask-image: linear-gradient(to right, black 80%, transparent 100%);
+    mask-image: linear-gradient(to var(--scroll-fade-dir, right), black 80%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to var(--scroll-fade-dir, right), black 80%, transparent 100%);
 }
 
 /* Hide scrollbar on node wheel dropdown */
@@ -216,7 +225,7 @@ input[type="range"],
 .scrolling-text {
     display: inline-block;
     white-space: nowrap;
-    padding-right: 20px;
+    padding-inline-end: 20px;
 }
 
 .group:hover .scrolling-text {
@@ -342,7 +351,7 @@ input[type=number] {
 .switch-slider {
     position: absolute;
     cursor: pointer;
-    top: 0; left: 0; right: 0; bottom: 0;
+    inset: 0;
     background-color: #8e8e93;
     transition: 0.4s;
     border-radius: var(--zephyr-switch-radius);
@@ -355,7 +364,7 @@ input[type=number] {
     border-radius: 50%;
     height: 20px;
     width: 20px;
-    left: 2px;
+    inset-inline-start: 2px;
     bottom: 2px;
 }
 input:checked + .switch-slider {
@@ -364,7 +373,7 @@ input:checked + .switch-slider {
 
 /* Default size: 40x24 */
 input:checked + .switch-slider:before {
-    transform: translateX(16px);
+    transform: translateX(calc(var(--rtl-sign, 1) * 16px));
 }
 
 /* Large size: 48x28 */
@@ -375,11 +384,11 @@ input:checked + .switch-slider:before {
 .ios-switch.switch-lg .switch-slider:before {
     height: 24px;
     width: 24px;
-    left: 2px;
+    inset-inline-start: 2px;
     bottom: 2px;
 }
 .ios-switch.switch-lg input:checked + .switch-slider:before {
-    transform: translateX(20px);
+    transform: translateX(calc(var(--rtl-sign, 1) * 20px));
 }
 
 /* Small size: 32x18 */
@@ -390,11 +399,11 @@ input:checked + .switch-slider:before {
 .ios-switch.switch-sm .switch-slider:before {
     height: 14px;
     width: 14px;
-    left: 2px;
+    inset-inline-start: 2px;
     bottom: 2px;
 }
 .ios-switch.switch-sm input:checked + .switch-slider:before {
-    transform: translateX(14px);
+    transform: translateX(calc(var(--rtl-sign, 1) * 14px));
 }
 
 /* UI Scale — applied on body to avoid conflicting with #app-main-container transitions */
@@ -1423,7 +1432,7 @@ html.dark #fullscreen-editor-output {
 .dz-kpi-value b { font-size: 24px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.03em; line-height: 1.1; }
 .dz-kpi-value span { font-size: 10px; font-weight: 600; color: var(--zephyr-text-muted); text-transform: uppercase; }
 .dz-kpi-foot { font-size: 10px; color: var(--zephyr-text-tertiary); font-weight: 500; display: flex; align-items: center; gap: 4px; white-space: nowrap; }
-.dz-spark { position: absolute; right: 0; bottom: 0; width: 72px; height: 28px; opacity: .55; pointer-events: none; }
+.dz-spark { position: absolute; inset-inline-end: 0; bottom: 0; width: 72px; height: 28px; opacity: .55; pointer-events: none; }
 
 /* ── Main grid ── */
 .dz-grid-main { display: grid; grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr); gap: 12px; flex-shrink: 0; min-width: 0; }
@@ -1452,8 +1461,8 @@ html.dark #fullscreen-editor-output {
 .dz-node-sub { font-size: 11px; color: var(--zephyr-text-muted); margin-top: 3px; display: flex; align-items: center; gap: 6px; }
 .dz-node-latency { display: flex; align-items: center; gap: 10px; margin-top: 14px; }
 .dz-latency-num { font-size: 28px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
-.dz-latency-num small { font-size: 11px; color: var(--zephyr-text-muted); font-weight: 600; margin-left: 2px; }
-.dz-test-btn { margin-left: auto; }
+.dz-latency-num small { font-size: 11px; color: var(--zephyr-text-muted); font-weight: 600; margin-inline-start: 2px; }
+.dz-test-btn { margin-inline-start: auto; }
 
 /* Node card */
 .dz-node-wrap { position: relative; }
@@ -1465,7 +1474,7 @@ html.dark #fullscreen-editor-output {
 .dz-switch-node-btn.open svg { transform: rotate(180deg); }
 
 /* Node picker panel */
-.dz-node-picker { position: absolute; top: calc(100% + 8px); left: 0; right: 0; z-index: 40; display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: var(--zephyr-radius-md); background: var(--zephyr-bg-elevated); border: 1px solid var(--zephyr-border-default); box-shadow: var(--zephyr-shadow-dialog); animation: dz-pop .28s cubic-bezier(0.16,1,0.3,1); }
+.dz-node-picker { position: absolute; top: calc(100% + 8px); inset-inline: 0; z-index: 40; display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: var(--zephyr-radius-md); background: var(--zephyr-bg-elevated); border: 1px solid var(--zephyr-border-default); box-shadow: var(--zephyr-shadow-dialog); animation: dz-pop .28s cubic-bezier(0.16,1,0.3,1); }
 html:not(.dark) .dz-node-picker { background: rgba(255,255,255,.97); }
 @keyframes dz-pop { from { opacity: 0; transform: translateY(-6px) scale(.98); } to { opacity: 1; transform: none; } }
 .dz-picker-subs { display: flex; flex-wrap: wrap; gap: 6px; }
@@ -1480,7 +1489,7 @@ html:not(.dark) .dz-node-picker { background: rgba(255,255,255,.97); }
 .dz-picker-node-meta { font-size: 10px; color: var(--zephyr-text-tertiary); font-family: var(--font-mono); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dz-picker-check { width: 14px; height: 14px; color: var(--color-accent); flex-shrink: 0; visibility: hidden; }
 .dz-picker-node.active .dz-picker-check { visibility: visible; }
-.dz-picker-sub-count { opacity: .55; font-weight: 500; margin-left: 2px; }
+.dz-picker-sub-count { opacity: .55; font-weight: 500; margin-inline-start: 2px; }
 
 /* Connection sort button */
 .dz-sort-btn { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; color: var(--zephyr-text-tertiary); font-weight: 600; background: none; border: none; cursor: pointer; padding: 3px 8px; border-radius: 6px; transition: all .21s ease-out; white-space: nowrap; }
@@ -1513,7 +1522,7 @@ html:not(.dark) .dz-node-picker { background: rgba(255,255,255,.97); }
 .dz-quick-row-label { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--zephyr-text-secondary); }
 .dz-quick-row-label svg { width: 14px; height: 14px; color: var(--zephyr-text-muted); }
 .dz-mode-seg { position: relative; display: grid; grid-template-columns: repeat(3, 1fr); padding: 4px; background: var(--zephyr-bg-muted); border: 1px solid var(--zephyr-border-subtle); border-radius: var(--radius-lg); height: 36px; width: 100%; margin-top: 12px; }
-.dz-mode-slider { position: absolute; top: 4px; bottom: 4px; left: 4px; width: calc((100% - 8px)/3); border-radius: var(--radius-lg); box-shadow: var(--zephyr-shadow-sm); border: 1px solid var(--zephyr-border-default); transition: transform .3s cubic-bezier(0.16,1,0.3,1); }
+.dz-mode-slider { position: absolute; top: 4px; bottom: 4px; inset-inline-start: 4px; width: calc((100% - 8px)/3); border-radius: var(--radius-lg); box-shadow: var(--zephyr-shadow-sm); border: 1px solid var(--zephyr-border-default); transition: transform .3s cubic-bezier(0.16,1,0.3,1); transform: translateX(calc(var(--rtl-sign, 1) * var(--slider-idx, 0) * 100%)); }
 html.dark .dz-mode-slider { background: rgba(255,255,255,.09); }
 html:not(.dark) .dz-mode-slider { background: #fff; }
 .dz-mode-seg button { position: relative; z-index: 1; font-size: 10px; font-weight: 700; letter-spacing: .04em; color: var(--zephyr-text-secondary); background: none; border: none; cursor: pointer; transition: color .21s; white-space: nowrap; overflow: hidden; }
@@ -1531,7 +1540,7 @@ html:not(.dark) .dz-mode-slider { background: #fff; }
 .dz-conn-info { flex: 1; min-width: 0; }
 .dz-conn-host { font-size: 12px; font-weight: 600; color: var(--zephyr-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dz-conn-chain { font-size: 10px; color: var(--zephyr-text-tertiary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: var(--font-mono); margin-top: 1px; }
-.dz-conn-speed { font-size: 11px; font-weight: 700; color: var(--zephyr-text-secondary); font-variant-numeric: tabular-nums; text-align: right; flex-shrink: 0; }
+.dz-conn-speed { font-size: 11px; font-weight: 700; color: var(--zephyr-text-secondary); font-variant-numeric: tabular-nums; text-align: end; flex-shrink: 0; }
 .dz-conn-speed small { display: block; font-size: 9px; color: var(--zephyr-text-tertiary); font-weight: 500; }
 
 /* Subscription traffic */
@@ -1541,11 +1550,11 @@ html:not(.dark) .dz-mode-slider { background: #fff; }
 .dz-progress { height: 6px; border-radius: 3px; background: var(--zephyr-bg-muted); overflow: hidden; margin-top: 14px; }
 .dz-progress-fill { height: 100%; width: 0%; border-radius: 3px; background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 65%, white)); position: relative; }
 .dz-progress-fill::after { content: ''; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--color-accent) 35%, transparent), transparent); animation: dz-shimmer 2.6s ease-in-out infinite; }
-@keyframes dz-shimmer { 0% { transform: translateX(-100%); } 60%,100% { transform: translateX(100%); } }
+@keyframes dz-shimmer { 0% { transform: translateX(calc(var(--rtl-sign, 1) * -100%)); } 60%,100% { transform: translateX(calc(var(--rtl-sign, 1) * 100%)); } }
 .dz-sub-rows { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
 .dz-sub-row { display: flex; justify-content: space-between; align-items: center; font-size: 11px; min-width: 0; }
 .dz-sub-row span { color: var(--zephyr-text-tertiary); font-weight: 500; flex-shrink: 0; white-space: nowrap; }
-.dz-sub-row b { color: var(--zephyr-text-secondary); font-weight: 600; font-variant-numeric: tabular-nums; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; text-align: right; }
+.dz-sub-row b { color: var(--zephyr-text-secondary); font-weight: 600; font-variant-numeric: tabular-nums; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; text-align: end; }
 .dz-sub-actions { display: flex; gap: 8px; margin-top: 16px; }
 .dz-mini-btn { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 6px 0; border-radius: var(--zephyr-radius-md); font-size: 11px; font-weight: 600; cursor: pointer; transition: all .21s ease-out; border: 1px solid color-mix(in srgb, var(--color-accent) 12%, transparent); background: color-mix(in srgb, var(--color-accent) 8%, transparent); color: var(--zephyr-text-primary); white-space: nowrap; }
 .dz-mini-btn:hover { background: color-mix(in srgb, var(--color-accent) 15%, transparent); }
@@ -1566,6 +1575,50 @@ html:not(.dark) .dz-mode-slider { background: #fff; }
 
 
 .dz-hidden { display: none !important; }
+
+/* ═══════════════════════════════════════════════════════════════
+   RTL Utilities — direction-aware transforms & positioning
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Hover slide for card items — replaces hover:translate-x-1.
+   Both .group and .rtl-slide are on the same element, so use self-hover
+   rather than a descendant combinator. */
+.rtl-slide:hover {
+    transform: translateX(calc(var(--rtl-sign, 1) * 0.25rem));
+}
+
+/* Notification enter/exit animation — replaces translate-x-full */
+.notif-offscreen {
+    transform: translateX(calc(var(--rtl-sign, 1) * 100%));
+}
+
+/* Mode slider — CSS variable driven, RTL-aware */
+.rtl-slider {
+    transform: translateX(calc(var(--rtl-sign, 1) * var(--slider-idx, 0) * 100%));
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   RTL Safety-Net — global overrides for physical leftovers
+   These rules catch UnoCSS utilities that don't have logical
+   equivalents and ensure they flip correctly in RTL.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Flip directional chevrons & arrows in RTL */
+[dir="rtl"] .rtl-flip { transform: scaleX(-1); }
+
+/* Scrollbar container inherits RTL direction from <html> */
+/* Code/log panes that must stay LTR are handled below */
+
+/* Ensure textarea/code/log inputs keep LTR for code even in RTL UI */
+[dir="rtl"] [data-code-editor],
+[dir="rtl"] textarea.font-mono,
+[dir="rtl"] textarea.form-control-mono,
+[dir="rtl"] pre.font-mono,
+[dir="rtl"] #log-content,
+[dir="rtl"] #log-ext-content {
+    direction: ltr;
+    text-align: left;
+}
 
 /* Responsive - switch to single-column on narrow viewports */
 @media (max-width: 1080px) {

--- a/apps/desktop/src/ui/advanced.js
+++ b/apps/desktop/src/ui/advanced.js
@@ -489,14 +489,14 @@ function renderConfigItem(key, value, fullKey) {
         const input = document.createElement('input');
         input.type = "number";
         input.value = String(value);
-        input.className = "form-control form-control-md form-control-mono max-w-[100px] text-right";
+        input.className = "form-control form-control-md form-control-mono max-w-[100px] text-end";
         input.onchange = () => handleConfigUpdate(fullKey, Number(input.value));
         valueContainer.appendChild(input);
     } else if (typeof value === 'string') {
         const input = document.createElement('input');
         input.type = "text";
         input.value = value;
-        input.className = "form-control form-control-md form-control-mono text-right";
+        input.className = "form-control form-control-md form-control-mono text-end";
         input.onchange = () => handleConfigUpdate(fullKey, input.value);
         valueContainer.appendChild(input);
     } else if (Array.isArray(value)) {

--- a/apps/desktop/src/ui/console-home.js
+++ b/apps/desktop/src/ui/console-home.js
@@ -1183,7 +1183,7 @@ function syncModeSegs(/** @type {string} */ mode) {
     for (const { seg, slider } of MODE_SEGS) {
         if (!seg) continue;
         seg.querySelectorAll('button').forEach((/** @type {HTMLButtonElement} */ b, /** @type {number} */ j) => b.classList.toggle('active', j === idx));
-        if (slider) slider.style.transform = `translateX(${idx * 100}%)`;
+        if (slider) slider.style.transform = `translateX(calc(var(--rtl-sign, 1) * ${idx * 100}%))`;
     }
 }
 

--- a/apps/desktop/src/ui/dropdown.js
+++ b/apps/desktop/src/ui/dropdown.js
@@ -44,6 +44,8 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
         // are in the container's coordinate space. Divide by ui-scale to compensate.
         const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
         menu.style.position = 'fixed';
+        menu.style.insetInlineStart = 'auto';
+        menu.style.insetInlineEnd = 'auto';
         menu.style.left = `${rect.left / uiScale}px`;
         menu.style.top = `${(rect.bottom + 6) / uiScale}px`;
         menu.style.width = `${rect.width / uiScale}px`;
@@ -70,6 +72,8 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
             isPortalActive = false;
             menu.style.position = '';
             menu.style.left = '';
+            menu.style.insetInlineStart = '';
+            menu.style.insetInlineEnd = '';
             menu.style.top = '';
             menu.style.width = '';
             menu.style.zIndex = '';

--- a/apps/desktop/src/ui/global-shortcut.js
+++ b/apps/desktop/src/ui/global-shortcut.js
@@ -346,7 +346,7 @@ function addShortcutRow(t, actionId, existingAccelerator) {
     `;
 
     const dropdownMenu = document.createElement('div');
-    dropdownMenu.className = 'shortcut-dropdown-menu hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30';
+    dropdownMenu.className = 'shortcut-dropdown-menu hidden absolute inset-inline-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30';
 
     const menuScroll = document.createElement('div');
     menuScroll.className = 'menu-scroll max-h-[200px]';
@@ -362,7 +362,7 @@ function addShortcutRow(t, actionId, existingAccelerator) {
         const opt = document.createElement('button');
         opt.type = 'button';
         opt.dataset.value = actionDef.id;
-        opt.className = 'dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
+        opt.className = 'dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
         if (actionDef.id === actionId) opt.classList.add('active');
         opt.textContent = getActionLabel(actionDef.id, t);
         opt.addEventListener('click', () => {

--- a/apps/desktop/src/ui/logs.js
+++ b/apps/desktop/src/ui/logs.js
@@ -303,12 +303,12 @@ function buildPageHTML() {
                 <div class="flex-1"></div>
                 <!-- Search Box -->
                 <div class="relative group flex items-center">
-                    <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                    <div class="absolute inset-y-0 start-0 ps-4 flex items-center pointer-events-none">
                         <svg class="h-4 w-4 text-[var(--text-secondary)] group-focus-within:text-[var(--text-primary)] transition-colors duration-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                         </svg>
                     </div>
-                    <input id="log-search" type="text" placeholder="${t('searchLogs')}" data-i18n-placeholder="searchLogs" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 pl-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
+                    <input id="log-search" type="text" placeholder="${t('searchLogs')}" data-i18n-placeholder="searchLogs" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 ps-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
                 </div>
             </div>
 
@@ -332,12 +332,12 @@ function buildPageHTML() {
                 <div class="flex-1"></div>
                 <!-- Search Box -->
                 <div class="relative group flex items-center">
-                    <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                    <div class="absolute inset-y-0 start-0 ps-4 flex items-center pointer-events-none">
                         <svg class="h-4 w-4 text-[var(--text-secondary)] group-focus-within:text-[var(--text-primary)] transition-colors duration-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                         </svg>
                     </div>
-                    <input id="log-ext-search" type="text" placeholder="${t('searchLogs')}" data-i18n-placeholder="searchLogs" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 pl-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
+                    <input id="log-ext-search" type="text" placeholder="${t('searchLogs')}" data-i18n-placeholder="searchLogs" class="bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] rounded-full py-2 px-5 ps-11 text-[var(--text-primary)] text-xs w-52 transition-all duration-400 focus:outline-none focus:border-[var(--zephyr-border-strong)] focus:bg-[var(--zephyr-bg-input)] focus:w-72 placeholder:text-[var(--text-secondary)] shadow-inner">
                 </div>
             </div>
             <div id="log-ext-content" class="flex-1 min-h-0 overflow-y-auto rounded-lg bg-[var(--zephyr-bg-muted)] border border-[var(--zephyr-border-default)] p-4 font-mono text-2xs leading-relaxed tabular-nums custom-scrollbar">

--- a/apps/desktop/src/ui/modes.js
+++ b/apps/desktop/src/ui/modes.js
@@ -93,7 +93,7 @@ export function updateModeUI(mode) {
     const idx = modes.indexOf(mode.toLowerCase());
 
     if (idx !== -1 && slider) {
-        slider.style.transform = `translateX(${idx * 100}%)`;
+        slider.style.transform = `translateX(calc(var(--rtl-sign, 1) * ${idx * 100}%))`;
         buttons.forEach((b, i) => {
             if (i === idx) {
                 b.classList.add('text-[var(--text-primary)]');

--- a/apps/desktop/src/ui/notifications.js
+++ b/apps/desktop/src/ui/notifications.js
@@ -46,7 +46,7 @@ export function showNotification(message, type = 'info', title = null, { log = t
     }
 
     const notif = document.createElement('div');
-    notif.className = 'glass-card py-3 px-5 border-l-4 flex flex-col gap-1 shadow-2xl transition-all duration-500 translate-x-full opacity-0 pointer-events-auto min-w-0 max-w-[480px]';
+    notif.className = 'glass-card py-3 px-5 border-s-4 flex flex-col gap-1 shadow-2xl transition-all duration-500 notif-offscreen opacity-0 pointer-events-auto min-w-0 max-w-[480px]';
 
     const colors = {
         info: 'border-accent text-accent',
@@ -85,11 +85,11 @@ export function showNotification(message, type = 'info', title = null, { log = t
     }
 
     requestAnimationFrame(() => {
-        notif.classList.remove('translate-x-full', 'opacity-0');
+        notif.classList.remove('notif-offscreen', 'opacity-0');
     });
 
     setTimeout(() => {
-        notif.classList.add('translate-x-full', 'opacity-0');
+        notif.classList.add('notif-offscreen', 'opacity-0');
         setTimeout(() => notif.remove(), 500);
     }, title ? 4000 : 3000);
 
@@ -184,7 +184,7 @@ export function showModal(/** @type {string} */ title, placeholder = '', default
                 if (isCustomContent) {
                     container.classList.remove('w-[560px]', 'max-w-[90vw]');
                     container.classList.add('w-[400px]');
-                    contentArea.classList.remove('overflow-y-auto', 'max-h-[65vh]', 'pr-1', 'custom-scrollbar');
+                    contentArea.classList.remove('overflow-y-auto', 'max-h-[65vh]', 'pe-1', 'custom-scrollbar');
                     cancelBtn.classList.remove('hidden');
                     confirmBtn.classList.remove('hidden');
                 }
@@ -201,7 +201,7 @@ export function showModal(/** @type {string} */ title, placeholder = '', default
         if (isCustomContent) {
             container.classList.remove('w-[400px]');
             container.classList.add('w-[560px]', 'max-w-[90vw]');
-            contentArea.classList.add('overflow-y-auto', 'max-h-[65vh]', 'pr-1');
+            contentArea.classList.add('overflow-y-auto', 'max-h-[65vh]', 'pe-1');
             contentArea.classList.add('custom-scrollbar');
             // Hide default Cancel/Confirm buttons — custom content has its own action buttons
             cancelBtn.classList.add('hidden');

--- a/apps/desktop/src/ui/plugins-smart.js
+++ b/apps/desktop/src/ui/plugins-smart.js
@@ -227,7 +227,7 @@ async function loadPermissionsList() {
             <div class="flex items-center justify-between py-1 px-2 rounded-md hover:bg-[var(--zephyr-bg-muted)]">
                 <div>
                     <span class="text-xs text-[var(--text-secondary)] font-mono">${esc(p.name)}</span>
-                    <span class="text-2xs text-[var(--text-muted)] ml-2">${esc(p.displayName)}</span>
+                    <span class="text-2xs text-[var(--text-muted)] ms-2">${esc(p.displayName)}</span>
                 </div>
                 <div class="flex gap-2">
                     ${p.allowedForConfigPlugin ? '<span class="text-2xs text-blue-400">config</span>' : ''}
@@ -263,9 +263,9 @@ async function loadKvStore() {
             <div class="flex items-center justify-between py-1 px-2 rounded-md hover:bg-[var(--zephyr-bg-muted)]">
                 <div class="flex-1 min-w-0">
                     <span class="text-xs text-[var(--text-secondary)] font-mono">${esc(e.key)}</span>
-                    <span class="text-2xs text-[var(--text-tertiary)] ml-2 truncate">${esc(JSON.stringify(e.value)?.slice(0, 60) || 'null')}</span>
+                    <span class="text-2xs text-[var(--text-tertiary)] ms-2 truncate">${esc(JSON.stringify(e.value)?.slice(0, 60) || 'null')}</span>
                 </div>
-                <div class="flex items-center gap-1 ml-2">
+                <div class="flex items-center gap-1 ms-2">
                     <button class="kv-edit-btn text-2xs text-blue-400 hover:text-blue-300" data-key="${esc(e.key)}">edit</button>
                     <button class="kv-delete-key-btn text-2xs text-red-400 hover:text-red-300" data-key="${esc(e.key)}">✕</button>
                 </div>
@@ -601,12 +601,12 @@ async function loadSmartRankings() {
             const barColor = barWidth >= 80 ? 'bg-success' : barWidth >= 50 ? 'bg-warning' : 'bg-danger';
             return `
                 <div class="flex items-center gap-3 py-1">
-                    <span class="text-2xs text-[var(--text-tertiary)] w-6 text-right">#${i + 1}</span>
+                    <span class="text-2xs text-[var(--text-tertiary)] w-6 text-end">#${i + 1}</span>
                     <span class="text-xs text-[var(--text-secondary)] flex-1 truncate font-mono">${esc(r.name || 'Unknown')}</span>
                     <div class="w-24 h-2 bg-[var(--zephyr-bg-input)] rounded-full overflow-hidden">
                         <div class="${barColor} h-full rounded-full transition-[width]" style="width: ${barWidth}%"></div>
                     </div>
-                    <span class="text-xs font-bold text-[var(--text-primary)] w-10 text-right">${score}</span>
+                    <span class="text-xs font-bold text-[var(--text-primary)] w-10 text-end">${score}</span>
                 </div>`;
         }).join('');
     } catch (e) {

--- a/apps/desktop/src/ui/plugins.js
+++ b/apps/desktop/src/ui/plugins.js
@@ -1025,7 +1025,7 @@ function updateOverrideCardContent(card, item) {
  */
 function buildOverrideCard(item) {
     const card = document.createElement('div');
-    card.className = 'glass-card p-4 flex items-center justify-between group hover:translate-x-1 hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
+    card.className = 'glass-card p-4 flex items-center justify-between group rtl-slide hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
     card.dataset.id = item.id;
 
     // ── Type badge color ───────────────────────────────────────
@@ -1443,7 +1443,7 @@ function openFullscreenEditor() {
     setupFullscreenEditorStatus();
 
     // Focus editor
-    /** @type {{focus: function(): void}} */ (/** @type {unknown} */ (fullscreenEditorView)).focus();
+    (/** @type {{focus: () => void}} */ (/** @type {unknown} */ (fullscreenEditorView))).focus();
 
     // Clear output
     clearFullscreenOutput();

--- a/apps/desktop/src/ui/prism.js
+++ b/apps/desktop/src/ui/prism.js
@@ -99,7 +99,7 @@ export async function pluginCheckPermission(pluginId, permission) {
 /** Execute a script against the running config.
  *  @param {string} script - JavaScript source code
  *  @param {string} scriptName - Name for logging
- *  @returns {Promise<{logs: Array, duration_us: number, success: boolean, error: string|null, patches: Array}>}
+ *  @returns {Promise<{logs: Array<{level: string, message: string}>, duration_us: number, success: boolean, error: string|null, patches: Array<Record<string, unknown>>}>}
  */
 export async function scriptExecute(script, scriptName) {
     return invoke(COMMANDS.SCRIPT.EXECUTE, { script, scriptName });

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -409,7 +409,7 @@ function setActiveNode(card, _container) {
 
     if (!card.querySelector('.active-dot')) {
         const activeDot = document.createElement('div');
-        activeDot.className = 'active-dot absolute top-2 right-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
+        activeDot.className = 'active-dot absolute top-2 end-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
         card.appendChild(activeDot);
     }
 
@@ -510,7 +510,7 @@ function updateModeUI(mode) {
     const idx = modes.indexOf(mode.toLowerCase());
 
     if (idx !== -1 && slider) {
-        slider.style.transform = `translateX(${idx * 100}%)`;
+        slider.style.transform = `translateX(calc(var(--rtl-sign, 1) * ${idx * 100}%))`;
         buttons.forEach((b, i) => {
             if (i === idx) {
                 b.classList.add('text-[var(--text-primary)]');
@@ -1080,7 +1080,7 @@ function renderGroupExplanationBar(uiGroupName, effectiveGroupName, observedGrou
 
     // Dismiss button
     const dismiss = document.createElement('button');
-    dismiss.className = 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] ml-2 flex-shrink-0';
+    dismiss.className = 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] ms-2 flex-shrink-0';
      
     dismiss.textContent = '\u00D7';
     dismiss.title = t('dismiss');
@@ -1148,7 +1148,7 @@ function renderGroupSelector(groups, currentGroup) {
     groups.forEach(groupName => {
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'proxy-group-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
+        btn.className = 'proxy-group-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors';
         if (groupName === currentGroup) {
             btn.classList.add('active');
         }
@@ -1580,7 +1580,7 @@ async function updateProxiesInPlace(container, proxies, data, current) {
                 card.classList.remove(INACTIVE_HOVER_CLASS);
                 if (!card.querySelector('.active-dot')) {
                     const activeDot = document.createElement('div');
-                    activeDot.className = 'active-dot absolute top-2 right-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
+                    activeDot.className = 'active-dot absolute top-2 end-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
                     card.appendChild(activeDot);
                 }
             } else {
@@ -1637,7 +1637,8 @@ function buildProxyWrappers(container, proxies, data, current, mainGroup) {
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
         let latFromWrapper = null;
-        if ((/** @type {HTMLElement} */ (wrapper)).dataset.latency) latFromWrapper = parseInt((/** @type {HTMLElement} */ (wrapper)).dataset.latency, 10);
+        const _latency = (/** @type {HTMLElement} */ (wrapper)).dataset.latency;
+        if (_latency) latFromWrapper = Number.parseInt(_latency, 10);
 
         const isPending = (/** @type {HTMLElement} */ (wrapper)).dataset.pending === '1';
 
@@ -1732,7 +1733,7 @@ dot.style.boxShadow = "0 0 8px color-mix(in srgb, var(--zephyr-color-success) 40
 
         if (isSelected) {
             const activeDot = document.createElement('div');
-            activeDot.className = 'active-dot absolute top-2 right-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
+            activeDot.className = 'active-dot absolute top-2 end-2 w-2.5 h-2.5 bg-accent rounded-full border-2 border-[var(--zephyr-bg-elevated)] shadow-lg animate-pulse';
             card.appendChild(activeDot);
         }
 
@@ -1741,7 +1742,7 @@ dot.style.boxShadow = "0 0 8px color-mix(in srgb, var(--zephyr-color-success) 40
         // Smart score badge (between title and UDP rows, only visible when smart mode is enabled)
         // Use absolute positioning with fixed pixel value for consistent cross-system placement
         const scoreBadge = document.createElement('div');
-        scoreBadge.className = 'score-badge absolute left-4 top-[40px] text-center text-2xs tabular-nums font-bold';
+        scoreBadge.className = 'score-badge absolute start-4 top-[40px] text-center text-2xs tabular-nums font-bold';
         scoreBadge.setAttribute('data-score-badge', 'true');
         scoreBadge.textContent = '--';
         card.appendChild(scoreBadge);

--- a/apps/desktop/src/ui/rule-library.js
+++ b/apps/desktop/src/ui/rule-library.js
@@ -160,7 +160,7 @@ async function updateStatusBar() {
             else if (isCompiling) stateLabel = t.ruleLibraryStatusCompiling || 'Compiling';
             else stateLabel = t.ruleLibraryStatusReady || 'Ready';
             // eslint-disable-next-line no-unsanitized/property -- values escaped via escapeHtml() // nosemgrep: js-innerhtml-assignment — verified safe, see eslint-disable above
-            statusEl.innerHTML = `<span class="inline-block w-1.5 h-1.5 rounded-full ${dotColor} mr-1.5"></span>${escapeHtml(stateLabel)}`;
+            statusEl.innerHTML = `<span class="inline-block w-1.5 h-1.5 rounded-full ${dotColor} me-1.5"></span>${escapeHtml(stateLabel)}`;
         }
 
         if (statsEl) {
@@ -171,7 +171,7 @@ async function updateStatusBar() {
     } catch {
         // Fallback to local computation
         if (statusEl) {
-            const dot = '<span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 mr-1.5"></span>';
+            const dot = '<span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 me-1.5"></span>';
             // eslint-disable-next-line no-unsanitized/property -- values escaped via escapeHtml()
             statusEl.innerHTML = dot + escapeHtml(t.ruleLibraryStatusReady || 'Ready'); // nosemgrep: js-innerhtml-assignment — verified safe, see eslint-disable above
         }
@@ -393,7 +393,7 @@ function buildGroupSection(group, files, fileMap, isUngrouped = false) {
 
     // Toggle collapse
     const body = document.createElement('div');
-    body.className = 'space-y-2 pl-2 transition-all duration-[var(--zephyr-time-standard)]';
+    body.className = 'space-y-2 ps-2 transition-all duration-[var(--zephyr-time-standard)]';
     const bodyId = generateDomId('rl-group-body');
     body.id = bodyId;
     header.setAttribute('aria-controls', bodyId);
@@ -426,7 +426,7 @@ function buildGroupSection(group, files, fileMap, isUngrouped = false) {
 function buildFileCard(file, _fileMap) {
     const t = /** @type {Record<string, string>} */ (/** @type {any} */ (translations)[currentLang] || {});
     const card = document.createElement('div');
-    card.className = 'glass-card p-4 flex items-center justify-between group hover:translate-x-1 hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
+    card.className = 'glass-card p-4 flex items-center justify-between group rtl-slide hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
 
     const sourceBadge = getSourceBadge(file.source);
 
@@ -588,7 +588,7 @@ function renderActiveRules(container) {
 
     // Virtual scroll container
     const scrollBox = document.createElement('div');
-    scrollBox.className = 'overflow-y-auto custom-scrollbar pr-1';
+    scrollBox.className = 'overflow-y-auto custom-scrollbar pe-1';
     scrollBox.innerHTML = '<div id="arl-vs-spacer-top" style="height:0"></div><div id="arl-vs-lines" class="space-y-1"></div><div id="arl-vs-spacer-bottom" style="height:0"></div>'; // nosemgrep: js-innerhtml-assignment — static HTML
     ct.appendChild(scrollBox);
 
@@ -676,7 +676,7 @@ function renderActiveRules(container) {
 
                 const el = document.createElement('div');
                 el.setAttribute('data-line-idx', String(idx));
-                el.className = 'glass-card p-3 flex items-center justify-between group hover:translate-x-1 transition-transform duration-[var(--zephyr-time-micro)]';
+                el.className = 'glass-card p-3 flex items-center justify-between group rtl-slide transition-transform duration-[var(--zephyr-time-micro)]';
                 // eslint-disable-next-line no-unsanitized/property -- values escaped via escapeHtml() // nosemgrep: js-innerhtml-assignment — verified safe, see eslint-disable above
                 el.innerHTML = `
                     <div class="flex items-center gap-4 flex-1 min-w-0">
@@ -971,7 +971,7 @@ async function handleMoveToGroup(filename) {
 
     // Use a simple modal to pick group
     const optionsHtml = groupNames
-        .map((name, i) => `<button type="button" class="w-full text-left px-4 py-2.5 text-sm text-[var(--text-secondary)] hover:bg-accent/10 hover:text-accent transition-colors rounded-lg" data-group-index="${i}">${escapeHtml(name)}</button>`)
+        .map((name, i) => `<button type="button" class="w-full text-start px-4 py-2.5 text-sm text-[var(--text-secondary)] hover:bg-accent/10 hover:text-accent transition-colors rounded-lg" data-group-index="${i}">${escapeHtml(name)}</button>`)
         .join('');
 
     const result = await showModal(
@@ -1100,7 +1100,7 @@ function buildEditorHtml(t) {
                     </button>
                 </div>
             </div>
-            <div id="rl-editor-visual" class="flex-1 min-h-0 overflow-y-auto overflow-x-clip custom-scrollbar pr-1 relative mt-4">
+            <div id="rl-editor-visual" class="flex-1 min-h-0 overflow-y-auto overflow-x-clip custom-scrollbar pe-1 relative mt-4">
                 <div id="rl-vs-spacer-top" style="height:0"></div>
                 <div id="rl-vs-lines" class="space-y-2"></div>
                 <div id="rl-vs-spacer-bottom" style="height:0"></div>
@@ -1198,7 +1198,7 @@ async function handleEditRule(filename) {
             const isLast = index === rules.length - 1;
 
             const item = document.createElement('div');
-            item.className = 'glass-card p-4 flex items-center justify-between group hover:translate-x-1 hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
+            item.className = 'glass-card p-4 flex items-center justify-between group rtl-slide hover:z-10 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
             item.draggable = true;
             item.style.setProperty('-webkit-user-drag', 'element');
             item.dataset.ruleIndex = String(index);
@@ -1211,7 +1211,7 @@ async function handleEditRule(filename) {
                     <div class="text-xs text-[var(--text-secondary)] font-mono truncate max-w-[240px]">${escapeHtml(value)}</div>
                 </div>
                 <div class="flex items-center gap-2">
-                    <div class="text-2xs font-bold ${getPolicyColor(policy)} uppercase tracking-wider mr-2">${escapeHtml(policy)}</div>
+                    <div class="text-2xs font-bold ${getPolicyColor(policy)} uppercase tracking-wider me-2">${escapeHtml(policy)}</div>
                     <button type="button" class="btn-rl-rule-top opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1.5 rounded-lg text-[var(--text-muted)] hover:text-accent hover:bg-accent/10 transition-[opacity,color] ${isFirst ? 'invisible' : ''}" title="${escapeAttr(t.moveToTop || 'Move to Top')}" aria-label="${escapeAttr(t.moveToTop || 'Move to Top')}">
                         ${SVG_ICONS.arrowUp}
                     </button>
@@ -1435,7 +1435,7 @@ async function handleViewChanges(filename) {
                     <span class="text-xs text-[var(--text-muted)]">${escapeHtml(filename)}</span>
                     <span class="text-xs text-[var(--text-muted)]">${totalChanges} ${t.ruleLibraryDiffChanges || 'changes'}</span>
                 </div>
-                <div class="space-y-3 overflow-y-auto max-h-[400px] custom-scrollbar pr-1">${diffHtml}</div>
+                <div class="space-y-3 overflow-y-auto max-h-[400px] custom-scrollbar pe-1">${diffHtml}</div>
             </div>
         `;
 
@@ -1656,7 +1656,7 @@ async function handleExtractFromSubscription() {
             .map((/** @type {any} */ p, /** @type {number} */ i) => {
                 const pName = p.name || p.label || p.id || `Profile ${i + 1}`;
                 const pId = p.id || p.name || p;
-                return `<button type="button" class="w-full text-left px-4 py-3 text-sm text-[var(--text-secondary)] hover:bg-accent/10 hover:text-accent transition-colors rounded-lg flex items-center justify-between group/prof" data-profile-id="${escapeHtml(String(pId))}">
+                return `<button type="button" class="w-full text-start px-4 py-3 text-sm text-[var(--text-secondary)] hover:bg-accent/10 hover:text-accent transition-colors rounded-lg flex items-center justify-between group/prof" data-profile-id="${escapeHtml(String(pId))}">
                     <span>${escapeHtml(String(pName))}</span>
                     <span class="text-xs text-[var(--text-muted)]">${escapeHtml(String(pId))}</span>
                 </button>`;

--- a/apps/desktop/src/ui/rules.js
+++ b/apps/desktop/src/ui/rules.js
@@ -170,7 +170,7 @@ async function renderRulesList(searchQuery = '') {
         const policy = parts[2] || 'Proxy';
 
         const item = document.createElement('div');
-        item.className = 'glass-card p-4 flex items-center justify-between group hover:translate-x-1 transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
+        item.className = 'glass-card p-4 flex items-center justify-between group rtl-slide transition-transform duration-[var(--zephyr-time-standard)] cursor-pointer';
 
         // Mark Prism-managed rules with a visual indicator
         const isPrismManaged = await isPrismRule(index);
@@ -187,7 +187,7 @@ async function renderRulesList(searchQuery = '') {
                 <div class="text-xs text-[var(--text-secondary)] font-mono truncate max-w-[240px]">${escapeHtml(value)}</div>
             </div>
             <div class="flex items-center gap-2">
-                <div class="text-2xs font-bold ${getPolicyColor(policy)} uppercase tracking-wider mr-2">${escapeHtml(policy)}</div>
+                <div class="text-2xs font-bold ${getPolicyColor(policy)} uppercase tracking-wider me-2">${escapeHtml(policy)}</div>
 
                 <button type="button" class="btn-move-top-rule opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1.5 rounded-sm text-[var(--text-muted)] hover:text-accent hover:bg-accent/10 transition-[opacity,color]" title="${escapeAttr(/** @type {any} */ (translations)[currentLang]?.moveToTop || 'Move to Top')}" aria-label="${escapeAttr(/** @type {any} */ (translations)[currentLang]?.moveToTop || 'Move to Top')}">
                     ${SVG_ICONS.arrowUp}

--- a/apps/desktop/src/ui/settings.js
+++ b/apps/desktop/src/ui/settings.js
@@ -226,7 +226,7 @@ function initCopyEnvSettings() {
                 </div>
                 <div class="space-y-1">
                     ${formats.map(f => `
-                        <button type="button" class="copy-env-format-option w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-[var(--zephyr-bg-muted)] ${f.key === currentFormat ? 'bg-[var(--zephyr-bg-muted)]' : ''}" data-format="${f.key}" aria-pressed="${f.key === currentFormat ? 'true' : 'false'}">
+                        <button type="button" class="copy-env-format-option w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-start transition-colors hover:bg-[var(--zephyr-bg-muted)] ${f.key === currentFormat ? 'bg-[var(--zephyr-bg-muted)]' : ''}" data-format="${f.key}" aria-pressed="${f.key === currentFormat ? 'true' : 'false'}">
                             <span class="text-xs text-[var(--text-primary)]">${f.label}</span>
                             ${f.key === currentFormat ? '<svg class="w-4 h-4 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>' : ''}
                         </button>
@@ -592,14 +592,14 @@ function initLogSettingsModal() {
                                 <path d="m6 9 6 6 6-6"></path>
                             </svg>
                         </button>
-                        <div id="log-level-menu" class="hidden absolute left-0 right-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                        <div id="log-level-menu" class="hidden absolute inset-inline-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
                             <div class="menu-scroll">
-                                <button type="button" data-value="fatal" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">FATAL</button>
-                                <button type="button" data-value="error" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">ERROR</button>
-                                <button type="button" data-value="warn" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">WARN</button>
-                                <button type="button" data-value="info" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">INFO</button>
-                                <button type="button" data-value="debug" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">DEBUG</button>
-                                <button type="button" data-value="trace" class="w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">TRACE</button>
+                                <button type="button" data-value="fatal" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">FATAL</button>
+                                <button type="button" data-value="error" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">ERROR</button>
+                                <button type="button" data-value="warn" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">WARN</button>
+                                <button type="button" data-value="info" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">INFO</button>
+                                <button type="button" data-value="debug" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">DEBUG</button>
+                                <button type="button" data-value="trace" class="w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">TRACE</button>
                             </div>
                         </div>
                         <select id="log-export-level" class="hidden">
@@ -1078,7 +1078,7 @@ export async function initSettings() {
     /** @param {string} mode */
     const setHomeModeUI = (mode) => {
         const isConsole = mode === 'console';
-        if (homeModeSlider) homeModeSlider.style.transform = isConsole ? 'translateX(100%)' : 'translateX(0)';
+        if (homeModeSlider) homeModeSlider.style.transform = isConsole ? 'translateX(calc(var(--rtl-sign, 1) * 100%))' : '';
         homeModeButtons.forEach((btn) => {
             const btnMode = /** @type {HTMLElement} */ (btn).dataset.homeMode;
             const isSelected = btnMode === mode;

--- a/apps/desktop/src/ui/settings/subscriptions.js
+++ b/apps/desktop/src/ui/settings/subscriptions.js
@@ -134,7 +134,7 @@ async function showEditPanel(configInfo) {
 
     // Build dropdown menu items (escape labels for XSS safety)
     const dropdownMenuItems = autoUpdateOptions.map(opt => 
-        `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(opt.label)}" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">${escapeHtml(opt.label)}</button>`
+        `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(opt.label)}" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">${escapeHtml(opt.label)}</button>`
     ).join('');
 
     // Determine which UA option is currently selected (prefix match for versioned values)
@@ -148,7 +148,7 @@ async function showEditPanel(configInfo) {
     // Build UA dropdown menu items
     const uaMenuItems = UA_OPTIONS.map(opt => {
         const lbl = uaLabel(opt, t);
-        return `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(lbl)}" class="dropdown-option w-full text-left px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">${escapeHtml(lbl)}</button>`;
+        return `<button type="button" data-value="${opt.value}" data-label="${escapeAttr(lbl)}" class="dropdown-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">${escapeHtml(lbl)}</button>`;
     }).join('');
 
     // Remove any existing modal to prevent duplicate IDs
@@ -197,7 +197,7 @@ async function showEditPanel(configInfo) {
                             <span id="edit-ua-label">${escapeHtml(currentUALabel)}</span>
                             <svg class="w-3.5 h-3.5 text-[var(--text-muted)] transition-transform duration-[var(--zephyr-time-micro)] dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"></path></svg>
                         </button>
-                        <div id="edit-ua-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
+                        <div id="edit-ua-menu" class="hidden absolute inset-inline-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
                             <div class="menu-scroll">
                                 ${uaMenuItems}
                             </div>
@@ -217,7 +217,7 @@ async function showEditPanel(configInfo) {
                             <span id="edit-auto-update-label">${escapeHtml(currentIntervalLabel)}</span>
                             <svg class="w-3.5 h-3.5 text-[var(--text-muted)] transition-transform duration-[var(--zephyr-time-micro)] dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"></path></svg>
                         </button>
-                        <div id="edit-auto-update-menu" class="hidden absolute left-0 right-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30 w-40">
+                        <div id="edit-auto-update-menu" class="hidden absolute inset-inline-0 top-[calc(100%+6px)] rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30 w-40">
                             <div class="menu-scroll">
                                 ${dropdownMenuItems}
                             </div>
@@ -561,7 +561,7 @@ export function initSubscriptionSettings({
 
         // Flow array: profile: [a, b]
         if (rest.startsWith('[')) {
-            const items = rest.replace(/,\s*$/, '').slice(1, -1).split(',').map(/** @type {string} */ s => s.trim()).filter(Boolean);
+            const items = rest.replace(/,\s*$/, '').slice(1, -1).split(',').map(s => s.trim()).filter(Boolean);
             return { items, startLine: profileLineIdx, endLine: profileLineIdx, indent };
         }
 
@@ -678,7 +678,7 @@ export function initSubscriptionSettings({
             if (!parsed) continue;
 
             // Already present?
-            if (parsed.items.some(/** @type {string} */ item => item.toLowerCase() === lowerName)) {
+            if (parsed.items.some(item => item.toLowerCase() === lowerName)) {
                 return content;
             }
 
@@ -707,7 +707,7 @@ export function initSubscriptionSettings({
             const parsed = parseProfileBlock(lines, i);
             if (!parsed) continue;
 
-            const filtered = parsed.items.filter(/** @type {string} */ item => item.toLowerCase() !== lowerName);
+            const filtered = parsed.items.filter(item => item.toLowerCase() !== lowerName);
 
             let newLines;
             if (filtered.length === 0) {
@@ -871,7 +871,7 @@ export function initSubscriptionSettings({
 
                         // Show spinner while processing
                         const spinner = document.createElement('span');
-                        spinner.className = 'animate-spin ml-1 text-[var(--text-muted)]';
+                        spinner.className = 'animate-spin ms-1 text-[var(--text-muted)]';
                         spinner.innerHTML = '<svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2a10 10 0 0 1 10 10"/></svg>'; // nosemgrep: js-innerhtml-assignment — static HTML
                         item.appendChild(spinner);
                         checkbox.disabled = true;
@@ -967,7 +967,7 @@ export function initSubscriptionSettings({
                     label.textContent = file.filename.replace(/\.yaml\.prism\.yaml$/i, '').replace(/\.(yaml|yml)$/i, '');
 
                     const count = document.createElement('span');
-                    count.className = 'ml-auto text-2xs text-[var(--text-tertiary)] shrink-0';
+                    count.className = 'ms-auto text-2xs text-[var(--text-tertiary)] shrink-0';
                     count.textContent = String(file.rule_count || 0);
 
                     item.appendChild(checkbox);

--- a/apps/desktop/src/ui/settings/theme.js
+++ b/apps/desktop/src/ui/settings/theme.js
@@ -91,7 +91,7 @@ export function initThemeSettings({
     const updateThemeModeUI = (mode) => {
         const idx = themeModeMap.indexOf(mode);
         if (themeModeSlider && idx !== -1) {
-            themeModeSlider.style.transform = `translateX(${idx * 100}%)`;
+            themeModeSlider.style.transform = `translateX(calc(var(--rtl-sign, 1) * ${idx * 100}%))`;
         }
         themeModeButtons.forEach((btn, btnIdx) => {
             if (btnIdx === idx) {

--- a/apps/desktop/src/utils/context-menu.js
+++ b/apps/desktop/src/utils/context-menu.js
@@ -47,7 +47,11 @@ export function createContextMenuContainer(e) {
 
     const menu = document.createElement('div');
     menu.className = `${ROOT_CLASS} fixed z-[9999] min-w-[180px] max-w-[320px] max-h-[60vh] overflow-hidden shadow-xl border border-[var(--zephyr-border-default)] rounded-lg glass-card`;
-    menu.style.left = `${e.clientX / uiScale}px`;
+    // In RTL, insetInlineStart maps to physical right, so mirror clientX
+    // to keep the menu anchored at the cursor position.
+    const isRTL = document.documentElement.dir === 'rtl';
+    const inlineStartX = (isRTL ? window.innerWidth - e.clientX : e.clientX) / uiScale;
+    menu.style.insetInlineStart = `${inlineStartX}px`;
     menu.style.top = `${e.clientY / uiScale}px`;
 
     // Inner scroll wrapper so scrollbar is clipped by outer border-radius
@@ -69,8 +73,10 @@ export function attachContextMenuCloseHandlers(menu) {
     requestAnimationFrame(() => {
         const uiScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')) || 1;
         const rect = menu.getBoundingClientRect();
-        if (rect.right > window.innerWidth) {
-            menu.style.left = `${(window.innerWidth - rect.width - 8) / uiScale}px`;
+        const isRTL = document.documentElement.dir === 'rtl';
+        if (isRTL ? rect.left < 0 : rect.right > window.innerWidth) {
+            menu.style.insetInlineStart = 'auto';
+            menu.style.insetInlineEnd = `${8 / uiScale}px`;
         }
         if (rect.bottom > window.innerHeight) {
             menu.style.top = `${(window.innerHeight - rect.height - 8) / uiScale}px`;
@@ -146,7 +152,7 @@ export function showContextMenu(e, items) {
 
         // Standard button item
         const btn = document.createElement('button');
-        btn.className = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] hover:text-[var(--text-primary)] transition-colors text-left';
+        btn.className = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] hover:text-[var(--text-primary)] transition-colors text-start';
         const iconHtml = item.icon ? '<span class="w-4 shrink-0">' + sanitizeHtml(item.icon) + '</span>' : '';
         // eslint-disable-next-line no-unsanitized/property -- label escaped, icon sanitized
         btn.innerHTML = iconHtml + '<span>' + escapeHtml(item.label || '') + '</span>'; // nosemgrep: js-innerhtml-assignment — verified safe, see eslint-disable above

--- a/apps/desktop/src/utils/markdown.js
+++ b/apps/desktop/src/utils/markdown.js
@@ -62,7 +62,7 @@ export function markdownToHtml(md) {
     html = html.replace(/^# (.+)$/gm, (_, t) => `<h2 class="text-lg font-bold text-[var(--text-primary)] mt-5 mb-2">${t}</h2>`);
 
     // 5. Blockquotes
-    html = html.replace(/^&gt; (.+)$/gm, (_, t) => `<blockquote class="border-l-2 border-accent/40 pl-3 my-2 text-xs text-[var(--text-secondary)] italic">${t}</blockquote>`);
+    html = html.replace(/^&gt; (.+)$/gm, (_, t) => `<blockquote class="border-s-2 border-accent/40 ps-3 my-2 text-xs text-[var(--text-secondary)] italic">${t}</blockquote>`);
 
     // 6. Bold (before italic to avoid ** being partially consumed)
     html = html.replace(/\*\*(.+?)\*\*/g, (_, t) => `<strong class="font-semibold text-[var(--text-primary)]">${t}</strong>`);
@@ -96,11 +96,11 @@ export function markdownToHtml(md) {
     });
 
     // 12. Unordered lists
-    html = html.replace(/^(\s*)[-*] (.+)$/gm, (_, indent, t) => `${indent}<li class="ml-4 list-disc text-xs text-[var(--text-secondary)] leading-relaxed py-0.5">${t}</li>`);
+    html = html.replace(/^(\s*)[-*] (.+)$/gm, (_, indent, t) => `${indent}<li class="ms-4 list-disc text-xs text-[var(--text-secondary)] leading-relaxed py-0.5">${t}</li>`);
     html = html.replace(/((?:<li[^>]*>.*<\/li>\n?)+)/g, '<ul class="my-3 space-y-2">$1</ul>');
 
     // 13. Ordered lists
-    html = html.replace(/^\d+\. (.+)$/gm, (_, t) => `<li class="ml-4 list-decimal text-xs text-[var(--text-secondary)] leading-relaxed py-0.5">${t}</li>`);
+    html = html.replace(/^\d+\. (.+)$/gm, (_, t) => `<li class="ms-4 list-decimal text-xs text-[var(--text-secondary)] leading-relaxed py-0.5">${t}</li>`);
 
     // 14. Paragraphs: wrap remaining loose lines that aren't already HTML tags or code block placeholders
     html = html.replace(/^(?!\s*<[a-z/]|\s*\x00CODEBLOCK)(.*\S.*)$/gm, (_, t) => `<p class="text-xs text-[var(--text-secondary)] leading-relaxed my-2">${t}</p>`);

--- a/apps/desktop/src/websocket.js
+++ b/apps/desktop/src/websocket.js
@@ -48,7 +48,7 @@ const _wsState = Object.seal({ secret: '' });
 /** @type {string} */
 let wsBaseUrl = 'ws://127.0.0.1:9090';
 
-/** @type {ConnectionState} */
+/** @type {typeof ConnectionState[keyof typeof ConnectionState]} */
 let _connectionState = ConnectionState.DISCONNECTED;
 
 /** @type {{close: Function, reconnect: Function, isMaxRetriesReached: Function} | null} */
@@ -134,7 +134,7 @@ export function isTrafficConnected() {
 /**
  * Read-only snapshot of the current connection state.
  *
- * @returns {ConnectionState}
+ * @returns {typeof ConnectionState[keyof typeof ConnectionState]}
  */
 export function getConnectionState() {
   return _connectionState;
@@ -159,7 +159,7 @@ function formatSpeed(bytes) {
 /**
  * Transition the global connection state and log the change.
  *
- * @param {ConnectionState} newState
+ * @param {typeof ConnectionState[keyof typeof ConnectionState]} newState
  */
 function setState(newState) {
   if (_connectionState === newState) return;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "happy-dom": "^20.11.1",
     "husky": "^9.1.7",
     "style-dictionary": "^5.5.0",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "unocss": "^66.7.5",
     "vite": "8.2.0",
     "vitest": "4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0(tslib@2.8.1)
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       unocss:
         specifier: ^66.7.5
         version: 66.7.5(vite@8.1.4(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -1041,6 +1041,126 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@unocss/cli@66.7.5':
     resolution: {integrity: sha512-fgWkECRn2LGVo9sEpmjk/KJ3NSKUDitaZCNrJcEYM93DG+ELriTHcL+VWBlF4rcZf9fdGlq1nKbbRHUZirFCHQ==}
@@ -2293,6 +2413,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
@@ -3419,6 +3544,66 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.1.2
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@unocss/cli@66.7.5':
     dependencies:
@@ -4810,7 +4995,31 @@ snapshots:
 
   type-level-regexp@0.1.17: {}
 
-  typescript@6.0.3: {}
+  typescript@6.0.3:
+    optional: true
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
## Summary

Full production-grade RTL (Right-to-Left) infrastructure for the Zephyr desktop app. This lays the groundwork for Arabic, Hebrew, Persian, and Urdu support without adding translations yet.

## Changes

### CSS Logical Properties Migration (`styles.css`)
- Migrated all physical properties to logical equivalents:
  - `margin-left/right` -> `margin-inline-start/end`
  - `padding-left/right` -> `padding-inline-start/end`
  - `left/right` positioning -> `inset-inline-start/end` or `inset`
  - `text-align: right` -> `text-align: end`
- Introduced `--rtl-sign` (1 for LTR, -1 for RTL) and `--scroll-fade-dir` CSS custom properties with `:root[dir="rtl"]` for correct cascade specificity
- Merged `:root` selectors to avoid SonarQube duplicate-selector warning
- Fixed `currentColor` -> `currentcolor` for stylelint compliance
- Refactored iOS Switch, mode slider, shimmer, and text-scroll animations to use `var(--rtl-sign)`
- Added RTL safety-net rules: `.rtl-flip`, code-editor LTR lock, `#log-content`/`#log-ext-content` LTR lock, `textarea.form-control-mono` LTR lock
- Fixed `.rtl-slide:hover` selector (was `.group:hover .rtl-slide` which never matched)
- Fixed `.dz-mode-slider` transform to include `--rtl-sign`

### UnoCSS Class Migration
- **`index.html`**: Replaced ~50 physical-direction classes with logical equivalents
- **14 JS modules**: Batch-migrated all physical-direction UnoCSS classes
- Added `dir="ltr"` default on `<html>` to prevent FOUC
- Kept `left-1/2 -translate-x-1/2` for direction-invariant centered elements
- Added `for` attributes on SOCKS5/Redir/TProxy port labels for accessibility

### JS Directional Logic Adaptation
- All 5 mode slider `translateX` calls now use `var(--rtl-sign)`
- Notification animation: `translate-x-full` -> `.notif-offscreen` (RTL-aware)
- Context menu: pure logical properties with RTL coordinate mirroring (`window.innerWidth - e.clientX`)
- Dropdown menu: portal clears both `insetInlineStart` and `insetInlineEnd`

### i18n System Enhancement
- Added `getDirection()` and `getRTLSign()` utility functions
- Enhanced `setHTMLAttributes()` documentation

### Tests
- 6 new tests for `getDirection()` and `getRTLSign()`
- All 428 tests pass, zero lint errors

## Test Plan
- [x] `npx vitest run` 鈥?428 tests pass
- [x] `eslint` 鈥?zero errors
- [x] `tsc --noEmit` 鈥?zero errors
- [ ] Manual: switch `dir` to `rtl` and verify layout flips correctly