### PR TITLE
fix: RTL UI scale, i18n dynamic text, language dropdown UX, progress shimmer overflow

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -420,21 +420,21 @@
                                         </svg>
                                     </button>
                                     <div id="setting-lang-menu" class="hidden absolute end-0 top-[calc(100%+8px)] w-full rounded-lg border border-[var(--zephyr-border-default)] bg-[var(--zephyr-bg-elevated)] shadow-2xl z-30">
-                                        <div class="menu-scroll">
+                                        <div class="menu-scroll max-h-[300px]">
                                             <button type="button" data-lang-value="en" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">English</button>
                                             <button type="button" data-lang-value="zh" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">简体中文</button>
                                             <button type="button" data-lang-value="ja" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">日本語</button>
                                             <button type="button" data-lang-value="ko" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">한국어</button>
+                                            <button type="button" data-lang-value="my" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">ဗမာ</button>
+                                            <button type="button" data-lang-value="vi" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Tiếng Việt</button>
                                             <button type="button" data-lang-value="ru" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Русский</button>
                                             <button type="button" data-lang-value="es" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Español</button>
-                                            <button type="button" data-lang-value="fa" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">فارسی</button>
+                                            <button type="button" data-lang-value="tr" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Türkçe</button>
                                             <button type="button" data-lang-value="tk" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Türkmen</button>
-                                            <button type="button" data-lang-value="my" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">ဗမာ</button>
+                                            <button type="button" data-lang-value="sw" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Kiswahili</button>
+                                            <button type="button" data-lang-value="fa" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">فارسی</button>
                                             <button type="button" data-lang-value="ar" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">العربية</button>
                                             <button type="button" data-lang-value="ur" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">اردو</button>
-                                            <button type="button" data-lang-value="sw" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Kiswahili</button>
-                                            <button type="button" data-lang-value="tr" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Türkçe</button>
-                                            <button type="button" data-lang-value="vi" class="setting-lang-option w-full text-start px-3 py-2 rounded-[var(--radius-dropdown-option)] text-xs text-[var(--text-secondary)] hover:bg-[var(--zephyr-bg-muted)] transition-colors">Tiếng Việt</button>
                                         </div>
                                     </div>
                                     <select id="setting-lang" class="hidden">
@@ -442,16 +442,16 @@
                                         <option value="zh">简体中文</option>
                                         <option value="ja">日本語</option>
                                         <option value="ko">한국어</option>
+                                        <option value="my">ဗမာ</option>
+                                        <option value="vi">Tiếng Việt</option>
                                         <option value="ru">Русский</option>
                                         <option value="es">Español</option>
-                                        <option value="fa">فارسی</option>
+                                        <option value="tr">Türkçe</option>
                                         <option value="tk">Türkmen</option>
-                                        <option value="my">ဗမာ</option>
+                                        <option value="sw">Kiswahili</option>
+                                        <option value="fa">فارسی</option>
                                         <option value="ar">العربية</option>
                                         <option value="ur">اردو</option>
-                                        <option value="sw">Kiswahili</option>
-                                        <option value="tr">Türkçe</option>
-                                        <option value="vi">Tiếng Việt</option>
                                     </select>
                                 </div>
                             </div>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -15,13 +15,14 @@
    --rtl-sign: 1 in LTR, -1 in RTL. Used for translateX flips.
    --scroll-fade-dir: controls gradient mask direction for scrolling text.
    ═══════════════════════════════════════════════════════════════ */
