### PR TITLE
fix(check-i18n): rewrite with static parser and CLDR-aware plural validation

### DIFF
--- a/packages/scripts/check-i18n.js
+++ b/packages/scripts/check-i18n.js
@@ -3,21 +3,35 @@
 /**
  * Zephyr i18n Completeness Checker
  *
- * Extracts translation keys from apps/desktop/src/i18n.js using a
- * brace-depth-aware parser (no AST dependency, no DOM dependency).
+ * Parses the `translations` object from i18n.js using a static recursive-
+ * descent parser — no dynamic code execution (no eval, no new Function,
+ * no vm.runInNewContext). This avoids SonarCloud security alerts while
+ * preserving identical string-parsing semantics to the JavaScript runtime.
+ *
+ * Key design principle: the checker mirrors `resolveKey()` and `t()` from
+ * i18n.js — using `hasOwnProperty` for key existence (same as resolveKey)
+ * and `typeof value === 'string'` for value type (same as t()).
  *
  * Reports:
- *   - Missing keys per locale (present in `en` but absent in target)
- *   - Empty-string keys per locale (present but will fallback to English)
+ *   - Missing keys per locale (present in `en` but absent in target —
+ *     runtime falls back to English)
+ *   - Empty-string keys per locale (present but blank — runtime shows "",
+ *     does NOT fall back to English)
+ *   - Type-mismatched keys per locale (en value is string but target is
+ *     not — runtime returns the raw key name instead of a translation)
+ *   - Stale keys per locale (present in target but absent from en — likely
+ *     orphaned after an en key was renamed or removed)
+ *   - Duplicate keys per locale (silently overwritten — a translation defect)
  *   - data-i18n / data-i18n-placeholder attributes used in HTML/JS but
  *     missing from en translations
  *
  * Exit codes:
- *   0  — always (warnings only; ja/ko are known skeleton translations)
- *   1  — when --strict is passed AND issues are found
+ *   0  — no issues, or issues found without --strict (warnings only;
+ *        incomplete locales fall back to English)
+ *   1  — when --strict is passed AND issues are found, or on fatal error
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname, join, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -34,81 +48,211 @@ const args = process.argv.slice(2);
 const strict = args.includes('--strict');
 
 // ---------------------------------------------------------------------------
-// Brace-depth-aware block extractor
+// Static object literal parser (module-level class to keep cognitive
+// complexity below SonarCloud's threshold — nested closures would
+// attribute all branching to the enclosing function)
 // ---------------------------------------------------------------------------
 
 /**
- * Given the full source text and a language identifier, locate the
- * `lang: { ... }` block and return its inner content as a string.
+ * Recursive-descent parser for JavaScript object literals — no `eval`,
+ * `new Function`, or `vm.runInNewContext`.
  *
- * Handles nested braces inside string literals correctly.
+ * Supports the subset used in the translations object:
+ * - Double- and single-quoted strings with standard escape sequences
+ *   (\n \t \r \b \f \v \0 \\ \" \' \` \/ \uXXXX \u{...} \xXX)
+ * - Nested object literals (for locale blocks and plural forms)
+ * - Unquoted identifier keys (e.g. `en:`, `zh:`)
+ * - Quoted string keys (e.g. `"key":`)
+ * - Commas required between properties (with optional trailing
+ *   comma before `}`), matching real JavaScript object-literal syntax
  */
