### PR TITLE
fix(webview-recovery): invalidate heartbeat before recreate_window and fix is_webview_alive check order

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -525,12 +525,17 @@ pub(crate) fn touch_heartbeat(app: &tauri::AppHandle) {
     }
 }
 
-/// Mark the heartbeat as stale (e.g. after window destroy).
+/// Mark the heartbeat as stale (e.g. after window destroy or `WebView2` crash).
 ///
 /// This is the **only** place that writes `i64::MIN` — the sentinel for
 /// "explicitly invalidated". `is_webview_alive` checks `last == i64::MIN`
-/// first and returns `false` immediately, so the window is guaranteed to
-/// be recreated on the next show attempt.
+/// **before** any other logic (including the hidden-window shortcut), so
+/// the window is guaranteed to be recreated on the next show attempt or
+/// crash recovery path.
+///
+/// Called from:
+/// - `show_or_recreate_main_window` (after destroying a zombie window)
+/// - `webview_recovery::handle_process_failed` (before `recreate_window`)
 ///
 /// `i64::MIN` is used instead of `0` to avoid a collision with the 10s
 /// grace period calculation (`monotonic_ms() - 35_000`) which could
@@ -573,18 +578,24 @@ pub(crate) fn release_reconstruct_gate(app: &tauri::AppHandle) {
 /// when hidden, so the heartbeat naturally stops), or if the health state
 /// is not yet registered.
 pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
-    // If the window is hidden, the browser engine throttles JS timers,
-    // so the heartbeat will naturally stop. Treat the webview as alive
-    // to avoid false-positive recreation when showing.
-    if let Some(window) = app.get_webview_window("main") {
-        if !window.is_visible().unwrap_or(true) {
-            return true;
-        }
-    }
     if let Some(health) = app.try_state::<WebviewHealth>() {
         let last = health.last_heartbeat_ms.load(Ordering::Relaxed);
+        // Check the explicit invalidation sentinel FIRST — before the
+        // hidden-window shortcut below.  Otherwise, if `WebView2` crashes
+        // while the window is hidden-to-tray, invalidate_heartbeat() would
+        // set the sentinel but is_webview_alive() would short-circuit to
+        // `true` at the hidden check, causing recreate_window() to skip
+        // recreation and leaving a transparent zombie window.
         if last == i64::MIN {
             return false;
+        }
+        // If the window is hidden, the browser engine throttles JS timers,
+        // so the heartbeat will naturally stop. Treat the webview as alive
+        // to avoid false-positive recreation when showing.
+        if let Some(window) = app.get_webview_window("main") {
+            if !window.is_visible().unwrap_or(true) {
+                return true;
+            }
         }
         let elapsed_ms = monotonic_ms() - last;
         let timeout_ms = i64::try_from(HEARTBEAT_TIMEOUT_SECS)
@@ -593,6 +604,14 @@ pub(crate) fn is_webview_alive(app: &tauri::AppHandle) -> bool {
             .unwrap_or(i64::MAX);
         elapsed_ms < timeout_ms
     } else {
+        // No health state registered — assume alive to avoid false-positive
+        // recreation during early startup.
+        // If the window is hidden, also treat as alive (same throttle rationale).
+        if let Some(window) = app.get_webview_window("main") {
+            if !window.is_visible().unwrap_or(true) {
+                return true;
+            }
+        }
         true
     }
 }

--- a/apps/desktop/src-tauri/src/webview_recovery.rs
+++ b/apps/desktop/src-tauri/src/webview_recovery.rs
@@ -145,6 +145,8 @@ fn handle_process_failed(
             "Browser process exited — recreating window"
         );
         UNRESPONSIVE_COUNT.store(0, Ordering::Relaxed);
+        // Invalidate heartbeat so is_webview_alive() returns false in recreate_window().
+        crate::invalidate_heartbeat(app);
         recreate_window(app);
     } else if raw_kind == COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED {
         // Rate-limit: if the render process crashes repeatedly within a
@@ -178,6 +180,7 @@ fn handle_process_failed(
                 "Render process crashing repeatedly — escalating to full window recreation"
             );
             EXIT_COUNT.store(0, Ordering::Relaxed);
+            crate::invalidate_heartbeat(app);
             recreate_window(app);
         } else {
             reload_webview(app);


### PR DESCRIPTION
## Summary

Fixes transparent zombie window issue when WebView2 crashes.

## Root Cause

WebView2 browser process crashed at 17:45:24. The crash recovery system (`webview_recovery.rs`) detected the crash and called `recreate_window()`, but `is_webview_alive()` returned `true` because the frontend heartbeat was still "fresh" (sent right before the crash). The system skipped window recreation, leaving a transparent HWND shell with no WebView2 content.

## Fixes

### 1. Invalidate heartbeat before `recreate_window()` (`webview_recovery.rs`)

Call `invalidate_heartbeat(app)` before `recreate_window()` in both crash escalation paths:
- `BROWSER_PROCESS_EXITED` — browser process died
- `RENDER_PROCESS_EXITED` with crash-loop threshold reached

This sets the heartbeat timestamp to `i64::MIN` (sentinel), forcing `is_webview_alive()` to return `false`.

### 2. Fix `is_webview_alive()` check order (`lib.rs`)

The `i64::MIN` sentinel check was **after** the hidden-window short-circuit. If WebView2 crashed while the window was hidden-to-tray, `is_webview_alive()` would return `true` at the hidden check before ever reaching the sentinel check — making `invalidate_heartbeat()` ineffective.

**Fix:** Move the `i64::MIN` check to the **very first** check inside `is_webview_alive()`, before the hidden-window optimization. This matches the existing docstring which already stated "checks `last == i64::MIN` first".

## Review Feedback Addressed

- **Qodo**: "Hidden bypasses invalidation" — Fixed by reordering checks in `is_webview_alive()`.
- **Sourcery**: "Duplicated rationale" — Shortened call-site comments; moved full explanation to `invalidate_heartbeat()` docstring.
