### PR TITLE
fix(check-i18n): parse translations with static recursive-descent parser

### DIFF
--- a/packages/scripts/check-i18n.js
+++ b/packages/scripts/check-i18n.js
@@ -3,21 +3,34 @@
 /**
  * Zephyr i18n Completeness Checker
  *
- * Extracts translation keys from apps/desktop/src/i18n.js using a
- * brace-depth-aware parser (no AST dependency, no DOM dependency).
+ * Parses the `translations` object from i18n.js using a static recursive-
+ * descent parser — no dynamic code execution (no eval, no new Function,
+ * no vm.runInNewContext). This avoids SonarCloud security alerts while
+ * preserving identical string-parsing semantics to the JavaScript runtime.
+ *
+ * Key design principle: the checker mirrors `resolveKey()` and `t()` from
+ * i18n.js — using `hasOwnProperty` for key existence (same as resolveKey)
+ * and `typeof value === 'string'` for value type (same as t()).
  *
  * Reports:
- *   - Missing keys per locale (present in `en` but absent in target)
- *   - Empty-string keys per locale (present but will fallback to English)
+ *   - Missing keys per locale (present in `en` but absent in target —
+ *     runtime falls back to English)
+ *   - Empty-string keys per locale (present but blank — runtime shows "",
+ *     does NOT fall back to English)
+ *   - Type-mismatched keys per locale (en value is string but target is
+ *     not — runtime returns the raw key name instead of a translation)
+ *   - Stale keys per locale (present in target but absent from en — likely
+ *     orphaned after an en key was renamed or removed)
+ *   - Duplicate keys per locale (silently overwritten — a translation defect)
  *   - data-i18n / data-i18n-placeholder attributes used in HTML/JS but
  *     missing from en translations
  *
  * Exit codes:
- *   0  — always (warnings only; ja/ko are known skeleton translations)
- *   1  — when --strict is passed AND issues are found
+ *   0  — always (warnings only; incomplete locales fall back to English)
+ *   1  — when --strict is passed AND issues are found, or on fatal error
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname, join, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -34,81 +47,211 @@ const args = process.argv.slice(2);
 const strict = args.includes('--strict');
 
 // ---------------------------------------------------------------------------
-// Brace-depth-aware block extractor
+// Static object literal parser (module-level class to keep cognitive
+// complexity below SonarCloud's threshold — nested closures would
+// attribute all branching to the enclosing function)
 // ---------------------------------------------------------------------------
 
 /**
- * Given the full source text and a language identifier, locate the
- * `lang: { ... }` block and return its inner content as a string.
+ * Recursive-descent parser for JavaScript object literals — no `eval`,
+ * `new Function`, or `vm.runInNewContext`.
  *
- * Handles nested braces inside string literals correctly.
+ * Supports the subset used in the translations object:
+ * - Double- and single-quoted strings with standard escape sequences
+ *   (\n \t \r \b \f \v \0 \\ \" \' \` \/ \uXXXX \u{...} \xXX)
+ * - Nested object literals (for locale blocks and plural forms)
+ * - Unquoted identifier keys (e.g. `en:`, `zh:`)
+ * - Quoted string keys (e.g. `"key":`)
+ * - Trailing commas (commas are consumed as trivia, so they are
+ *   optional between properties — this is lenient but acceptable
+ *   for a dev-only checker reading version-controlled source)
  */
