### PR TITLE
fix: persist custom theme color across restarts

### DIFF
--- a/apps/desktop/src/ui/settings/theme.js
+++ b/apps/desktop/src/ui/settings/theme.js
@@ -8,7 +8,7 @@
  * @module ui/settings/theme
  */
 
-import { applyTheme } from '../theme.js';
+import { applyTheme, currentTheme } from '../theme.js';
 import { appStore } from '../state.js';
 import { Bus, Events } from '../events.js';
 import { debounce } from '../../utils/debounce.js';
@@ -177,12 +177,19 @@ export function initThemeSettings({
         media._zephyrBound = true;
     }
 
-    applyColorTheme(savedTheme);
+    const saved = typeof savedTheme === 'string' && savedTheme.trim() ? savedTheme : null;
+    const stored = appStore.get('currentTheme');
+    const storedTheme = typeof stored === 'string' && stored.trim() ? stored : null;
+    const initialTheme = saved ?? storedTheme ?? 'purple';
+    applyColorTheme(initialTheme);
+    appStore.set('currentTheme', currentTheme);
 
     if (customColorInput) {
         customColorInput.onchange = () => {
             const color = customColorInput.value;
             applyColorTheme(color);
+            appStore.set('currentTheme', currentTheme);
+            Bus.emit(Events.THEME_CHANGED, currentTheme);
             save();
         };
     }


### PR DESCRIPTION
## Fix: Custom theme color resets on restart

### Root Cause

The `customColorInput.onchange` handler was missing `appStore.set` and `Bus.emit` that the preset theme handler had. The `save()` function reads `appStore.get('currentTheme')`, so custom hex colors were never persisted 鈥?only the stale preset name (e.g. `"purple"`) was saved.

Additionally, `initThemeSettings()` never synced the applied theme into `appStore`, so any later `save()` could overwrite the persisted theme with a stale default.

### Fix

1. **Import `currentTheme`** (normalized export from `applyTheme()`) 鈥?ensures stored value is always normalized
2. **Custom color handler** 鈥?`appStore.set('currentTheme', currentTheme)` + `Bus.emit(Events.THEME_CHANGED, currentTheme)` before `save()`
3. **Init** 鈥?resolve initial theme with blank-string guards: `saved ?? storedTheme ?? 'purple'`, then sync normalized `currentTheme` into `appStore`

### Verification

- `pnpm lint` 鈥?passed
- `pnpm typecheck` 鈥?passed
- 1 file changed, 9 insertions(+), 2 deletions(-)