-function extractBlock(content, lang) {
-    // Validate lang to prevent ReDoS — only allow word chars and hyphens
-    if (!/^[\w-]+$/.test(lang)) return null;
-    // Use [ \t] instead of \s to avoid super-linear backtracking (SonarCloud)
-    const blockStart = /(?:^|\n)[ \t]*([\w-]+)[ \t]*:[ \t]*\{/g;
-    let match;
-    while ((match = blockStart.exec(content)) !== null) {
-        if (match[1] === lang) break;
-    }
-    if (!match || match[1] !== lang) return null;
 
-    let depth = 0;
-    let inString = false;
-    let stringChar = '';
-    const start = match.index + match[0].length;
+/** Simple (single-character) escape sequences. */
+const SIMPLE_ESCAPES = new Map([
+    ['n', '\n'], ['t', '\t'], ['r', '\r'], ['b', '\b'],
+    ['f', '\f'], ['v', '\v'], ['0', '\0'], ['\\', '\\'],
+    ['"', '"'], ["'", "'"], ['`', '`'], ['/', '/'],
+]);
 
-    for (let i = start; i < content.length; i++) {
-        const ch = content[i];
+const TRIVIA_CHARS = new Set([' ', '\t', '\n', '\r']);
 
-        if (inString) {
-            if (ch === '\\') { i++; continue; }
-            if (ch === stringChar) inString = false;
-            continue;
-        }
-
-        if (ch === '"' || ch === "'" || ch === '`') {
-            inString = true;
-            stringChar = ch;
-            continue;
-        }
-
-        if (ch === '{') depth++;
-        if (ch === '}') {
-            if (depth === 0) return content.substring(start, i);
-            depth--;
-        }
+class ObjectLiteralParser {
+    /**
+     * @param {string} content - Full source text
+     * @param {number} startPos - Position of the opening `{`
+     */
+    constructor(content, startPos) {
+        this.content = content;
+        this.pos = startPos;
+        /** @type {string[]} */
+        this.duplicateKeys = [];
     }
 
-    return null;
+    /** Skip a `//` or block comment. Returns true if one was skipped. */
+    skipComment() {
+        const { content } = this;
+        if (content[this.pos] !== '/') return false;
+        if (content[this.pos + 1] === '/') {
+            this.pos += 2;
+            while (this.pos < content.length && content[this.pos] !== '\n') this.pos++;
+            return true;
+        }
+        if (content[this.pos + 1] === '*') {
+            const end = content.indexOf('*/', this.pos + 2);
+            this.pos = end === -1 ? content.length : end + 2;
+            return true;
+        }
+        return false;
+    }
+
+    /** Advance over whitespace and comments. Commas are handled in parseObject(). */
+    skipTrivia() {
+        while (this.pos < this.content.length) {
+            if (TRIVIA_CHARS.has(this.content[this.pos])) { this.pos++; continue; }
+            if (!this.skipComment()) break;
+        }
+    }
+
+    /** Decode a `\uXXXX` or `\u{...}` escape at the backslash `this.pos`. */
+    parseUnicodeEscape() {
+        const { content } = this;
+        if (content[this.pos + 2] === '{') {
+            const end = content.indexOf('}', this.pos + 3);
+            if (end === -1) throw new Error(`Unterminated \\u{...} escape at position ${this.pos}`);
+            const hex = content.substring(this.pos + 3, end);
+            if (!/^[0-9a-fA-F]+$/.test(hex)) throw new Error(`Invalid \\u{...} escape at position ${this.pos}`);
+            const code = Number.parseInt(hex, 16);
+            if (code > 0x10FFFF) throw new Error(`Code point out of range in \\u{...} escape at position ${this.pos}`);
+            this.pos = end + 1;
+            // \u{...} can produce any code point 0–0x10FFFF.  For BMP code
+            // points (≤ 0xFFFF), use fromCharCode to produce the UTF-16 code
+            // unit directly.  For astral-plane code points (> 0xFFFF), use
+            // fromCodePoint which emits a surrogate pair.
+            if (code <= 0xFFFF) return String.fromCharCode(code);
+            return String.fromCodePoint(code);
+        }
+        const hex4 = content.substring(this.pos + 2, this.pos + 6);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex4)) throw new Error(`Invalid \\u escape at position ${this.pos}`);
+        this.pos += 6;
+        // \uXXXX produces a UTF-16 code unit, not a code point.
+        // Use fromCharCode to correctly handle lone surrogates.
+        return String.fromCharCode(Number.parseInt(hex4, 16));
+    }
+
+    /** Decode a `\xXX` escape at the backslash `this.pos`. */
+    parseHexEscape() {
+        const hex2 = this.content.substring(this.pos + 2, this.pos + 4);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex2)) throw new Error(`Invalid \\x escape at position ${this.pos}`);
+        this.pos += 4;
+        // \xXX produces a UTF-16 code unit, not a code point.
+        return String.fromCharCode(Number.parseInt(hex2, 16));
+    }
+
+    /** Decode the escape sequence starting at the backslash at `this.pos`. */
+    parseEscape() {
+        const next = this.content[this.pos + 1];
+        if (next === undefined) throw new Error(`Unterminated escape sequence at position ${this.pos}`);
+        const simple = SIMPLE_ESCAPES.get(next);
+        if (simple !== undefined) { this.pos += 2; return simple; }
+        if (next === 'u') return this.parseUnicodeEscape();
+        if (next === 'x') return this.parseHexEscape();
+        if (next === '\n' || next === '\r') {
+            this.pos += 2;
+            if (next === '\r' && this.content[this.pos] === '\n') this.pos++;
+            return '';
+        }
+        this.pos += 2;
+        return next;
+    }
+
+    /** Parse a string literal (double- or single-quoted). */
+    parseString() {
+        const { content } = this;
+        const quote = content[this.pos];
+        this.pos++;
+        const parts = [];
+        while (this.pos < content.length) {
+            const ch = content[this.pos];
+            if (ch === '\\') parts.push(this.parseEscape());
+            else if (ch === quote) { this.pos++; return parts.join(''); }
+            else { parts.push(ch); this.pos++; }
+        }
+        throw new Error('Unterminated string literal in translations object');
+    }
+
+    /** Parse a property key (identifier or string). */
+    parseKey() {
+        this.skipTrivia();
+        const { content } = this;
+        if (content[this.pos] === '"' || content[this.pos] === "'") return this.parseString();
+        const start = this.pos;
+        while (this.pos < content.length && /[\w$]/.test(content[this.pos])) this.pos++;
+        if (this.pos === start) throw new Error(`Expected key at position ${this.pos}`);
+        return content.substring(start, this.pos);
+    }
+
+    /** Parse a value: nested object or string literal. */
+    parseValue(path = '') {
+        this.skipTrivia();
+        const ch = this.content[this.pos];
+        if (ch === '{') return this.parseObject(path);
+        if (ch === '"' || ch === "'") return this.parseString();
+        throw new Error(`Unsupported value '${ch}' at position ${this.pos} — only quoted strings and object literals are supported (numbers, booleans, null, template literals, and concatenated strings are not allowed)`);
+    }
+
+    /** Parse an object literal: { key: value, ... } */
+    parseObject(path = '') {
+        this.pos++; // skip '{'
+        /** @type {Record<string, unknown>} */
+        const obj = Object.create(null);
+        this.skipTrivia();
+        while (this.content[this.pos] !== '}') {
+            if (this.pos >= this.content.length) throw new Error('Unterminated object literal');
+            const key = this.parseKey();
+            this.skipTrivia();
+            if (this.content[this.pos] !== ':') throw new Error(`Expected ':' at position ${this.pos}`);
+            this.pos++;
+            const qualified = path ? `${path}.${key}` : key;
+            if (Object.hasOwn(obj, key)) this.duplicateKeys.push(qualified);
+            obj[key] = this.parseValue(qualified);
+            this.skipTrivia();
+            // Require comma between properties; trailing comma allowed.
+            if (this.content[this.pos] === ',') {
+                this.pos++;
+                this.skipTrivia();
+            } else if (this.content[this.pos] !== '}') {
+                throw new Error(`Expected ',' or '}' at position ${this.pos}`);
+            }
+        }
+        this.pos++;
+        return obj;
+    }
 }
 
 /**
- * Extract all top-level keys from a block string.
- * Matches lines like `  someKey: "value"` or `someKey: 'value'`.
+ * Find the `{` that opens the `translations` object, then parse it
+ * statically into a JavaScript object.
+ *
+ * @param {string} content - Full source text of i18n.js
+ * @returns {{translations: Record<string, Record<string, unknown>>, duplicates: string[]}}
+ * @throws {Error} If the object cannot be found or parsed
  */
