### PR TITLE
fix: persist custom theme color across restarts

### DIFF
--- a/apps/desktop/src/ui/settings/theme.js
+++ b/apps/desktop/src/ui/settings/theme.js
@@ -8,7 +8,7 @@
  * @module ui/settings/theme
  */
 
-import { applyTheme } from '../theme.js';
+import { applyTheme, currentTheme } from '../theme.js';
 import { appStore } from '../state.js';
 import { Bus, Events } from '../events.js';
 import { debounce } from '../../utils/debounce.js';
@@ -178,11 +178,14 @@ export function initThemeSettings({
     }
 
     applyColorTheme(savedTheme);
+    appStore.set('currentTheme', currentTheme);
 
     if (customColorInput) {
         customColorInput.onchange = () => {
             const color = customColorInput.value;
             applyColorTheme(color);
+            appStore.set('currentTheme', currentTheme);
+            Bus.emit(Events.THEME_CHANGED, currentTheme);
             save();
         };
     }


### PR DESCRIPTION
## Fix: Custom theme color resets on restart

### Root Cause

The `customColorInput.onchange` handler in `apps/desktop/src/ui/settings/theme.js` was missing two critical lines that the preset theme circle handler (`themeCircles.onclick`) already had:

```js
appStore.set('currentTheme', color);
Bus.emit(Events.THEME_CHANGED, color);
```

The `save()` function in `settings.js` persists the theme by reading `appStore.get('currentTheme')`. Since the custom color picker never wrote to `appStore`, `save()` always stored the stale preset theme name (e.g. `"purple"`). On restart, the app loaded the stale value from `settings.json`, causing the custom hex color to be lost.

Additionally, `initThemeSettings()` called `applyColorTheme(savedTheme)` on startup but never synced the theme into `appStore`. This meant any later `save()` (triggered by changing unrelated settings) could overwrite the persisted custom hex theme with the stale store default.

### Fix

**1. Custom color input handler** 鈥?added `appStore.set` and `Bus.emit` to match the preset color circle handler:

```diff
  customColorInput.onchange = () => {
      const color = customColorInput.value;
      applyColorTheme(color);
+     appStore.set('currentTheme', color);
+     Bus.emit(Events.THEME_CHANGED, color);
      save();
  };
```

**2. Theme initialization** 鈥?sync the normalized theme into `appStore` on startup to prevent stale store value from overwriting persisted theme:

```diff
+ import { applyTheme, currentTheme } from '../theme.js';
  ...
  applyColorTheme(savedTheme);
+ appStore.set('currentTheme', currentTheme);
```

Using `currentTheme` (the normalized export from `applyTheme()`) instead of raw `savedTheme` ensures that `null`/invalid values are properly fallback to `'purple'` before being stored, preventing them from being persisted back to `settings.json` by a later `save()`.

### Verification

- `pnpm lint` 鈥?passed
- `pnpm typecheck` 鈥?passed
- 1 file changed, 4 insertions(+), 1 deletion(-)