-function extractBlock(content, lang) {
-    // Validate lang to prevent ReDoS — only allow word chars and hyphens
-    if (!/^[\w-]+$/.test(lang)) return null;
-    // Use [ \t] instead of \s to avoid super-linear backtracking (SonarCloud)
-    const blockStart = /(?:^|\n)[ \t]*([\w-]+)[ \t]*:[ \t]*\{/g;
-    let match;
-    while ((match = blockStart.exec(content)) !== null) {
-        if (match[1] === lang) break;
-    }
-    if (!match || match[1] !== lang) return null;
 
-    let depth = 0;
-    let inString = false;
-    let stringChar = '';
-    const start = match.index + match[0].length;
+/** Simple (single-character) escape sequences. */
+const SIMPLE_ESCAPES = new Map([
+    ['n', '\n'], ['t', '\t'], ['r', '\r'], ['b', '\b'],
+    ['f', '\f'], ['v', '\v'], ['0', '\0'], ['\\', '\\'],
+    ['"', '"'], ["'", "'"], ['`', '`'], ['/', '/'],
+]);
 
-    for (let i = start; i < content.length; i++) {
-        const ch = content[i];
+const TRIVIA_CHARS = new Set([' ', '\t', '\n', '\r', ',']);
 
-        if (inString) {
-            if (ch === '\\') { i++; continue; }
-            if (ch === stringChar) inString = false;
-            continue;
-        }
-
-        if (ch === '"' || ch === "'" || ch === '`') {
-            inString = true;
-            stringChar = ch;
-            continue;
-        }
-
-        if (ch === '{') depth++;
-        if (ch === '}') {
-            if (depth === 0) return content.substring(start, i);
-            depth--;
-        }
+class ObjectLiteralParser {
+    /**
+     * @param {string} content - Full source text
+     * @param {number} startPos - Position of the opening `{`
+     */
+    constructor(content, startPos) {
+        this.content = content;
+        this.pos = startPos;
+        /** @type {string[]} */
+        this.duplicateKeys = [];
     }
 
-    return null;
+    /** Skip a `//` or block comment. Returns true if one was skipped. */
+    skipComment() {
+        const { content } = this;
+        if (content[this.pos] !== '/') return false;
+        if (content[this.pos + 1] === '/') {
+            this.pos += 2;
+            while (this.pos < content.length && content[this.pos] !== '\n') this.pos++;
+            return true;
+        }
+        if (content[this.pos + 1] === '*') {
+            const end = content.indexOf('*/', this.pos + 2);
+            this.pos = end === -1 ? content.length : end + 2;
+            return true;
+        }
+        return false;
+    }
+
+    /** Advance over whitespace, commas, and comments. */
+    skipTrivia() {
+        while (this.pos < this.content.length) {
+            if (TRIVIA_CHARS.has(this.content[this.pos])) { this.pos++; continue; }
+            if (!this.skipComment()) break;
+        }
+    }
+
+    /** Decode a `\uXXXX` or `\u{...}` escape at the backslash `this.pos`. */
+    parseUnicodeEscape() {
+        const { content } = this;
+        if (content[this.pos + 2] === '{') {
+            const end = content.indexOf('}', this.pos + 3);
+            if (end === -1) throw new Error(`Unterminated \\u{...} escape at position ${this.pos}`);
+            const hex = content.substring(this.pos + 3, end);
+            if (!/^[0-9a-fA-F]+$/.test(hex)) throw new Error(`Invalid \\u{...} escape at position ${this.pos}`);
+            const code = Number.parseInt(hex, 16);
+            if (code > 0x10FFFF) throw new Error(`Code point out of range in \\u{...} escape at position ${this.pos}`);
+            this.pos = end + 1;
+            return String.fromCodePoint(code);
+        }
+        const hex4 = content.substring(this.pos + 2, this.pos + 6);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex4)) throw new Error(`Invalid \\u escape at position ${this.pos}`);
+        this.pos += 6;
+        return String.fromCodePoint(Number.parseInt(hex4, 16));
+    }
+
+    /** Decode a `\xXX` escape at the backslash `this.pos`. */
+    parseHexEscape() {
+        const hex2 = this.content.substring(this.pos + 2, this.pos + 4);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex2)) throw new Error(`Invalid \\x escape at position ${this.pos}`);
+        this.pos += 4;
+        return String.fromCodePoint(Number.parseInt(hex2, 16));
+    }
+
+    /** Decode the escape sequence starting at the backslash at `this.pos`. */
+    parseEscape() {
+        const next = this.content[this.pos + 1];
+        if (next === undefined) throw new Error(`Unterminated escape sequence at position ${this.pos}`);
+        const simple = SIMPLE_ESCAPES.get(next);
+        if (simple !== undefined) { this.pos += 2; return simple; }
+        if (next === 'u') return this.parseUnicodeEscape();
+        if (next === 'x') return this.parseHexEscape();
+        if (next === '\n' || next === '\r') {
+            this.pos += 2;
+            if (next === '\r' && this.content[this.pos] === '\n') this.pos++;
+            return '';
+        }
+        this.pos += 2;
+        return next;
+    }
+
+    /** Parse a string literal (double- or single-quoted). */
+    parseString() {
+        const { content } = this;
+        const quote = content[this.pos];
+        this.pos++;
+        let result = '';
+        while (this.pos < content.length) {
+            const ch = content[this.pos];
+            if (ch === '\\') result += this.parseEscape();
+            else if (ch === quote) { this.pos++; return result; }
+            else { result += ch; this.pos++; }
+        }
+        throw new Error('Unterminated string literal in translations object');
+    }
+
+    /** Parse a property key (identifier or string). */
+    parseKey() {
+        this.skipTrivia();
+        const { content } = this;
+        if (content[this.pos] === '"' || content[this.pos] === "'") return this.parseString();
+        const start = this.pos;
+        while (this.pos < content.length && /[\w$]/.test(content[this.pos])) this.pos++;
+        if (this.pos === start) throw new Error(`Expected key at position ${this.pos}`);
+        return content.substring(start, this.pos);
+    }
+
+    /** Parse a value: nested object or string literal. */
+    parseValue() {
+        this.skipTrivia();
+        const ch = this.content[this.pos];
+        if (ch === '{') return this.parseObject();
+        if (ch === '"' || ch === "'") return this.parseString();
+        throw new Error(`Unsupported value '${ch}' at position ${this.pos} — only quoted strings and object literals are supported (numbers, booleans, null, template literals, and concatenated strings are not allowed)`);
+    }
+
+    /** Parse an object literal: { key: value, ... } */
+    parseObject() {
+        this.pos++; // skip '{'
+        /** @type {Record<string, unknown>} */
+        const obj = Object.create(null);
+        this.skipTrivia();
+        while (this.content[this.pos] !== '}') {
+            if (this.pos >= this.content.length) throw new Error('Unterminated object literal');
+            const key = this.parseKey();
+            this.skipTrivia();
+            if (this.content[this.pos] !== ':') throw new Error(`Expected ':' at position ${this.pos}`);
+            this.pos++;
+            if (Object.hasOwn(obj, key)) this.duplicateKeys.push(key);
+            obj[key] = this.parseValue();
+            this.skipTrivia();
+        }
+        this.pos++;
+        return obj;
+    }
 }
 
 /**
- * Extract all top-level keys from a block string.
- * Matches lines like `  someKey: "value"` or `someKey: 'value'`.
+ * Find the `{` that opens the `translations` object, then parse it
+ * statically into a JavaScript object.
+ *
+ * @param {string} content - Full source text of i18n.js
+ * @returns {{translations: Record<string, Record<string, unknown>>, duplicates: string[]}}
+ * @throws {Error} If the object cannot be found or parsed
  */
