### PR TITLE
fix(webview-recovery): invalidate heartbeat before recreate_window to prevent transparent zombie window

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -525,12 +525,17 @@ pub(crate) fn touch_heartbeat(app: &tauri::AppHandle) {
     }
 }
 
-/// Mark the heartbeat as stale (e.g. after window destroy).
+/// Mark the heartbeat as stale (e.g. after window destroy or WebView2 crash).
 ///
 /// This is the **only** place that writes `i64::MIN` — the sentinel for
 /// "explicitly invalidated". `is_webview_alive` checks `last == i64::MIN`
-/// first and returns `false` immediately, so the window is guaranteed to
-/// be recreated on the next show attempt.
+/// **before** any other logic (including the hidden-window shortcut), so
+/// the window is guaranteed to be recreated on the next show attempt or
+/// crash recovery path.
+///
+/// Called from:
+/// - `show_or_recreate_main_window` (after destroying a zombie window)
+/// - `webview_recovery::handle_process_failed` (before `recreate_window`)
 ///
 /// `i64::MIN` is used instead of `0` to avoid a collision with the 10s
 /// grace period calculation (`monotonic_ms() - 35_000`) which could
@@ -573,18 +578,24 @@ pub(crate) fn release_reconstruct_gate(app: &tauri::AppHandle) {
 /// when hidden, so the heartbeat naturally stops), or if the health state
 /// is not yet registered.
 pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
-    // If the window is hidden, the browser engine throttles JS timers,
-    // so the heartbeat will naturally stop. Treat the webview as alive
-    // to avoid false-positive recreation when showing.
-    if let Some(window) = app.get_webview_window("main") {
-        if !window.is_visible().unwrap_or(true) {
-            return true;
-        }
-    }
     if let Some(health) = app.try_state::<WebviewHealth>() {
         let last = health.last_heartbeat_ms.load(Ordering::Relaxed);
+        // Check the explicit invalidation sentinel FIRST — before the
+        // hidden-window shortcut below.  Otherwise, if WebView2 crashes
+        // while the window is hidden-to-tray, invalidate_heartbeat() would
+        // set the sentinel but is_webview_alive() would short-circuit to
+        // `true` at the hidden check, causing recreate_window() to skip
+        // recreation and leaving a transparent zombie window.
         if last == i64::MIN {
             return false;
+        }
+        // If the window is hidden, the browser engine throttles JS timers,
+        // so the heartbeat will naturally stop. Treat the webview as alive
+        // to avoid false-positive recreation when showing.
+        if let Some(window) = app.get_webview_window("main") {
+            if !window.is_visible().unwrap_or(true) {
+                return true;
+            }
         }
         let elapsed_ms = monotonic_ms() - last;
         let timeout_ms = i64::try_from(HEARTBEAT_TIMEOUT_SECS)
@@ -593,6 +604,14 @@ pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
             .unwrap_or(i64::MAX);
         elapsed_ms < timeout_ms
     } else {
+        // No health state registered — assume alive to avoid false-positive
+        // recreation during early startup.
+        // If the window is hidden, also treat as alive (same throttle rationale).
+        if let Some(window) = app.get_webview_window("main") {
+            if !window.is_visible().unwrap_or(true) {
+                return true;
+            }
+        }
         true
     }
 }

--- a/apps/desktop/src-tauri/src/webview_recovery.rs
+++ b/apps/desktop/src-tauri/src/webview_recovery.rs
@@ -145,6 +145,8 @@ fn handle_process_failed(
             "Browser process exited — recreating window"
         );
         UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+        // Invalidate heartbeat so is_webview_alive() returns false in recreate_window().
+        crate::invalidate_heartbeat(app);
         recreate_window(app);
     } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED {
         // Rate-limit: if the render process crashes repeatedly within a
@@ -178,6 +180,7 @@ fn handle_process_failed(
                 "Render process crashing repeatedly — escalating to full window recreation"
             );
             EXIT_COUNT.store(0, Ordering::Relaxed);
+            crate::invalidate_heartbeat(app);
             recreate_window(app);
         } else {
             reload_webview(app);


### PR DESCRIPTION
## Fix: WebView2 崩溃后透明僵尸窗口

### 问题

当 WebView2 浏览器进程或渲染进程崩溃时，防崩溃恢复系统检测到崩溃并调用 `recreate_window()` 准备重建窗口。但 `recreate_window()` 内部有一个双重检查：通过 `is_webview_alive()` 判断 webview 是否还活着——该函数依赖前端心跳时间戳（45 秒超时）。

由于前端在崩溃前一直在正常发送心跳（每 15 秒一次），崩溃瞬间心跳时间戳仍然新鲜，`is_webview_alive()` 返回 `true`，系统错误地认为"窗口已经重建且活着"，**跳过了重建**。

**结果**：HWND 窗口壳存活（`transparent: true`），但 WebView2 内容已死 → 用户看到透明面板，无法交互。

### 日志证据

应用日志 `2026-08-05.log` 最后两行：
```
[2026-08-05 17:45:24.513] Browser process exited — recreating window
[2026-08-05 17:45:24.513] Window already recreated and alive — skipping
```

### 修复

在 `handle_process_failed` 中，当收到 `BROWSER_PROCESS_EXITED`（浏览器进程退出）或渲染进程崩溃循环达到阈值（3 次）时，**在调用 `recreate_window()` 之前先调用 `invalidate_heartbeat(app)`**。

`invalidate_heartbeat` 将心跳时间戳设为 `i64::MIN`（哨兵值），确保 `is_webview_alive()` 返回 `false`，窗口重建得以正确执行。

### 安全性

- `invalidate_heartbeat` 是原子写入，在 `recreate_window` 的主线程检查之前完成
- 如果另一条路径（Layer 2 心跳超时）已经重建了新窗口，新窗口发送的心跳会覆盖 `i64::MIN`，`is_webview_alive` 正确返回 `true` 跳过重复重建
- 重建门控（`try_acquire_reconstruct_gate`）仍然防止并发双重重建

### 检查

- [x] `cargo fmt -- --check` ✅
- [x] `cargo clippy --all-targets -- -D warnings` ✅
- [x] `cargo test -p zephyr-core` ✅ (149 passed, 0 failed)