-:root[dir="rtl"] { --rtl-sign: -1; --scroll-fade-dir: left; }
+:root[dir="rtl"] { --rtl-sign: -1; --scroll-fade-dir: left; --scale-origin-x: right; }
 
 /* ── Font stack + Accent + 圆角系统 (原 @theme → :root) ── */
 :root {
   --rtl-sign: 1;
   --scroll-fade-dir: right;
   --ui-scale: 1;
+  --scale-origin-x: left;
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Noto Sans", "DejaVu Sans", "WenQuanYi Micro Hei",
     "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
@@ -406,10 +407,14 @@ input:checked + .switch-slider:before {
     transform: translateX(calc(var(--rtl-sign, 1) * 14px));
 }
 
-/* UI Scale — applied on body to avoid conflicting with #app-main-container transitions */
+/* UI Scale — applied on body to avoid conflicting with #app-main-container transitions.
+   transform-origin follows the inline-start edge via --scale-origin-x
+   (defined in the :root / :root[dir="rtl"] rules above):
+   LTR → top left, RTL → top right (CSS 2.1 §10.3.3).
+   Scaling from the wrong edge pushes content outside the viewport. */
 body {
   transform: scale(var(--ui-scale));
-  transform-origin: top left;
+  transform-origin: top var(--scale-origin-x);
   width: calc(100% / var(--ui-scale));
   height: calc(100% / var(--ui-scale));
   clip-path: inset(0 round var(--zephyr-radius-window-clip, 24px));
@@ -698,6 +703,7 @@ html:not(.dark) .script-output {
 .menu-scroll {
   overflow-y: auto;
   overflow-x: hidden;
+  overscroll-behavior: contain;
 }
 [id$="-menu"] .menu-scroll {
   padding: var(--zephyr-dropdown-padding);
@@ -1548,7 +1554,7 @@ html:not(.dark) .dz-mode-slider { background: #fff; }
 .dz-sub-used b { font-size: 26px; font-weight: 200; color: var(--zephyr-text-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
 .dz-sub-used span { font-size: 11px; color: var(--zephyr-text-muted); font-weight: 500; }
 .dz-progress { height: 6px; border-radius: 3px; background: var(--zephyr-bg-muted); overflow: hidden; margin-top: 14px; }
-.dz-progress-fill { height: 100%; width: 0%; border-radius: 3px; background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 65%, white)); position: relative; }
+.dz-progress-fill { height: 100%; width: 0%; border-radius: 3px; background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 65%, white)); position: relative; overflow: hidden; }
 .dz-progress-fill::after { content: ''; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--color-accent) 35%, transparent), transparent); animation: dz-shimmer 2.6s ease-in-out infinite; }
 @keyframes dz-shimmer { 0% { transform: translateX(calc(var(--rtl-sign, 1) * -100%)); } 60%,100% { transform: translateX(calc(var(--rtl-sign, 1) * 100%)); } }
 .dz-sub-rows { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; min-width: 0; }

--- a/apps/desktop/src/ui/dropdown.js
+++ b/apps/desktop/src/ui/dropdown.js
@@ -35,6 +35,21 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
     const arrow = trigger.querySelector('.dropdown-arrow');
     let isPortalActive = false;
 