-function extractKeys(block) {
-    const keys = new Set();
-    const keyRegex = /^\s*(\w+)\s*:/gm;
-    let m;
-    while ((m = keyRegex.exec(block)) !== null) {
-        keys.add(m[1]);
-    }
-    return keys;
-}
+function loadTranslations(content) {
+    const declMatch = /export\s+const\s+translations\s*=/g.exec(content);
+    if (!declMatch) throw new Error('Could not find `export const translations =` in i18n.js');
 
-/**
- * Extract keys whose values are empty strings: `key: ""` or `key: ''`.
- */
-function extractEmptyKeys(block) {
-    const empty = new Set();
-    const emptyRegex = /^\s*(\w+)\s*:\s*["']\s*["']/gm;
-    let m;
-    while ((m = emptyRegex.exec(block)) !== null) {
-        empty.add(m[1]);
+    let pos = declMatch.index + declMatch[0].length;
+
+    // Skip whitespace and comments between `=` and `{`
+    while (pos < content.length) {
+        const ch = content[pos];
+        if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') { pos++; continue; }
+        if (ch === '/' && content[pos + 1] === '/') {
+            pos += 2;
+            while (pos < content.length && content[pos] !== '\n') pos++;
+            continue;
+        }
+        if (ch === '/' && content[pos + 1] === '*') {
+            const end = content.indexOf('*/', pos + 2);
+            pos = end === -1 ? content.length : end + 2;
+            continue;
+        }
+        break;
     }
-    return empty;
+    if (content[pos] !== '{') throw new Error(`Expected '{' after "export const translations =" at position ${pos}`);
+
+    const parser = new ObjectLiteralParser(content, pos);
+    const result = parser.parseObject();
+    if (!result || typeof result !== 'object') throw new Error('translations object parsed to a non-object value');
+    return {
+        translations: /** @type {Record<string, Record<string, unknown>>} */ (result),
+        duplicates: parser.duplicateKeys,
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +262,9 @@ function extractEmptyKeys(block) {
  * Recursively walk SRC_DIR and extract all unique keys from
  * data-i18n="key" and data-i18n-placeholder="key" attributes
  * in .html and .js files.
+ *
+ * @param {string} srcDir - Root directory to walk
+ * @returns {Set<string>} Unique i18n keys referenced in HTML attributes
  */
 function extractDataI18nKeys(srcDir) {
     const keys = new Set();
@@ -151,22 +297,78 @@ function extractDataI18nKeys(srcDir) {
 }
 
 // ---------------------------------------------------------------------------
+// Type-compatibility checker
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a target locale value's type is compatible with the English
+ * value's type — matching the runtime `t()` function's dispatch.
+ *
+ * - en=string → target must be string. If target is an object, `t()`
+ *   falls through to `typeof value === 'string' ? value : key` and returns
+ *   the raw key name — a real type mismatch.
+ * - en=object → target may be object (plural form) or string. When `t()`
+ *   is called with a count and the resolved value is a string, the runtime
+ *   interpolates it with `{count}` — no plural-category selection, but
+ *   still a valid rendered string, not the raw key.
+ *
+ * @param {*} enValue - The English locale's value for this key
+ * @param {*} targetValue - The target locale's value for this key
+ * @returns {boolean} `true` if types are compatible, `false` on mismatch
+ */
+function isTypeCompatible(enValue, targetValue) {
+    const targetIsString = typeof targetValue === 'string';
+    const targetIsObject = typeof targetValue === 'object' && targetValue !== null;
+
+    if (typeof enValue === 'string') return targetIsString;
+    if (typeof enValue === 'object' && enValue !== null) return targetIsString || targetIsObject;
+    return false;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 function main() {
-    const content = readFileSync(I18N_PATH, 'utf-8');
-
-    const enBlock = extractBlock(content, 'en');
-    if (!enBlock) {
-        console.error(`[check-i18n] ERROR: Could not locate "en" block in ${I18N_PATH}`);
+    let translations, duplicateKeys;
+    try {
+        const content = readFileSync(I18N_PATH, 'utf-8');
+        ({ translations, duplicates: duplicateKeys } = loadTranslations(content));
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[check-i18n] ERROR: Failed to load translations from ${I18N_PATH}: ${msg}`);
         process.exit(1);
     }
 
-    const enKeys = extractKeys(enBlock);
-    const targetLocales = ['zh', 'ja', 'ko'];
-
     let totalIssues = 0;
+
+    if (duplicateKeys.length > 0) {
+        console.log('Duplicate keys detected in translations object:');
+        for (const key of duplicateKeys) console.log(`  - ${key}`);
+        console.log('');
+        totalIssues += duplicateKeys.length;
+    }
+
+    // Use the exact same lookup that resolveKey() uses at runtime:
+    //   translations.en  →  the base locale
+    const enObj = translations.en;
+    if (!enObj || typeof enObj !== 'object') {
+        console.error(`[check-i18n] ERROR: "en" locale not found or invalid in ${I18N_PATH}`);
+        process.exit(1);
+    }
+
+    // Object.keys() returns own enumerable properties — exactly what
+    // resolveKey() iterates over via hasOwnProperty.
+    const enKeys = new Set(Object.keys(enObj));
+
+    // Discover all target locales dynamically: every key in translations
+    // except 'en'. This never goes stale when new languages are added.
+    const targetLocales = Object.keys(translations).filter(l => l !== 'en');
+
+    if (targetLocales.length === 0) {
+        console.error('[check-i18n] ERROR: No target locales found in translations object');
+        process.exit(1);
+    }
 
     console.log('========================================');
     console.log('  Zephyr i18n Completeness Report');
@@ -174,37 +376,90 @@ function main() {
     console.log('========================================\n');
 
     for (const locale of targetLocales) {
-        const block = extractBlock(content, locale);
-        if (!block) {
-            console.error(`[check-i18n] ERROR: Could not locate "${locale}" block in ${I18N_PATH}`);
+        const localeObj = translations[locale];
+        if (!localeObj || typeof localeObj !== 'object') {
+            console.error(`[check-i18n] ERROR: Locale "${locale}" is defined but has no object value`);
             totalIssues += enKeys.size;
             continue;
         }
 
-        const localeKeys = extractKeys(block);
-        const emptyKeys = extractEmptyKeys(block);
+        // Mirror resolveKey(): check hasOwnProperty for each en key.
+        // If the key exists in the target locale, resolveKey() returns
+        // its value (even if it's ""). If not, resolveKey() falls back
+        // to the en value.
+        const missing = [];
+        const empty = [];
+        const typeMismatch = [];
+        const extra = Object.keys(localeObj).filter(k => !enKeys.has(k));
 
-        const missing = [...enKeys].filter(k => !localeKeys.has(k));
-        const empty = [...emptyKeys];
+        for (const key of enKeys) {
+            if (!Object.hasOwn(localeObj, key)) {
+                // Key absent → runtime falls back to English
+                missing.push(key);
+            } else {
+                const val = localeObj[key];
+                const enVal = enObj[key];
 
-        const localeIssues = missing.length + empty.length;
+                if (!isTypeCompatible(enVal, val)) {
+                    // Type mismatch: en is string but target is not.
+                    // At runtime, t() returns the raw key name
+                    // instead of a translation.
+                    typeMismatch.push(key);
+                } else if (typeof val === 'string' && val.trim() === '') {
+                    // Empty or whitespace-only string — t() returns it,
+                    // the UI shows blank, with NO English fallback.
+                    empty.push(key);
+                } else if (typeof enVal === 'object' && enVal !== null &&
+                           typeof val === 'object' && val !== null) {
+                    // Recursively check nested plural-object keys:
+                    for (const sub of Object.keys(enVal)) {
+                        if (!Object.hasOwn(val, sub)) {
+                            missing.push(`${key}.${sub}`);
+                        } else if (typeof val[sub] !== 'string') {
+                            typeMismatch.push(`${key}.${sub}`);
+                        } else if (val[sub].trim() === '') {
+                            empty.push(`${key}.${sub}`);
+                        }
+                    }
+                }
+            }
+        }
+
+        const localeKeyCount = Object.keys(localeObj).filter(k => enKeys.has(k)).length;
+        const localeIssues = missing.length + empty.length + typeMismatch.length + extra.length;
         totalIssues += localeIssues;
 
         if (localeIssues === 0) {
-            console.log(`[${locale}] OK — ${localeKeys.size}/${enKeys.size} keys, 0 issues`);
+            console.log(`[${locale}] OK — ${localeKeyCount}/${enKeys.size} keys, 0 issues`);
         } else {
-            console.log(`[${locale}] ${localeIssues} issue(s) — ${localeKeys.size}/${enKeys.size} keys present`);
+            console.log(`[${locale}] ${localeIssues} issue(s) — ${localeKeyCount}/${enKeys.size} keys present`);
 
             if (missing.length > 0) {
-                console.log(`  Missing keys (${missing.length}):`);
+                console.log(`  Missing keys (${missing.length}, runtime falls back to English):`);
                 for (const key of missing) {
                     console.log(`    - ${key}`);
                 }
             }
 
             if (empty.length > 0) {
-                console.log(`  Empty-string keys (${empty.length}, fallback to English):`);
+                console.log(`  Empty-string keys (${empty.length}, blank at runtime — no English fallback):`);
                 for (const key of empty) {
+                    console.log(`    - ${key}`);
+                }
+            }
+
+            if (typeMismatch.length > 0) {
+                console.log(`  Type-mismatched keys (${typeMismatch.length}, runtime returns raw key name):`);
+                for (const key of typeMismatch) {
+                    const enType = Array.isArray(enObj[key]) ? 'array' : typeof enObj[key];
+                    const targetType = Array.isArray(localeObj[key]) ? 'array' : typeof localeObj[key];
+                    console.log(`    - ${key} (en: ${enType}, ${locale}: ${targetType})`);
+                }
+            }
+
+            if (extra.length > 0) {
+                console.log(`  Stale keys (${extra.length}, present in ${locale} but not in en):`);
+                for (const key of extra) {
                     console.log(`    - ${key}`);
                 }
             }
@@ -240,7 +495,8 @@ function main() {
     console.log('----------------------------------------');
 
     if (totalIssues > 0) {
-        console.log('\nNOTE: ja/ko are skeleton translations — missing keys are expected.');
+        console.log('\nNOTE: Some locales may have incomplete translations.');
+        console.log('      Missing keys fall back to English; empty strings show blank.');
         console.log('      Re-run with --strict to make this check fail (exit 1).\n');
 
         if (strict) {


### PR DESCRIPTION
## Problem

The i18n completeness checker had three categories of bugs:

### 1. Stale hardcoded locale list

`i18n.js` defines **14 languages** (`en` + 13 targets), but the checker only validated `['zh', 'ja', 'ko']` — `ru`, `es`, `fa`, `tk`, `my`, `ar`, `ur`, `sw`, `tr`, `vi` were invisible.

### 2. Regex false positives

- **Mixed quotes**: `"'@@requested@@' ..."` misidentified as empty string
- **Wrong backreference**: `global: "global"` matched because `\1` (key name) appeared at start of value
- **Phantom keys**: `ja`/`ko` reported 727/726 keys from regex matching `word:` inside string values

### 3. Dynamic code execution (SonarCloud Quality Gate failure)

`new Function` / `vm.runInNewContext` triggered SonarCloud security alerts.

## Solution

**Static recursive-descent parser** — no `eval`, no `new Function`, no `vm.runInNewContext`. The parser handles the exact subset used in translations:
- Double/single-quoted strings with all escape sequences (`\n \t \r \b \f \v \0 \\ \" \' \` \/ \uXXXX \u{...} \xXX`)
- Nested objects (locale blocks + plural forms)
- Unquoted identifier keys, quoted string keys, trailing commas

### Runtime parity

| Check | Runtime | Checker |
|---|---|---|
| Key existence | `hasOwnProperty(primary, key)` | `Object.hasOwn(localeObj, key)` |
| Value is string | `typeof value === 'string'` | `typeof val === 'string'` |
| Type mismatch | `t()` returns raw key name | `isTypeCompatible()` checked first |
| Empty string | `t()` returns `""` (no fallback) | Reports "blank, no English fallback" |
| en=object, target=string | `t(key, count)` interpolates string with `{count}` | Compatible (no false type mismatch) |
| Nested plural categories | `pluralObj[category] \u2014 pluralObj.other \u2014 pluralObj.one` | Recursive check for missing/empty sub-keys |

### Hardening (from review feedback across 3 PR rounds)

- **Escape decoding extracted** to `parseEscape()`, `parseUnicodeEscape()`, `parseHexEscape()` — reduces `parseString` cognitive complexity below 15
- **`SIMPLE_ESCAPES` lookup table** replaces 14-case switch statement
- **Strict hex-digit validation** — `/^[0-9a-fA-F]{4}$/` for `\uXXXX`, `/^[0-9a-fA-F]{2}$/` for `\xXX`, `/^[0-9a-fA-F]+$/` for `\u{...}`
- **Code point range check** — `code > 0x10FFFF` throws before `String.fromCodePoint()`
- **EOF guard in `parseEscape`** — throws on backslash at end of input
- **CRLF line continuation** — handles `\r`, `\r\n` in addition to `\n`
- **`String.fromCodePoint()`** for `\xXX` escapes (was `String.fromCharCode`)
- **`parseValue` error message** — names unsupported types (numbers, booleans, null, template literals)
- **`isTypeCompatible` fix** — en=object + target=string is now compatible (runtime interpolates string with count)
- **Recursive nested plural validation** — checks each plural category exists and is non-empty in target locale
- **Stale key detection** — reports keys in target locale but absent from `en`
- **Robust declaration matching** — skips comments between `=` and `{` in `export const translations = ...`
- **`readFileSync` inside try/catch** — consistent error handling
- **`Object.create(null)`** in `parseObject` — prevents `__proto__` pollution
- **`skipComment()` extracted** — reduces cognitive complexity

## Verification

```
Base locale "en": 726 keys

[zh] 2 issue(s) — 726/726 keys present
  Missing keys (2, runtime falls back to English):
    - consoleSubDaysLeft.one
    - consoleSubNodes.one
[ja] 2 issue(s) — 726/726 keys present
  Missing keys (2, runtime falls back to English):
    - consoleSubDaysLeft.one
    - consoleSubNodes.one
[ko] 2 issue(s) — 726/726 keys present
  Missing keys (2, runtime falls back to English):
    - consoleSubDaysLeft.one
    - consoleSubNodes.one
[ru] OK    [es] OK    [fa] OK    [tk] OK    [my] OK
[ar] OK    [ur] OK    [sw] OK    [tr] OK    [vi] OK

data-i18n Attribute Coverage: OK — all 249 keys found
Total issues: 6
```

The 6 issues are real: zh/ja/ko plural objects `consoleSubDaysLeft` and `consoleSubNodes` are missing the `one` category — runtime falls back to `other` form.

## Changes

- `packages/scripts/check-i18n.js` — rewritten (337 insertions, 86 deletions)