### PR TITLE
fix: prevent transient locks from persisting across WebView refreshes

### DIFF
--- a/apps/desktop/src/api.js
+++ b/apps/desktop/src/api.js
@@ -183,23 +183,53 @@ async function listen(event, handler) {
       handler: callbackId,
     });
   } catch (e) {
-    _t.transformCallback(undefined, false, callbackId);
+    if (typeof _t.unregisterCallback === 'function') {
+      _t.unregisterCallback(callbackId);
+    } else {
+      _t.transformCallback(undefined, false, callbackId);
+    }
     throw e;
   }
   return async () => {
-    _t.transformCallback(undefined, false, callbackId);
+    // Deregister the JS callback. Tauri v2 exposes `unregisterCallback(id)`
+    // for this purpose; `transformCallback(undefined, …)` does NOT
+    // deregister an existing callback — the third argument is ignored.
+    // Fall back to transformCallback for older Tauri versions that lack
+    // unregisterCallback.
+    try {
+      if (typeof _t.unregisterCallback === 'function') {
+        _t.unregisterCallback(callbackId);
+      } else {
+        _t.transformCallback(undefined, false, callbackId);
+      }
+    } catch (err) {
+      apiLogger.warn(`[API] unregisterCallback(${callbackId}) failed:`, err);
+    }
     // Clean up the listener entry from the internal listeners object.
     // Tauri's unlisten_js_script only calls unregisterCallback but does NOT
     // delete `obj[event][eventId]`, leaving a stale entry. This causes
     // emit_to_main to falsely believe a listener still exists and dispatch
     // events to a dead callback (which silently fails, losing the event).
-    const obj = /** @type {any} */ (window)['__internal_unstable_listeners_object_id__'];
-    if (obj?.[event]) {
-      delete obj[event][eventId];
-      // If no listeners remain for this event, clean up the event key too
-      // so emit_to_main correctly detects "no listeners" and buffers the event.
-      if (Object.getOwnPropertyNames(obj[event]).length === 0) {
-        delete obj[event];
+    //
+    // The `delete` may throw TypeError if the property is non-configurable
+    // (sealed/frozen internal object). We only catch TypeError so that other
+    // unexpected failures are not silently masked.
+    try {
+      const obj = /** @type {any} */ (window)['__internal_unstable_listeners_object_id__'];
+      if (obj?.[event]) {
+        delete obj[event][eventId];
+        // If no listeners remain for this event, clean up the event key too
+        // so emit_to_main correctly detects "no listeners" and buffers the event.
+        if (Object.getOwnPropertyNames(obj[event]).length === 0) {
+          delete obj[event];
+        }
+      }
+    } catch (err) {
+      if (err instanceof TypeError) {
+        // Non-configurable property — expected on sealed/frozen internal objects.
+        apiLogger.warn(`[API] listener-map cleanup for event "${event}" skipped (non-configurable)`);
+      } else {
+        throw err;
       }
     }
     await invoke('plugin:event|unlisten', { event, eventId });

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -394,6 +394,13 @@ async function initApp() {
 
   apiLogger.info(`[Zephyr] initApp started at ${new Date().toLocaleTimeString()}`);
 
+  // 0a. Reset transient locks that may have been persisted to localStorage
+  // by a prior session that crashed or was refreshed mid-operation.
+  // While the transientKeys array in state.js prevents future persistence,
+  // we also reset here to clean up any stale values from older builds.
+  appStore.set('isNetworkUpdating', false);
+  appStore.set('isTestingLatency', false);
+
   // 1. Disable context menu globally (except on draggable titlebar)
   document.addEventListener('contextmenu', (e) => {
     const target = /** @type {Element} */ (e.target);
@@ -601,7 +608,7 @@ async function initApp() {
   });
   registerCleanup(() => { cleanupChart(); });
   registerCleanup(() => { stopUnifiedSync(); });
-  registerCleanup(() => { cleanupTrayEventListeners(); });
+  registerCleanup(cleanupTrayEventListeners);
 
   window.addEventListener('beforeunload', () => runCleanup());
 

--- a/apps/desktop/src/ui/state.js
+++ b/apps/desktop/src/ui/state.js
@@ -426,7 +426,17 @@ export const appStore = createStore('zephyr.app', {
     currentConfigName: null,
     currentCoreVersion: '',
 }, {
-    transientKeys: ['uiGroupName', 'uiPrimaryGroupName', 'effectiveGroupName', 'observedGroupName', 'observedNodeName'],
+    transientKeys: [
+        // Proxy group resolver state — re-resolved each session.
+        'uiGroupName', 'uiPrimaryGroupName', 'effectiveGroupName', 'observedGroupName', 'observedNodeName',
+        // Locks — must never survive a page reload. If the WebView is
+        // refreshed while one of these is true (e.g. during a config switch
+        // or latency test), the flag would be persisted to localStorage
+        // and restored as true on the next init, permanently locking out
+        // every operation that checks it (switchConfig, TUN toggle, mode
+        // selector, etc.).
+        'isNetworkUpdating', 'isTestingLatency',
+    ],
 });
 
 /** Tray state (replaces the old sealed TrayState) */

--- a/apps/desktop/src/ui/tray.js
+++ b/apps/desktop/src/ui/tray.js
@@ -37,16 +37,21 @@ const tr = (/** @type {string} */ key, /** @type {string} */ fallback) => {
 
 // --- Tray event listener cleanup ---
 
-/** @type {Array<() => void>} */
+/** @type {Array<() => void | Promise<void>>} */
 let _trayEventUnlisteners = [];
 
-export function cleanupTrayEventListeners() {
-    _trayEventUnlisteners.forEach(unlisten => {
-        if (typeof unlisten === 'function') {
-            unlisten();
-        }
-    });
+export async function cleanupTrayEventListeners() {
+    const unlisteners = _trayEventUnlisteners;
     _trayEventUnlisteners = [];
+    await Promise.all(unlisteners.map(async (unlisten) => {
+        if (typeof unlisten === 'function') {
+            try {
+                await unlisten();
+            } catch (err) {
+                trayLogger.warn('[tray] unlisten failed during cleanup:', err);
+            }
+        }
+    }));
 }
 
 // --- Tray status ---


### PR DESCRIPTION
## Root Cause

```isNetworkUpdating``` and ```isTestingLatency``` were **not** in the ```transientKeys``` array in ```state.js``, so they were persisted to ```localStorage``` via the debounced ```schedulePersist()```.

If a WebView refresh occurred while one of these flags was ```true``` (e.g. during a config switch, latency test, or TUN toggle), the flag would be:
1. Written to ```localStorage``` by ```schedulePersist()``` (100ms debounce)
2. Restored as ```true``` on the next ```initApp()``` via ```hydrate()``
3. **Permanently locking out** every operation that checks it

### Affected operations (all silent-return when ```isNetworkUpdating === true```):
- Console picker subscription switch (```console-home.js:753```)
- Settings page subscription switch (```subscriptions.js:1335```)
- TUN toggle (```tun.js:39```)
- Mode selector (```modes.js:23```)
- Geo data update (```settings.js:1681```)
- Global shortcut (```global-shortcut.js:543```)

### Why some operations still worked:
- Switch nodes, test latency, delete subscriptions, and "Update All Subscriptions" (subscriptions page) do **not** check ```isNetworkUpdating``, so they were unaffected.

## Fixes

### 1. ```state.js``` - Add flags to ```transientKeys``
Added ```isNetworkUpdating``` and ```isTestingLatency``` to ```transientKeys``` so they are **never persisted** to ```localStorage``` and always start as ```false``` on every page load.

### 2. ```main.js``` - Defense-in-depth reset at ```initApp``` startup
Explicitly reset both flags to ```false``` at the top of ```initApp()```. This:
- Cleans up stale values from older builds that may already have the bad value in ```localStorage``
- Acts as a safety net even if someone accidentally adds a new lock flag without adding it to ```transientKeys```

### 3. ```api.js``` - Hardened ```listen()``` unlisten function
Wrapped the ```delete obj[event][eventId]``` operations in a try-catch. Tauri's internal listener object can have **non-configurable properties** that throw ```TypeError: Cannot delete property '...' of [object Object]``, which previously prevented the backend ```plugin:event|unlisten``` IPC from executing, leaving **ghost listeners** that dispatch events to dead callbacks.

### 4. ```tray.js``` - Async ```cleanupTrayEventListeners``
Made ```cleanupTrayEventListeners``` ```async``` and ```await```ed each ```unlisten()``` call with try-catch. The previous sync implementation called ```unlisten()``` (an async function) without awaiting, causing **Unhandled Promise Rejections** when the ```delete``` inside ```unlisten``` threw TypeError.

### 5. ```main.js``` - Register ```cleanupTrayEventListeners``` directly (review fix)
Changed ```registerCleanup(() => { cleanupTrayEventListeners(); })``` to ```registerCleanup(cleanupTrayEventListeners)```. The block-bodied arrow did not return the Promise, so ```runCleanup()``` treated tray cleanup as complete immediately, allowing shutdown/refresh to proceed before tray unlisten IPCs finished.

## Testing
- ```pnpm lint``` - passed
- ```pnpm typecheck``` - passed