+    // Capture the nearest scrollable ancestor of the dropdown *before* the
+    // menu is portaled to <body>.  Once portaled, the menu's DOM parent is
+    // <body>, so traversing up from the menu would never reach the settings
+    // panel.  We need this reference for the wheel-passthrough fallback below.
+    const getScrollParent = (/** @type {Element|null} */ el) => {
+        let node = el?.parentElement;
+        while (node) {
+            const { overflowY } = getComputedStyle(node);
+            if (overflowY === 'auto' || overflowY === 'scroll') return node;
+            node = node.parentElement;
+        }
+        return null;
+    };
+    const scrollAncestor = getScrollParent(wrap);
+
     // Position the menu relative to the trigger (used when portaled to body)
     const positionMenu = () => {
         const rect = trigger.getBoundingClientRect();
@@ -52,15 +67,55 @@ export function initCustomDropdown({ wrapId, triggerId, menuId, labelId, selectI
         menu.style.zIndex = '99999';
     };
 
-    // Wheel scroll: JS passthrough with smooth scrolling
+    // ── Wheel scroll handling ──────────────────────────────────────
+    // Two modes depending on whether the menu itself can scroll:
+    //
+    // 1. Menu HAS scrollable content (e.g. language dropdown with 14 items
+    //    and max-h-[300px]):
+    //    Let .menu-scroll handle native scrolling. Call stopPropagation()
+    //    so the wheel event doesn't leak to the background page.
+    //
+    // 2. Menu content fits without scrolling (e.g. fake-client dropdown
+    //    with only 5 items, no max-height):
+    //    The menu is portaled to <body> as a sibling of the settings panel,
+    //    so natural scroll-chaining can't reach the background. Manually
+    //    pass the wheel delta to the nearest scrollable ancestor so the
+    //    user can still scroll the settings page behind the dropdown.
+    //
+    // DO NOT DELETE the passthrough branch — it is required for short
+    // dropdowns like fake-client. Only the first branch (canScroll) is
+    // the scroll-penetration fix added for long dropdowns like language.
+    // ──────────────────────────────────────────────────────────────
     menu.addEventListener('wheel', (e) => {
-        e.preventDefault();
-        const delta = e.deltaY;
-        document.querySelectorAll('.overflow-y-auto, .custom-scrollbar').forEach(el => {
-            if (el.scrollHeight > el.clientHeight) {
-                el.scrollBy({ top: delta, behavior: 'smooth' });
+        const scrollContainer = menu.querySelector('.menu-scroll');
+        const canScroll = scrollContainer && scrollContainer.scrollHeight > scrollContainer.clientHeight;
+        if (canScroll) {
+            // Menu has scrollable content — block passthrough so scrolling
+            // stays inside the menu and doesn't leak to the background.
+            // overscroll-behavior:contain on .menu-scroll (CSS) prevents
+            // scroll chaining when the menu reaches its top/bottom edge.
+            e.stopPropagation();
+        } else if (scrollAncestor && scrollAncestor.scrollHeight > scrollAncestor.clientHeight) {
+            // Menu content fits — pass wheel delta to the nearest scrollable
+            // ancestor (captured before portaling) so only the background
+            // panel behind this dropdown scrolls, not every scroll pane.
+            // Guard: only intercept when the ancestor is actually scrollable
+            // (overflow-y set but content doesn't overflow = no-op, let
+            // the event propagate naturally to avoid swallowing wheel input).
+            e.preventDefault();
+            // Normalize deltaMode: browsers may report deltas in lines (1)
+            // or pages (2) instead of pixels (0). Convert to pixels so
+            // scrollBy scrolls the right amount regardless of platform.
+            let dy = e.deltaY;
+            if (e.deltaMode === 1) {          // DOM_DELTA_LINE
+                dy *= 16;                    // CSS default line height
+            } else if (e.deltaMode === 2) {  // DOM_DELTA_PAGE
+                dy *= scrollAncestor.clientHeight;
             }
-        });
+            // Use 'auto' (not 'smooth') so successive wheel events apply
+            // immediately without queued animation conflicts.
+            scrollAncestor.scrollBy({ top: dy });
+        }
     }, { passive: false, signal });
 
     const closeMenu = () => {

--- a/apps/desktop/src/ui/proxies.js
+++ b/apps/desktop/src/ui/proxies.js
@@ -1332,14 +1332,16 @@ const ACCENT_BTN_CLASS = 'px-4 py-1.5 rounded-lg text-sm font-medium transition-
  * @param {string} text - Button label text
  * @param {(btn: HTMLButtonElement) => void} onClick - Click handler
  * @param {string} [id] - Optional element ID
+ * @param {string} [i18nKey] - Optional data-i18n key for live language switching
  * @returns {HTMLButtonElement}
  */
-function createAccentButton(text, onClick, id) {
+function createAccentButton(text, onClick, id, i18nKey) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = ACCENT_BTN_CLASS;
     btn.style.cssText = ACCENT_BTN_CSS;
     btn.textContent = text;
+    if (i18nKey) btn.dataset.i18n = i18nKey;
     if (id) btn.id = id;
     btn.addEventListener('click', () => onClick(btn));
     return btn;
@@ -1347,25 +1349,32 @@ function createAccentButton(text, onClick, id) {
 
 /**
  * Handle core restart from a button element.
+ * Reads translations live from currentLang so labels stay correct even if
+ * the user changed language between render time and button click.
  * @param {HTMLButtonElement} btn - The button that triggered the restart
- * @param {any} tObj - i18n translations object
  * @param {string} context - Logging context (e.g. 'loading state', 'error state')
  */
-async function handleCoreRestart(btn, tObj, context) {
+async function handleCoreRestart(btn, context) {
+    const t = /** @type {any} */ (translations)[currentLang] || {};
     btn.disabled = true;
-    btn.textContent = tObj.restartingCore || 'Restarting...';
+    btn.dataset.i18n = 'restartingCore';
+    btn.textContent = t.restartingCore || 'Restarting...';
     try {
         const settings = await getSettingsCached();
         const configPath = settings?.last_config || 'config.yaml';
         const customArgs = settings?.custom_args || [];
         await restartCore(configPath, customArgs);
         await postRestartRecovery(configPath);
-        showNotification(tObj.coreRestarted || 'Core restarted', 'success');
+        // Re-read after awaits: user may have switched language during restart.
+        const tSuccess = /** @type {any} */ (translations)[currentLang] || {};
+        showNotification(tSuccess.coreRestarted || 'Core restarted', 'success');
     } catch (err) {
         proxyLogger.error(`Failed to restart core from ${context}`, err);
         showNotification(String(err), 'error');
+        const t = /** @type {any} */ (translations)[currentLang] || {};
         btn.disabled = false;
-        btn.textContent = tObj.restartCore || 'Restart Core';
+        btn.dataset.i18n = 'restartCore';
+        btn.textContent = t.restartCore || 'Restart Core';
     }
 }
 
@@ -1382,6 +1391,7 @@ function renderProxiesLoading(container, loadingText) {
     loading.className = 'col-span-full text-center py-10 text-[var(--text-muted)] flex flex-col items-center gap-4';
     loading.id = 'proxies-loading-state';
     const span = document.createElement('span');
+    span.dataset.i18n = 'loadingNodes';
     span.textContent = loadingText;
     const spinner = document.createElement('div');
     spinner.className = 'w-6 h-6 border-2 border-[var(--zephyr-border-default)] border-t-transparent rounded-full animate-spin';
@@ -1397,8 +1407,9 @@ function renderProxiesLoading(container, loadingText) {
         const tObj = /** @type {any} */ (translations)[currentLang] || {};
         const btn = createAccentButton(
             tObj.restartCore || 'Restart Core',
-            (b) => handleCoreRestart(b, tObj, 'loading state'),
-            'restart-core-btn'
+            (b) => handleCoreRestart(b, 'loading state'),
+            'restart-core-btn',
+            'restartCore'
         );
         btn.className = 'mt-2 ' + ACCENT_BTN_CLASS;
         existing.appendChild(btn);
@@ -1417,6 +1428,7 @@ function renderProviderPollExhausted(container, tObj) {
     const wrap = document.createElement('div');
     wrap.className = 'col-span-full text-center py-10 text-[var(--text-muted)] flex flex-col items-center gap-4';
     const msg = document.createElement('span');
+    msg.dataset.i18n = 'providerPollExhausted';
     msg.textContent = tObj.providerPollExhausted || 'No nodes available from provider yet. The provider may still be downloading or failed to load.';
     wrap.appendChild(msg);
     const retryBtn = createAccentButton(
@@ -1424,7 +1436,9 @@ function renderProviderPollExhausted(container, tObj) {
         () => {
             _providerPollExhaustedGroup = undefined;
             renderProxies().catch(() => {});
-        }
+        },
+        undefined,
+        'retry'
     );
     wrap.appendChild(retryBtn);
     container.appendChild(wrap);
@@ -1878,7 +1892,7 @@ export async function renderProxies() {
         }
     }
 
-    const t = /** @type {any} */ (translations)[currentLang];
+    let t = /** @type {any} */ (translations)[currentLang];
 
     // Show loading state if empty
     if (container.children.length === 0) {
@@ -1897,17 +1911,23 @@ export async function renderProxies() {
     // Clear loading timeout — data fetch completed (success or failure)
     clearLoadingTimeout();
 
+    // Re-read after await: user may have switched language during fetch.
+    t = /** @type {any} */ (translations)[currentLang] || {};
+
     if (!data || !data.proxies) {
         container.replaceChildren();
         const errWrap = document.createElement('div');
         errWrap.className = 'col-span-full text-center py-10 text-rose-400 bg-rose-400/5 rounded-lg border border-rose-400/20 flex flex-col items-center gap-4';
         const errText = document.createElement('span');
+        errText.dataset.i18n = 'failedToConnect';
         errText.textContent = t.failedToConnect;
         errWrap.appendChild(errText);
         // Add restart core button on connection failure
         const restartBtn = createAccentButton(
             t.restartCore || 'Restart Core',
-            (b) => handleCoreRestart(b, t, 'error state')
+            (b) => handleCoreRestart(b, 'error state'),
+            undefined,
+            'restartCore'
         );
         errWrap.appendChild(restartBtn);
         container.appendChild(errWrap);


### PR DESCRIPTION
## Summary

Four UI/i18n fixes bundled in this PR:

### 1. RTL 界面缩放修复 (`styles.css`)
**问题**：当语言切换为 RTL（阿拉伯语、波斯语等）时，界面缩放（UI Scale）功能异常——元素被挤出窗口右边界。

**根因**：`body` 的 `transform: scale(var(--ui-scale))` 使用了 `transform-origin: top left`（物理左上角）。根据 CSS 2.1 §10.3.3，在 RTL 模式下，body 的**右边缘**对齐到包含块右边缘，左边缘位于 `x = (100% - width)` 处。缩放从左边缘展开后，body 延伸到 `(100% - width) + width × scale > 100%`，内容溢出视口右边界。

**修复**：引入 CSS 自定义属性 `--scale-origin-x`，LTR 时为 `left`，RTL 时为 `right`。缩放原点跟随 inline-start 边缘，两个方向都恰好填满视口。变量声明合并到已有的 `:root` / `:root[dir="rtl"]` 规则中，避免重复选择器。

### 2. 动态文本语言切换修复 (`proxies.js`)
**问题**：代理页面的加载状态文本、重启内核按钮、错误提示、重试按钮等动态创建的元素在切换语言后不会更新。

**修复**：为所有动态创建的文本元素添加 `data-i18n` 属性（通过 `.dataset.i18n`）；扩展 `createAccentButton` 新增 `i18nKey` 参数；`handleCoreRestart` 和 `renderProxies` 在 `await` 之后重新读取 `translations[currentLang]`，防止语言切换后恢复旧语言文本。

### 3. 语言下拉框 UX 优化 (`index.html`, `dropdown.js`)
- `max-h-[300px]` 固定高度内可滚动
- 语言按地理/文字谱系重新排列
- 智能滚动穿透判断：菜单可滚动时 `stopPropagation()`；不可滚动时只滚最近的滚动祖先（`getScrollParent(wrap)` 在 portal 前捕获），`preventDefault()` 仅在有滚动目标时调用

### 4. 订阅进度条涟漪溢出修复 (`styles.css`)
给 `.dz-progress-fill` 添加 `overflow: hidden`，涟漪被裁剪在彩色填充条内部。

## Files Changed
- `apps/desktop/src/styles.css` — RTL transform-origin + progress fill overflow
- `apps/desktop/src/ui/proxies.js` — data-i18n on dynamic elements + live language reads after awaits
- `apps/desktop/src/index.html` — language dropdown max-height + reorder
- `apps/desktop/src/ui/dropdown.js` — smart wheel scroll handling with nearest scroll parent