-function extractKeys(block) {
-    const keys = new Set();
-    const keyRegex = /^\s*(\w+)\s*:/gm;
-    let m;
-    while ((m = keyRegex.exec(block)) !== null) {
-        keys.add(m[1]);
-    }
-    return keys;
-}
+function loadTranslations(content) {
+    const declMatch = /export\s+const\s+translations\s*=/.exec(content);
+    if (!declMatch) throw new Error('Could not find `export const translations =` in i18n.js');
 
-/**
- * Extract keys whose values are empty strings: `key: ""` or `key: ''`.
- */
-function extractEmptyKeys(block) {
-    const empty = new Set();
-    const emptyRegex = /^\s*(\w+)\s*:\s*["']\s*["']/gm;
-    let m;
-    while ((m = emptyRegex.exec(block)) !== null) {
-        empty.add(m[1]);
+    const parser = new ObjectLiteralParser(content, declMatch.index + declMatch[0].length);
+    // Skip whitespace and comments between `=` and `{`
+    parser.skipTrivia();
+    if (content[parser.pos] !== '{') {
+        throw new Error(`Expected '{' after "export const translations =" at position ${parser.pos}`);
     }
-    return empty;
+    const result = parser.parseObject();
+    if (!result || typeof result !== 'object') throw new Error('translations object parsed to a non-object value');
+    return {
+        translations: /** @type {Record<string, Record<string, unknown>>} */ (result),
+        duplicates: parser.duplicateKeys,
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +263,9 @@ function extractEmptyKeys(block) {
  * Recursively walk SRC_DIR and extract all unique keys from
  * data-i18n="key" and data-i18n-placeholder="key" attributes
  * in .html and .js files.
+ *
+ * @param {string} srcDir - Root directory to walk
+ * @returns {Set<string>} Unique i18n keys referenced in HTML attributes
  */
 function extractDataI18nKeys(srcDir) {
     const keys = new Set();
@@ -151,22 +298,145 @@ function extractDataI18nKeys(srcDir) {
 }
 
 // ---------------------------------------------------------------------------
+// Type-compatibility checker
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the set of CLDR plural categories that a given locale requires.
+ *
+ * Mirrors the runtime `pluralCategory(count, lang)` function in i18n.js,
+ * which uses `Intl.PluralRules(lang).select(n)`. Different locales have
+ * different required categories — e.g. `en` needs `one`/`other`, `ru` needs
+ * `one`/`few`/`many`/`other`, `zh`/`ja`/`ko` need only `other`.
+ *
+ * @param {string} locale - Locale code (e.g. 'zh', 'ru', 'en')
+ * @returns {Set<string>} Set of required plural categories for this locale
+ */
+const _pluralCatCache = new Map();
+
+function getRequiredPluralCategories(locale) {
+    const cached = _pluralCatCache.get(locale);
+    if (cached) return cached;
+
+    let rules;
+    let localeInvalid = false;
+    try {
+        rules = new Intl.PluralRules(locale);
+    } catch {
+        localeInvalid = true;
+        console.warn(`[check-i18n] WARNING: "${locale}" is not a valid locale tag; using English plural rules.`);
+        rules = new Intl.PluralRules('en');
+    }
+
+    // Use resolvedOptions().pluralCategories for the authoritative CLDR
+    // category list — this is 100% accurate and immune to sampling gaps
+    // that could arise from non-contiguous CLDR ranges.
+    const resolvedOpts = rules.resolvedOptions();
+    // A small-icu Node build resolves unknown locales to the default
+    // locale without throwing, which would validate every locale against
+    // en rules. Detect this and warn — but only for valid original tags,
+    // since invalid tags already received a warning above.
+    if (!localeInvalid) {
+        const resolvedLocale = resolvedOpts.locale;
+        if (!resolvedLocale.toLowerCase().startsWith(locale.toLowerCase().split('-')[0])) {
+            console.warn(`[check-i18n] WARNING: plural rules for "${locale}" resolved to "${resolvedLocale}". Plural validation for this locale may not be reliable. Use a Node build with full ICU.`);
+        }
+    }
+    const cats = new Set(resolvedOpts.pluralCategories);
+    // 'other' is always the runtime fallback (pluralObj[category] || pluralObj.other)
+    cats.add('other');
+
+    _pluralCatCache.set(locale, cats);
+    return cats;
+}
+
+/**
+ * Resolve a dotted path (e.g. "plurals.one") within a nested object.
+ * @param {Record<string, unknown>} root - Root object
+ * @param {string} path - Dot-separated path
+ * @returns {unknown} Resolved value or undefined
+ */
+function resolvePath(root, path) {
+    let cur = /** @type {unknown} */ (root);
+    for (const part of path.split('.')) {
+        if (cur && typeof cur === 'object' && Object.hasOwn(cur, part)) {
+            cur = cur[part];
+        } else {
+            return undefined;
+        }
+    }
+    return cur;
+}
+
+/**
+ * Check whether a target locale value's type is compatible with the English
+ * value's type — matching the runtime `t()` function's dispatch.
+ *
+ * - en=string → target must be string. If target is an object, `t()`
+ *   falls through to `typeof value === 'string' ? value : key` and returns
+ *   the raw key name — a real type mismatch.
+ * - en=object → target may be object (plural form) or string. When `t()`
+ *   is called with a count and the resolved value is a string, the runtime
+ *   interpolates it with `{count}` — no plural-category selection, but
+ *   still a valid rendered string, not the raw key.
+ *
+ * @param {*} enValue - The English locale's value for this key
+ * @param {*} targetValue - The target locale's value for this key
+ * @returns {boolean} `true` if types are compatible, `false` on mismatch
+ */
+function isTypeCompatible(enValue, targetValue) {
+    const targetIsString = typeof targetValue === 'string';
+    const targetIsObject = typeof targetValue === 'object' && targetValue !== null;
+
+    if (typeof enValue === 'string') return targetIsString;
+    if (typeof enValue === 'object' && enValue !== null) return targetIsString || targetIsObject;
+    return false;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 function main() {
-    const content = readFileSync(I18N_PATH, 'utf-8');
-
-    const enBlock = extractBlock(content, 'en');
-    if (!enBlock) {
-        console.error(`[check-i18n] ERROR: Could not locate "en" block in ${I18N_PATH}`);
+    let translations, duplicateKeys;
+    try {
+        const content = readFileSync(I18N_PATH, 'utf-8');
+        ({ translations, duplicates: duplicateKeys } = loadTranslations(content));
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[check-i18n] ERROR: Failed to load translations from ${I18N_PATH}: ${msg}`);
         process.exit(1);
     }
 
-    const enKeys = extractKeys(enBlock);
-    const targetLocales = ['zh', 'ja', 'ko'];
-
     let totalIssues = 0;
+
+    if (duplicateKeys.length > 0) {
+        console.log('Duplicate keys detected in translations object:');
+        for (const key of duplicateKeys) console.log(`  - ${key}`);
+        console.log('');
+        totalIssues += duplicateKeys.length;
+    }
+
+    // Use the exact same lookup that resolveKey() uses at runtime:
+    //   translations.en  →  the base locale
+    const enObj = translations.en;
+    if (!enObj || typeof enObj !== 'object') {
+        console.error(`[check-i18n] ERROR: "en" locale not found or invalid in ${I18N_PATH}`);
+        process.exit(1);
+    }
+
+    // Object.keys() returns own enumerable properties — exactly what
+    // resolveKey() iterates over via hasOwnProperty.
+    const enKeys = new Set(Object.keys(enObj));
+
+    // Discover all target locales dynamically: every key in translations
+    // except 'en'. This never goes stale when new languages are added.
+    const targetLocales = Object.keys(translations).filter(l => l !== 'en');
+
+    if (targetLocales.length === 0) {
+        console.error('[check-i18n] ERROR: No target locales found in translations object');
+        process.exit(1);
+    }
 
     console.log('========================================');
     console.log('  Zephyr i18n Completeness Report');
@@ -174,40 +444,135 @@ function main() {
     console.log('========================================\n');
 
     for (const locale of targetLocales) {
-        const block = extractBlock(content, locale);
-        if (!block) {
-            console.error(`[check-i18n] ERROR: Could not locate "${locale}" block in ${I18N_PATH}`);
+        const localeObj = translations[locale];
+        if (!localeObj || typeof localeObj !== 'object') {
+            console.error(`[check-i18n] ERROR: Locale "${locale}" is defined but has no object value`);
             totalIssues += enKeys.size;
             continue;
         }
 
-        const localeKeys = extractKeys(block);
-        const emptyKeys = extractEmptyKeys(block);
+        // Mirror resolveKey(): check hasOwnProperty for each en key.
+        // If the key exists in the target locale, resolveKey() returns
+        // its value (even if it's ""). If not, resolveKey() falls back
+        // to the en value.
+        const missing = [];
+        const empty = [];
+        const typeMismatch = [];
+        const extra = Object.keys(localeObj).filter(k => !enKeys.has(k));
+        const unused = [];
 
-        const missing = [...enKeys].filter(k => !localeKeys.has(k));
-        const empty = [...emptyKeys];
+        for (const key of enKeys) {
+            if (!Object.hasOwn(localeObj, key)) {
+                // Key absent → runtime falls back to English
+                missing.push(key);
+            } else {
+                const val = localeObj[key];
+                const enVal = enObj[key];
 
-        const localeIssues = missing.length + empty.length;
+                if (!isTypeCompatible(enVal, val)) {
+                    // Type mismatch: en is string but target is not.
+                    // At runtime, t() returns the raw key name
+                    // instead of a translation.
+                    typeMismatch.push(key);
+                } else if (typeof val === 'string' && val.trim() === '') {
+                    // Empty or whitespace-only string — t() returns it,
+                    // the UI shows blank, with NO English fallback.
+                    empty.push(key);
+                } else if (typeof enVal === 'object' && enVal !== null &&
+                           typeof val === 'object' && val !== null) {
+                    // Validate against this locale's CLDR plural categories
+                    // (not en's), matching runtime pluralCategory(count, lang).
+                    const requiredCats = getRequiredPluralCategories(locale);
+                    for (const sub of requiredCats) {
+                        if (!Object.hasOwn(val, sub)) {
+                            missing.push(`${key}.${sub}`);
+                        } else if (typeof val[sub] !== 'string') {
+                            typeMismatch.push(`${key}.${sub}`);
+                        } else if (val[sub].trim() === '') {
+                            empty.push(`${key}.${sub}`);
+                        }
+                    }
+                    // Classify nested sub-keys:
+                    // - required by CLDR → valid, skip
+                    // - not in en and not required → stale (orphaned)
+                    // - in en but not required → unused (harmless redundancy)
+                    for (const sub of Object.keys(val)) {
+                        if (requiredCats.has(sub)) continue;
+                        if (!Object.hasOwn(enVal, sub)) {
+                            extra.push(`${key}.${sub}`);
+                        } else {
+                            unused.push(`${key}.${sub}`);
+                        }
+                    }
+                }
+            }
+        }
+
+        const localeKeyCount = Object.keys(localeObj).filter(k => enKeys.has(k)).length;
+        // unused forms are informational — harmless redundancy, not a defect
+        const localeIssues = missing.length + empty.length + typeMismatch.length + extra.length;
         totalIssues += localeIssues;
 
         if (localeIssues === 0) {
-            console.log(`[${locale}] OK — ${localeKeys.size}/${enKeys.size} keys, 0 issues`);
+            console.log(`[${locale}] OK — ${localeKeyCount}/${enKeys.size} keys, 0 issues`);
         } else {
-            console.log(`[${locale}] ${localeIssues} issue(s) — ${localeKeys.size}/${enKeys.size} keys present`);
+            console.log(`[${locale}] ${localeIssues} issue(s) — ${localeKeyCount}/${enKeys.size} keys present`);
 
             if (missing.length > 0) {
-                console.log(`  Missing keys (${missing.length}):`);
-                for (const key of missing) {
-                    console.log(`    - ${key}`);
+                // Distinguish top-level missing (falls back to English)
+                // from nested plural sub-key missing (falls back to 'other'
+                // form within the same locale).
+                const topMissing = missing.filter(k => !k.includes('.'));
+                const nestedMissing = missing.filter(k => k.includes('.'));
+                if (topMissing.length > 0) {
+                    console.log(`  Missing keys (${topMissing.length}, runtime falls back to English):`);
+                    for (const key of topMissing) console.log(`    - ${key}`);
+                }
+                if (nestedMissing.length > 0) {
+                    console.log(`  Missing nested keys (${nestedMissing.length}, runtime falls back through other/one forms in same locale):`);
+                    for (const key of nestedMissing) console.log(`    - ${key}`);
                 }
             }
 
             if (empty.length > 0) {
-                console.log(`  Empty-string keys (${empty.length}, fallback to English):`);
-                for (const key of empty) {
+                // Distinguish top-level empty strings (truly blank at
+                // runtime — t() returns "" with no fallback) from nested
+                // plural sub-key empty strings (falsy in the || chain,
+                // so runtime falls back through other/one forms).
+                const topEmpty = empty.filter(k => !k.includes('.'));
+                const nestedEmpty = empty.filter(k => k.includes('.'));
+                if (topEmpty.length > 0) {
+                    console.log(`  Empty-string keys (${topEmpty.length}, blank at runtime — no English fallback):`);
+                    for (const key of topEmpty) console.log(`    - ${key}`);
+                }
+                if (nestedEmpty.length > 0) {
+                    console.log(`  Empty nested plural forms (${nestedEmpty.length}, falsy at runtime — falls back through other/one forms):`);
+                    for (const key of nestedEmpty) console.log(`    - ${key}`);
+                }
+            }
+
+            if (typeMismatch.length > 0) {
+                console.log(`  Type-mismatched keys (${typeMismatch.length}, runtime returns raw key name):`);
+                for (const key of typeMismatch) {
+                    const enResolved = resolvePath(enObj, key);
+                    const targetResolved = resolvePath(localeObj, key);
+                    const enType = Array.isArray(enResolved) ? 'array' : typeof enResolved;
+                    const targetType = Array.isArray(targetResolved) ? 'array' : typeof targetResolved;
+                    console.log(`    - ${key} (en: ${enType}, ${locale}: ${targetType})`);
+                }
+            }
+
+            if (extra.length > 0) {
+                console.log(`  Stale keys (${extra.length}, present in ${locale} but not in en):`);
+                for (const key of extra) {
                     console.log(`    - ${key}`);
                 }
             }
+        }
+
+        if (unused.length > 0) {
+            console.log(`  Unused plural forms (${unused.length}, defined in ${locale} but never selected by ${locale} plural rules — informational):`);
+            for (const key of unused) console.log(`    - ${key}`);
         }
 
         console.log('');
@@ -240,7 +605,8 @@ function main() {
     console.log('----------------------------------------');
 
     if (totalIssues > 0) {
-        console.log('\nNOTE: ja/ko are skeleton translations — missing keys are expected.');
+        console.log('\nNOTE: Some locales may have incomplete translations.');
+        console.log('      Missing keys fall back to English; empty strings show blank.');
         console.log('      Re-run with --strict to make this check fail (exit 1).\n');
 
         if (strict) {


### PR DESCRIPTION
## Summary

Rewrite `check-i18n.js` to use a static recursive-descent parser instead of regex + `new Function`, with CLDR-aware plural validation.

## Changes

### Static Parser (`ObjectLiteralParser`)
- Replaced regex extraction + `new Function` with a hand-written recursive-descent parser that handles string literals, escape sequences (`\uXXXX`, `\u{...}`, `\xXX`, `\n`, `\t`, etc.), nested objects, duplicate key detection, and comment skipping.
- Eliminates SonarCloud `javascript:S1523` (dynamic code execution) alert.
- All parsed objects use `Object.create(null)` to prevent prototype pollution.

### Dynamic Locale Discovery
- Removed hardcoded `['zh', 'ja', 'ko']` target list.
- Locales are now discovered dynamically from the `translations` object keys.
- All 14 locales (`en`, `zh`, `ja`, `ko`, `ru`, `es`, `fa`, `tk`, `my`, `ar`, `ur`, `sw`, `tr`, `vi`) are checked automatically.

### CLDR-Aware Plural Validation
- Uses `Intl.PluralRules(locale).resolvedOptions().pluralCategories` for the authoritative CLDR category list — 100% accurate, immune to sampling gaps from non-contiguous CLDR ranges.
- Each locale is validated against its own required plural categories, not `en`'s.
- Classifies nested sub-keys:
  - **Required by CLDR** → validated (missing/empty/type-mismatch)
  - **Not in `en` and not required** → stale (orphaned)
  - **In `en` but not required** → unused (informational, excluded from issue count)

### Plural-Rule Fallback Diagnostics
- Warns when `Intl.PluralRules(locale)` throws (invalid locale tag) and falls back to English.
- Detects small-icu Node builds by comparing `resolvedOptions().locale` with the requested locale — warns when they differ, so silent fallback to English categories is never hidden.

### Robust Escape Handling
- `\uXXXX` and `\xXX` use `String.fromCharCode` (UTF-16 code unit, handles lone surrogates).
- `\u{...}` uses `fromCharCode` for BMP code points (including surrogate range 0xD800–0xDFFF) and `fromCodePoint` for astral-plane code points — avoids `RangeError` on lone surrogates.

### Reporting Improvements
- Distinguishes top-level missing keys (fall back to English) from nested plural sub-key missing (fall back to `other` form in same locale).
- `localeKeyCount` only counts keys present in `en` (excludes stale keys).
- Duplicate keys reported with qualified paths (e.g., `plurals.one` instead of bare `one`).
- Type-mismatch reporting uses `resolvePath` for accurate qualified-key resolution.

### Security & Robustness
- `Object.hasOwn` for property checks (safe against `__proto__`/`hasOwnProperty` overrides).
- Comprehensive error handling with clear diagnostics.
- `--strict` flag for CI enforcement.

## Test

```
node packages/scripts/check-i18n.js
```

Output: 10 issues (2 in `es`, 8 in `ar` — all missing plural forms for CLDR-required categories). All other locales pass cleanly.