### PR TITLE
fix: persist custom theme color across restarts

### DIFF
--- a/apps/desktop/src/ui/settings/theme.js
+++ b/apps/desktop/src/ui/settings/theme.js
@@ -178,11 +178,14 @@ export function initThemeSettings({
     }
 
     applyColorTheme(savedTheme);
+    appStore.set('currentTheme', savedTheme);
 
     if (customColorInput) {
         customColorInput.onchange = () => {
             const color = customColorInput.value;
             applyColorTheme(color);
+            appStore.set('currentTheme', color);
+            Bus.emit(Events.THEME_CHANGED, color);
             save();
         };
     }


### PR DESCRIPTION
## Fix: Custom theme color resets on restart

### Root Cause

The `customColorInput.onchange` handler in `apps/desktop/src/ui/settings/theme.js` was missing two critical lines that the preset theme circle handler (`themeCircles.onclick`) already had:

```js
appStore.set('currentTheme', color);
Bus.emit(Events.THEME_CHANGED, color);
```

The `save()` function in `settings.js` persists the theme by reading `appStore.get('currentTheme')`. Since the custom color picker never wrote to `appStore`, `save()` always stored the stale preset theme name (e.g. `"purple"`). On restart, the app loaded the stale value from `settings.json`, causing the custom hex color to be lost.

### Fix

Added the two missing lines to `customColorInput.onchange`, making it consistent with the preset color circle handler:

```diff
  customColorInput.onchange = () => {
      const color = customColorInput.value;
      applyColorTheme(color);
+     appStore.set('currentTheme', color);
+     Bus.emit(Events.THEME_CHANGED, color);
      save();
  };
```

### Verification

- `pnpm lint` 鈥?passed
- `pnpm typecheck` 鈥?passed
- 1 file changed, 2 insertions(+)