### PR TITLE
fix: prevent transient locks from persisting across WebView refreshes

### DIFF
--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -193,14 +193,22 @@ async function listen(event, handler) {
     // delete `obj[event][eventId]`, leaving a stale entry. This causes
     // emit_to_main to falsely believe a listener still exists and dispatch
     // events to a dead callback (which silently fails, losing the event).
-    const obj = /** @type {any} */ (window)['__internal_unstable_listeners_object_id__'];
-    if (obj?.[event]) {
-      delete obj[event][eventId];
-      // If no listeners remain for this event, clean up the event key too
-      // so emit_to_main correctly detects "no listeners" and buffers the event.
-      if (Object.getOwnPropertyNames(obj[event]).length === 0) {
-        delete obj[event];
+    //
+    // The `delete` may throw TypeError if the property is non-configurable
+    // (sealed/frozen internal object). We wrap it so that the backend unlisten
+    // IPC — which is the critical cleanup — always executes regardless.
+    try {
+      const obj = /** @type {any} */ (window)['__internal_unstable_listeners_object_id__'];
+      if (obj?.[event]) {
+        delete obj[event][eventId];
+        // If no listeners remain for this event, clean up the event key too
+        // so emit_to_main correctly detects "no listeners" and buffers the event.
+        if (Object.getOwnPropertyNames(obj[event]).length === 0) {
+          delete obj[event];
+        }
       }
+    } catch {
+      // Best-effort: the backend unlisten below is what truly matters.
     }
     await invoke('plugin:event|unlisten', { event, eventId });
   };

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -394,6 +394,13 @@ async function initApp() {
 
   apiLogger.info(`[Zephyr] initApp started at ${new Date().toLocaleTimeString()}`);
 
+  // 0a. Reset transient locks that may have been persisted to localStorage
+  // by a prior session that crashed or was refreshed mid-operation.
+  // While the transientKeys array in state.js prevents future persistence,
+  // we also reset here to clean up any stale values from older builds.
+  appStore.set('isNetworkUpdating', false);
+  appStore.set('isTestingLatency', false);
+
   // 1. Disable context menu globally (except on draggable titlebar)
   document.addEventListener('contextmenu', (e) => {
     const target = /** @type {Element} */ (e.target);
@@ -601,7 +608,7 @@ async function initApp() {
   });
   registerCleanup(() => { cleanupChart(); });
   registerCleanup(() => { stopUnifiedSync(); });
-  registerCleanup(() => { cleanupTrayEventListeners(); });
+  registerCleanup(cleanupTrayEventListeners);
 
   window.addEventListener('beforeunload', () => runCleanup());
 

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -426,7 +426,17 @@ export const appStore = createStore('zephyr.app', {
     currentConfigName: null,
     currentCoreVersion: '',
 }, {
-    transientKeys: ['uiGroupName', 'uiPrimaryGroupName', 'effectiveGroupName', 'observedGroupName', 'observedNodeName'],
+    transientKeys: [
+        // Proxy group resolver state — re-resolved each session.
+        'uiGroupName', 'uiPrimaryGroupName', 'effectiveGroupName', 'observedGroupName', 'observedNodeName',
+        // Locks — must never survive a page reload. If the WebView is
+        // refreshed while one of these is true (e.g. during a config switch
+        // or latency test), the flag would be persisted to localStorage
+        // and restored as true on the next init, permanently locking out
+        // every operation that checks it (switchConfig, TUN toggle, mode
+        // selector, etc.).
+        'isNetworkUpdating', 'isTestingLatency',
+    ],
 });
 
 /** Tray state (replaces the old sealed TrayState) */

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -40,13 +40,18 @@ const tr = (/** @type {string} */ key, /** @type {string} */ fallback) => {
 /** @type {Array<() => void>} */
 let _trayEventUnlisteners = [];
 
-export function cleanupTrayEventListeners() {
-    _trayEventUnlisteners.forEach(unlisten => {
-        if (typeof unlisten === 'function') {
-            unlisten();
-        }
-    });
+export async function cleanupTrayEventListeners() {
+    const unlisteners = _trayEventUnlisteners;
     _trayEventUnlisteners = [];
+    await Promise.all(unlisteners.map(async (unlisten) => {
+        if (typeof unlisten === 'function') {
+            try {
+                await unlisten();
+            } catch {
+                // Best-effort — each unlisten already wraps its own errors.
+            }
+        }
+    }));
 }
 
 // --- Tray status ---


### PR DESCRIPTION
## Root Cause

isNetworkUpdating and isTestingLatency were **not** in the 	ransientKeys array in state.js, so they were persisted to localStorage via the debounced schedulePersist().

If a WebView refresh occurred while one of these flags was 	rue (e.g. during a config switch, latency test, or TUN toggle), the flag would be:
1. Written to localStorage by schedulePersist() (100ms debounce)
2. Restored as 	rue on the next initApp() via hydrate()
3. **Permanently locking out** every operation that checks it

### Affected operations (all silent-return when isNetworkUpdating === true):
- Console picker subscription switch (console-home.js:753)
- Settings page subscription switch (subscriptions.js:1335)
- TUN toggle (	un.js:39)
- Mode selector (modes.js:23)
- Geo data update (settings.js:1681)
- Global shortcut (global-shortcut.js:543)

### Why some operations still worked:
- Switch nodes, test latency, delete subscriptions, and "Update All Subscriptions" (subscriptions page) do **not** check isNetworkUpdating, so they were unaffected.

## Fixes

### 1. state.js - Add flags to 	ransientKeys
Added isNetworkUpdating and isTestingLatency to 	ransientKeys so they are **never persisted** to localStorage and always start as alse on every page load.

### 2. main.js - Defense-in-depth reset at initApp startup
Explicitly reset both flags to alse at the top of initApp(). This:
- Cleans up stale values from older builds that may already have the bad value in localStorage
- Acts as a safety net even if someone accidentally adds a new lock flag without adding it to 	ransientKeys

### 3. pi.js - Hardened listen() unlisten function
Wrapped the delete obj[event][eventId] operations in a try-catch. Tauri's internal listener object can have **non-configurable properties** that throw TypeError: Cannot delete property '...' of [object Object]. Previously, this TypeError prevented the backend plugin:event|unlisten IPC from executing, leaving **ghost listeners** that dispatch events to dead callbacks.

### 4. 	ray.js - Async cleanupTrayEventListeners
Made cleanupTrayEventListeners sync and waited each unlisten() call with try-catch. The previous sync implementation called unlisten() (an async function) without awaiting, causing **Unhandled Promise Rejections** when the delete inside unlisten threw TypeError.

## Testing
- pnpm lint - passed
- pnpm typecheck - passed