### PR TITLE
feat: WiFi SSID condition support + fix apply_config hot reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "clash-prism-extension"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8dddc90d5a95608ca25fe2c43219fef995901314ec1b5d8ae1808b33186bf2"
+checksum = "f780a4f506c1d9249423ae4725820cf4b2a5221545c308f2d1c9dbab06da9858"
 dependencies = [
  "chrono",
  "clash-prism-core",
@@ -1385,7 +1385,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1598,7 +1598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ dependencies = [
  "gobject-sys 0.22.6",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2545,7 +2545,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3256,7 +3256,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3640,7 +3640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4541,7 +4541,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5269,7 +5269,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -5701,7 +5701,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6119,7 +6119,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6165,7 +6165,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6789,7 +6789,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -6813,7 +6813,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6853,7 +6853,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6884,7 +6884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6896,7 +6896,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6913,25 +6913,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6976,7 +6963,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -7552,7 +7539,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ aes-gcm = "0.11"
 pbkdf2 = "0.12"
 hmac = "0.12"
 clash-prism-core = "0.1.5"
-clash-prism-extension = { version = "0.1.8", features = ["watcher"] }
+clash-prism-extension = { version = "0.1.9", features = ["watcher"] }
 clash-prism-plugin = "0.1.1"
 clash-prism-script = "0.1.3"
 clash-prism-smart = "0.1.1"

--- a/apps/desktop/src-tauri/src/prism/host.rs
+++ b/apps/desktop/src-tauri/src/prism/host.rs
@@ -12,6 +12,134 @@ use zephyr_core::config::sanitizer::validate_path_within_dir;
 use super::prism_data_dir;
 use super::types::sanitize_filename;
 
+// ── WiFi SSID detection (for `__when__.ssid` condition) ──────────────────
+
+/// SSID cache TTL — avoids spawning a subprocess on every patch compilation.
+const SSID_CACHE_TTL_SECS: u64 = 5;
+
+/// Cached SSID result (including `None`) with the instant it was observed.
+/// Caching `None` avoids re-spawning subprocesses when `WiFi` is disconnected.
+static SSID_CACHE: std::sync::Mutex<Option<(Option<String>, std::time::Instant)>> =
+    std::sync::Mutex::new(None);
+
+/// Detect the current `WiFi` SSID via platform-specific commands.
+///
+/// Results are cached for `SSID_CACHE_TTL_SECS` to avoid excessive subprocess
+/// spawning during frequent recompilations (e.g. rapid rule edits).
+fn detect_ssid() -> Option<String> {
+    // Fast path: return cached value if still fresh.
+    if let Ok(cache) = SSID_CACHE.lock() {
+        if let Some((cached, instant)) = cache.as_ref() {
+            if instant.elapsed().as_secs() < SSID_CACHE_TTL_SECS {
+                return cached.clone();
+            }
+        }
+    }
+
+    let ssid = detect_ssid_uncached();
+
+    // Update cache (best-effort; lock failure is non-fatal).
+    if let Ok(mut cache) = SSID_CACHE.lock() {
+        *cache = Some((ssid.clone(), std::time::Instant::now()));
+    }
+
+    ssid
+}
+
+/// Platform-specific SSID detection without caching.
+#[cfg(target_os = "windows")]
+fn detect_ssid_uncached() -> Option<String> {
+    use std::os::windows::process::CommandExt as _;
+    let output = std::process::Command::new("netsh")
+        .args(["wlan", "show", "interfaces"])
+        .creation_flags(crate::core_manager::CREATE_NO_WINDOW)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // Parse: "    SSID                   : MyWiFi"
+    // Skip:  "    BSSID                  : aa:bb:cc:dd:ee:ff"
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("SSID") && !line.starts_with("BSSID"))
+        .and_then(|line| line.split_once(':').map(|(_, v)| v.trim().to_owned()))
+        .filter(|s| !s.is_empty())
+}
+
+/// Platform-specific SSID detection without caching.
+#[cfg(target_os = "macos")]
+fn detect_ssid_uncached() -> Option<String> {
+    let output = std::process::Command::new("networksetup")
+        .args(["-getairportnetwork", "en0"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // Output: "Current Wi-Fi Network: MyWiFi"
+    String::from_utf8_lossy(&output.stdout)
+        .strip_prefix("Current Wi-Fi Network: ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// Platform-specific SSID detection without caching.
+#[cfg(target_os = "linux")]
+fn detect_ssid_uncached() -> Option<String> {
+    // Try nmcli first (most common on modern Linux desktops).
+    // `-t -f active,ssid` produces terse output: "yes:MyWiFi\n:OtherNet"
+    if let Ok(output) = std::process::Command::new("nmcli")
+        .args(["-t", "-f", "active,ssid", "dev", "wifi"])
+        .output()
+    {
+        if output.status.success() {
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                // Active row starts with "yes:" — split on first ':' to get SSID
+                let (active, ssid) = line.split_once(':').unwrap_or((line, ""));
+                if active.trim() == "yes" {
+                    let ssid = ssid.trim();
+                    if !ssid.is_empty() {
+                        return Some(ssid.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: iwconfig (prints to stdout on some systems, stderr on others).
+    if let Ok(output) = std::process::Command::new("iwconfig").output() {
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in combined.lines() {
+            // Parse: '    ESSID:"MyWiFi"'
+            if let Some(rest) = line.split("ESSID:").nth(1) {
+                let rest = rest.trim();
+                if let Some(stripped) = rest.strip_prefix('"') {
+                    if let Some(end) = stripped.find('"') {
+                        let ssid = &stripped[..end];
+                        if !ssid.is_empty() {
+                            return Some(ssid.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Platform-specific SSID detection without caching.
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn detect_ssid_uncached() -> Option<String> {
+    None
+}
+
 pub(crate) struct ZephyrPrismHost {
     app: tauri::AppHandle,
 }
@@ -34,7 +162,7 @@ impl ZephyrPrismHost {
 
         let host = parsed.host_str().unwrap_or("127.0.0.1");
         let port = parsed.port().unwrap_or(9090);
-        let path = parsed.path();
+        let target = &parsed[url::Position::BeforePath..url::Position::AfterQuery];
 
         // Connect with timeout (2s connect, 5s total)
         let mut stream = match TcpStream::connect_timeout(
@@ -60,7 +188,7 @@ impl ZephyrPrismHost {
         };
 
         let request = format!(
-            "PUT {path} HTTP/1.1\r\n\
+            "PUT {target} HTTP/1.1\r\n\
              Host: {host}:{port}\r\n\
              Content-Type: application/json\r\n\
              Content-Length: {}\r\n\
@@ -89,8 +217,11 @@ impl ZephyrPrismHost {
             }
         }
 
-        // Check for HTTP 2xx status
-        response.starts_with(b"HTTP/") && response.get(9..12).is_some_and(|s| s == b"200")
+        // Check for HTTP 2xx status (200, 204, etc.)
+        response.starts_with(b"HTTP/")
+            && response
+                .get(9..10)
+                .is_some_and(|s| s.first() == Some(&b'2'))
     }
 }
 
@@ -121,10 +252,14 @@ impl PrismHost for ZephyrPrismHost {
         };
 
         let url = format!("http://127.0.0.1:{port}/configs?force=true");
+        // Mihomo's PUT /configs expects a JSON body {"path": "..."} to reload
+        // from disk — NOT the raw YAML config. Sending raw YAML with
+        // Content-Type: application/json causes a silent 400 Bad Request.
+        let body = serde_json::json!({ "path": run_config_path.to_string_lossy() }).to_string();
         // Synchronous HTTP PUT --- apply_config is a sync trait method that may be
         // called from non-tokio threads (e.g. WebView2 COM callbacks). Using
         // std::net avoids the "no reactor running" panic from block_on().
-        let hot_reload_success = Self::http_put(&url, config, &secret);
+        let hot_reload_success = Self::http_put(&url, &body, &secret);
 
         Ok(ApplyStatus {
             files_saved: true,
@@ -294,5 +429,9 @@ impl PrismHost for ZephyrPrismHost {
 
         let _ = std::fs::remove_file(&tmp_path);
         Ok(output.status.success())
+    }
+
+    fn get_ssid(&self) -> Option<String> {
+        detect_ssid()
     }
 }


### PR DESCRIPTION
## Summary

1. Enables `__when__.ssid` condition by upgrading `clash-prism-extension` 0.1.8 → 0.1.9 and implementing `get_ssid()`
2. Fixes a pre-existing bug in `apply_config` where the HTTP PUT body was raw YAML instead of `{"path":"..."}` JSON, causing mihomo hot reload to silently fail
3. Fixes `http_put` dropping `?force=true` query string from the request target

## Bug: `apply_config` sent wrong HTTP body

**Root cause**: `ZephyrPrismHost::apply_config()` passed the raw YAML config as the HTTP PUT body to mihomo's `/configs` endpoint. Mihomo expects JSON `{"path": "/path/to/run_config.yaml"}`, not raw YAML. The raw YAML was sent with `Content-Type: application/json`, causing a silent 400 Bad Request.

**Additional fix**: `http_put` used `parsed.path()` which strips the query string, so `?force=true` was lost on the wire. Fixed to use `url::Position::BeforePath..AfterQuery` to preserve the full request target.

**Impact**: `ext.apply()` internally calls `host.apply_config()` to write config and hot reload. Because the HTTP body and query string were wrong, the hot reload always failed silently. The config was saved to disk but mihomo never reloaded it.

## Feature: WiFi SSID detection

Upstream issue: [Clash-Prism-Engine#15](https://github.com/Juwan-Hwang/Clash-Prism-Engine/issues/15)

### `apps/desktop/src-tauri/Cargo.toml`
- `clash-prism-extension` 0.1.8 → 0.1.9

### `apps/desktop/src-tauri/src/prism/host.rs`
- `SSID_CACHE`: `static Mutex<Option<(Option<String>, Instant)>>` with 5-second TTL (caches `None` too, to avoid subprocess spawning when WiFi is disconnected)
- `detect_ssid()`: cached entry point
- `detect_ssid_uncached()` per platform:
  - **Windows**: `netsh wlan show interfaces` (CREATE_NO_WINDOW)
  - **macOS**: `networksetup -getairportnetwork en0`
  - **Linux**: `nmcli -t -f active,ssid dev wifi` → parse `yes:SSID` rows → `iwconfig` fallback (stdout+stderr)
  - **Other**: `None`
- Override `PrismHost::get_ssid()`
- Fix `http_put` to accept 2xx (not just 200) and preserve `?force=true`

## Review fixes applied

- CodeRabbit/Qodo: Cache `None` SSID results (avoids subprocess spam when WiFi disconnected)
- CodeRabbit/Qodo: Fix Linux `nmcli` parsing (`yes:SSID` not `active:SSID`)
- CodeRabbit/Qodo: `nmcli` spawn failure no longer prevents `iwconfig` fallback
- CodeRabbit/Qodo: `iwconfig` parses both stdout and stderr
- Qodo: `http_put` accepts all 2xx status codes, not just 200
- LlamaPReview: `http_put` preserves `?force=true` query string on the wire

## Verification

- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- SonarQube Quality Gate ✅
- User tested `__when__: { ssid: "YL" }` → `condition_matched: true` ✅