### PR TITLE
feat: add NetworkChangeCoordinator with fail-closed protocol verification

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -47,4 +47,10 @@ ignore = [
   "RUSTSEC-2025-0081",
   "RUSTSEC-2025-0098",
   "RUSTSEC-2025-0100",
+  # h2 unbounded empty DATA frames (RUSTSEC-2026-0258)
+  # Transitive via hyper/h2; upgrade blocked by Tauri's reqwest/hyper stack.
+  "RUSTSEC-2026-0258",
+  # event-listener unsound StackSlot (RUSTSEC-2026-0221)
+  # Transitive via async-channel (Tauri); fix requires event-listener >=5.5.0
+  "RUSTSEC-2026-0221",
 ]

--- a/apps/desktop/src-tauri/.cargo/audit.toml
+++ b/apps/desktop/src-tauri/.cargo/audit.toml
@@ -31,4 +31,10 @@ ignore = [
   "RUSTSEC-2025-0081",  # unic-char-property unmaintained
   "RUSTSEC-2025-0098",  # unic-ucd-version unmaintained
   "RUSTSEC-2025-0100",  # unic-ucd-ident unmaintained
+  # h2 unbounded empty DATA frames (RUSTSEC-2026-0258)
+  # Transitive via hyper/h2; upgrade blocked by Tauri's reqwest/hyper stack.
+  "RUSTSEC-2026-0258",
+  # event-listener unsound StackSlot (RUSTSEC-2026-0221)
+  # Transitive via async-channel (Tauri); fix requires event-listener >=5.5.0
+  "RUSTSEC-2026-0221",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -74,6 +74,8 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
     "Win32_System_Registry",
     "Win32_Networking_WinHttp",
     "Win32_Networking_WinInet",
@@ -109,6 +111,7 @@ arboard = { version = "3.3", features = ["wayland-data-control"] }
 # Note: System proxy uses gsettings for GNOME and kwriteconfig5/6 for KDE
 
 [dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
 mockall = "0.15"
 tempfile = "3.14"
 insta = { version = "1", features = ["filters"] }

--- a/apps/desktop/src-tauri/osv-scanner.toml
+++ b/apps/desktop/src-tauri/osv-scanner.toml
@@ -113,3 +113,15 @@ ignoreUntil = 2027-12-31
 reason = "rand 0.8 unsound; transitive via tauri ecosystem, our code pins rand 0.10.1"
 
 # RUSTSEC-2026-0098 / RUSTSEC-2026-0099: RESOLVED — rustls-webpki 0.103.13 (>=0.103.12)
+
+# ── Rust: upstream-blocked vulnerability fixes (transitive deps) ──
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0258"
+ignoreUntil = 2027-12-31
+reason = "h2 unbounded empty DATA frames; transitive via hyper/h2 (Tauri reqwest stack), upgrade blocked"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0221"
+ignoreUntil = 2027-12-31
+reason = "event-listener unsound StackSlot; transitive via async-channel (Tauri), fix requires event-listener >=5.5.0"

--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -318,6 +318,12 @@ pub mod codes {
     pub const SYS_RESUMED_CORE_RESTART: u16 = 6020;
     /// System resumed from sleep — core health check passed, no action needed.
     pub const SYS_RESUMED_CORE_HEALTHY: u16 = 6021;
+    /// Network state change detected and debounce initiated.
+    pub const SYS_NETWORK_STATE_CHANGED: u16 = 6022;
+    /// Prism rules re-applied automatically after network change.
+    pub const SYS_NETWORK_COORDINATOR_APPLIED: u16 = 6023;
+    /// Error during network coordinator auto-apply.
+    pub const SYS_NETWORK_COORDINATOR_ERROR: u16 = 6024;
 
     // Updater: 7000-7999
     pub const UPDATE_CHECK_FAILED: u16 = 7001;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub mod core_manager;
 pub mod deep_link;
 pub mod global_shortcut;
 pub mod minisign_verify;
+pub mod network_coordinator;
 pub mod os_notification;
 pub mod prism;
 pub mod sys_proxy;
@@ -1484,6 +1485,10 @@ pub fn run() {
             let scheduler_state = start_scheduler(app.handle().clone());
             app.manage(scheduler_state);
 
+            // Start Network Change Coordinator (SSID/interface monitoring & single-flight auto-apply)
+            let coordinator_handle = network_coordinator::start_coordinator(app.handle());
+            app.manage(coordinator_handle);
+
             // Init Tray using the new tray module
             init_tray(app.handle())?;
 
@@ -1784,6 +1789,9 @@ write_frontend_log,
             prism::script_revoke_plugin,
             prism::script_check_plugin_permission,
             prism::script_is_sandbox_safe,
+            // Network Coordinator commands
+            network_coordinator::get_network_state,
+            network_coordinator::notify_network_change,
         ]);
 
     #[allow(clippy::expect_used)]
@@ -1872,6 +1880,13 @@ async fn handle_system_resume(app: &tauri::AppHandle) {
         SYS_RESUMED_HEALTH_CHECK,
         "System resumed from sleep — checking core health"
     );
+
+    // Notify Network Change Coordinator that system woke from sleep.
+    // Use try_notify (non-blocking) so a full channel cannot delay the
+    // subsequent resume health check.
+    if let Some(coordinator) = app.try_state::<network_coordinator::NetworkCoordinatorHandle>() {
+        coordinator.try_notify(network_coordinator::NetworkChangeReason::Resume);
+    }
 
     // Read the last-known core port + config from MihomoState.
     let (port, config_path, custom_args) = {
@@ -1970,6 +1985,15 @@ async fn handle_system_resume(app: &tauri::AppHandle) {
             SYS_RESUMED_CORE_RESTART,
             "Failed to restart core after resume: {e}"
         );
+    } else {
+        // Core restarted successfully — the fresh process has no rules applied.
+        // Notify the coordinator to re-apply rules for the current network state.
+        // The earlier Resume notification may have already applied rules to the
+        // old (now-replaced) core instance, leaving applied_state stale.
+        if let Some(coordinator) = app.try_state::<network_coordinator::NetworkCoordinatorHandle>()
+        {
+            coordinator.try_notify(network_coordinator::NetworkChangeReason::Manual);
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/network_coordinator.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator.rs
@@ -1,0 +1,70 @@
+//! Network change coordinator and state management.
+
+#![allow(clippy::needless_pass_by_value)]
+
+pub mod coordinator;
+pub mod detector;
+pub mod platform;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use coordinator::{start_coordinator, NetworkCoordinatorHandle};
+pub use detector::{
+    detect_network_state, detect_network_state_uncached, detect_ssid, invalidate_ssid_cache,
+};
+pub use types::{
+    is_http_success, CoordinatorMetrics, CoreApplyResult, InterfaceType, NetworkChangeReason,
+    NetworkState,
+};
+
+use tauri::{AppHandle, Manager as _};
+
+/// Tauri command: Query the current network connectivity snapshot.
+/// Returns the SSID masked for privacy, consistent with the `network-state-changed` event.
+#[tauri::command]
+pub fn get_network_state(app: AppHandle) -> Result<NetworkState, String> {
+    if let Some(coordinator) = app.try_state::<NetworkCoordinatorHandle>() {
+        let mut state = coordinator.get_current_state();
+        // Mask SSID before exposing to frontend — consistent with masked_network_state_json
+        if state.ssid.is_some() {
+            state.ssid = Some("***".to_owned());
+        }
+        Ok(state)
+    } else {
+        let mut state = detect_network_state();
+        if state.ssid.is_some() {
+            state.ssid = Some("***".to_owned());
+        }
+        Ok(state)
+    }
+}
+
+/// Tauri command: Trigger a manual network change re-evaluation (e.g. from frontend online event or resume).
+#[tauri::command]
+pub async fn notify_network_change(app: AppHandle, source: Option<String>) -> Result<(), String> {
+    if let Some(coordinator) = app.try_state::<NetworkCoordinatorHandle>() {
+        /// Maximum length of a caller-supplied source string to prevent unbounded log writes.
+        const MAX_SOURCE_LEN: usize = 64;
+        let reason = match source.as_deref() {
+            Some("browser_online" | "online" | "browser_offline" | "offline") => {
+                NetworkChangeReason::OnlineEvent
+            }
+            Some("resume" | "wake") => NetworkChangeReason::Resume,
+            Some("manual") | None => NetworkChangeReason::Manual,
+            Some(other) => {
+                // Sanitize: strip control chars (including newlines) to prevent
+                // log injection, then truncate to MAX_SOURCE_LEN at a char boundary.
+                let sanitized: String = other
+                    .chars()
+                    .filter(|c| !c.is_control() && *c != '\u{2028}' && *c != '\u{2029}')
+                    .take(MAX_SOURCE_LEN)
+                    .collect();
+                NetworkChangeReason::NativeEvent(sanitized)
+            }
+        };
+        coordinator.try_notify(reason);
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/coordinator.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/coordinator.rs
@@ -1,0 +1,630 @@
+//! Network change coordinator: debounce state machine and single-flight rule application.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::{AppHandle, Manager as _};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::time::Instant;
+
+/// Maximum time to wait for a Prism apply (compile + HTTP PUT /configs) before giving up.
+const APPLY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// After this many consecutive apply failures, suppress polling-driven retries
+/// until an explicit event (native, resume, online, manual) arrives to reset.
+const MAX_CONSECUTIVE_FAILURES: u32 = 5;
+
+use super::detector::{detect_network_state, detect_network_state_uncached, invalidate_ssid_cache};
+use super::types::{CoordinatorMetrics, CoreApplyResult, NetworkChangeReason, NetworkState};
+
+/// Shared coordinator state passed to the actor loop and helper functions.
+/// Bundles the Arc handles to avoid exceeding clippy's argument count limit.
+struct CoordinatorShared {
+    observed_state: Arc<Mutex<NetworkState>>,
+    applied_state: Arc<Mutex<Option<NetworkState>>>,
+    is_applying: Arc<AtomicBool>,
+    pending_rerun: Arc<AtomicBool>,
+    consecutive_failures: Arc<AtomicU32>,
+    consecutive_deferred: Arc<AtomicU32>,
+    metrics: Arc<Mutex<CoordinatorMetrics>>,
+}
+
+/// Handle to the active `NetworkCoordinator`.
+#[derive(Clone)]
+pub struct NetworkCoordinatorHandle {
+    event_tx: Sender<NetworkChangeReason>,
+    observed_state: Arc<Mutex<NetworkState>>,
+    applied_state: Arc<Mutex<Option<NetworkState>>>,
+    metrics: Arc<Mutex<CoordinatorMetrics>>,
+}
+
+impl NetworkCoordinatorHandle {
+    /// Send a notification trigger to the coordinator.
+    pub async fn notify(&self, reason: NetworkChangeReason) {
+        let _ = self.event_tx.send(reason).await;
+    }
+
+    /// Non-blocking notification: drops the event if the channel is full.
+    /// Use this from latency-sensitive paths (e.g. system resume) where
+    /// blocking on a full channel would delay subsequent health checks.
+    pub fn try_notify(&self, reason: NetworkChangeReason) {
+        let _ = self.event_tx.try_send(reason);
+    }
+
+    /// Synchronously send a notification trigger (for non-async contexts).
+    pub fn notify_blocking(&self, reason: NetworkChangeReason) {
+        let _ = self.event_tx.blocking_send(reason);
+    }
+
+    /// Retrieve a snapshot of the current observed network state.
+    #[must_use]
+    pub fn get_current_state(&self) -> NetworkState {
+        self.observed_state
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+
+    /// Retrieve a snapshot of the current successfully applied network state.
+    #[must_use]
+    pub fn get_applied_state(&self) -> Option<NetworkState> {
+        self.applied_state.lock().ok().and_then(|g| g.clone())
+    }
+
+    /// Retrieve coordinator telemetry metrics.
+    #[must_use]
+    pub fn get_metrics(&self) -> CoordinatorMetrics {
+        self.metrics.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+
+    /// Manually mark that the initial/active rules in Prism match the given network state.
+    pub fn mark_applied(&self, state: NetworkState) {
+        if let Ok(mut g) = self.applied_state.lock() {
+            *g = Some(state);
+        }
+    }
+}
+
+/// Start the `NetworkChangeCoordinator` background actor.
+#[must_use]
+pub fn start_coordinator(app: &AppHandle) -> NetworkCoordinatorHandle {
+    let initial_state = detect_network_state_uncached();
+    let observed_state = Arc::new(Mutex::new(initial_state));
+    // Start with applied_state = None so the first polling cycle triggers
+    // reconciliation. The frontend runs prism.apply() during startup, but
+    // if that fails silently, we must not mask the failure by pre-seeding
+    // applied_state.  Starting with None ensures the coordinator verifies
+    // the initial apply and retries if needed.
+    let applied_state = Arc::new(Mutex::new(None));
+    let metrics = Arc::new(Mutex::new(CoordinatorMetrics::default()));
+
+    let (event_tx, event_rx) = mpsc::channel::<NetworkChangeReason>(32);
+    let is_applying = Arc::new(AtomicBool::new(false));
+    let pending_rerun = Arc::new(AtomicBool::new(false));
+    let consecutive_failures = Arc::new(AtomicU32::new(0));
+    let consecutive_deferred = Arc::new(AtomicU32::new(0));
+
+    let handle = NetworkCoordinatorHandle {
+        event_tx: event_tx.clone(),
+        observed_state: Arc::clone(&observed_state),
+        applied_state: Arc::clone(&applied_state),
+        metrics: Arc::clone(&metrics),
+    };
+
+    // Spawn the coordinator actor in Tauri's async runtime
+    let app_clone = app.clone();
+    let shared = CoordinatorShared {
+        observed_state: Arc::clone(&observed_state),
+        applied_state: Arc::clone(&applied_state),
+        is_applying: Arc::clone(&is_applying),
+        pending_rerun: Arc::clone(&pending_rerun),
+        consecutive_failures: Arc::clone(&consecutive_failures),
+        consecutive_deferred: Arc::clone(&consecutive_deferred),
+        metrics: Arc::clone(&metrics),
+    };
+
+    tauri::async_runtime::spawn(async move {
+        coordinator_actor_loop(app_clone, event_rx, shared).await;
+    });
+
+    // Start native OS event listener
+    super::platform::start_native_listener(event_tx);
+
+    handle
+}
+
+/// Main async actor loop for network event aggregation and debounce.
+async fn coordinator_actor_loop(
+    app: AppHandle,
+    mut event_rx: Receiver<NetworkChangeReason>,
+    shared: CoordinatorShared,
+) {
+    let mut debounce_deadline: Option<Instant> = None;
+    let mut last_reason: Option<NetworkChangeReason> = None;
+    let mut last_deferred_deadline: Option<Instant> = None;
+    // 5-second polling interval for robust fallback without excessive CPU overhead
+    let mut polling_interval = tokio::time::interval(Duration::from_secs(5));
+    polling_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            // 1. Inbound event from OS listener, resume, online, or manual trigger.
+            //    None means all Senders have been dropped — terminate gracefully.
+            recv_result = event_rx.recv() => {
+                if let Some(reason) = recv_result {
+                    if let Ok(mut m) = shared.metrics.lock() {
+                        m.events_received += 1;
+                    }
+
+                    let debounce_ms = match &reason {
+                        NetworkChangeReason::Resume => 2500, // Longer window for Wi-Fi reconnect on system wake
+                        NetworkChangeReason::NativeEvent(_)
+                        | NetworkChangeReason::Polling
+                        | NetworkChangeReason::OnlineEvent
+                        | NetworkChangeReason::Manual => 2000,
+                    };
+
+                    emit_info!(
+                        System,
+                        SYS_NETWORK_STATE_CHANGED,
+                        "[NetworkCoordinator] Network event received: {reason}. Resetting debounce timer ({debounce_ms}ms)."
+                    );
+
+                    // Invalidate SSID cache so upcoming check gets fresh hardware status
+                    invalidate_ssid_cache();
+                    // Explicit events (native, resume, online, manual) reset the
+                    // failure and deferred counters so polling-driven retries resume.
+                    shared.consecutive_failures.store(0, Ordering::SeqCst);
+                    shared.consecutive_deferred.store(0, Ordering::SeqCst);
+                    last_deferred_deadline = None;
+                    // Manual trigger (e.g. after core restart): clear applied_state
+                    // so the coordinator re-applies rules even if the network hasn't changed.
+                    if reason == NetworkChangeReason::Manual {
+                        if let Ok(mut g) = shared.applied_state.lock() {
+                            *g = None;
+                        }
+                    }
+                    last_reason = Some(reason);
+                    debounce_deadline =
+                        Some(Instant::now() + Duration::from_millis(debounce_ms));
+                } else {
+                    emit_info!(
+                        System,
+                        SYS_NETWORK_STATE_CHANGED,
+                        "[NetworkCoordinator] Event channel closed. Shutting down coordinator actor."
+                    );
+                    break;
+                }
+            }
+
+            // 2. Periodic polling fallback check (5s)
+            _ = polling_interval.tick() => {
+                let sampled = detect_network_state();
+                let last_observed = shared.observed_state
+                    .lock()
+                    .map(|g| g.clone())
+                    .unwrap_or_default();
+                let last_applied = shared.applied_state
+                    .lock()
+                    .ok()
+                    .and_then(|g| g.clone());
+
+                // Two distinct triggers:
+                //   a) `state_changed` — the network genuinely changed (sampled != observed).
+                //      This must ALWAYS trigger reconciliation, even if the failure cap
+                //      was reached, because it is a new transition, not a retry.
+                //   b) `needs_retry` — the state is the same but hasn't been applied yet.
+                //      Suppress after too many consecutive failures to avoid unbounded
+                //      recompile loops; an explicit event will reset the counter.
+                let state_changed = sampled != last_observed;
+                let needs_retry = last_applied.as_ref() != Some(&sampled);
+                let failures = shared.consecutive_failures.load(Ordering::SeqCst);
+                let deferred = shared.consecutive_deferred.load(Ordering::SeqCst);
+
+                // For deferred (core not running): apply exponential backoff to avoid
+                // churning detect→debounce→spawn→log every cycle while the core is stopped.
+                // 2^deferred seconds, capped at 60s.
+                let deferred_backoff = Duration::from_secs(
+                    1u64
+                        .checked_shl(deferred)
+                        .unwrap_or(64)
+                        .min(60),
+                );
+                let deferred_eligible = deferred == 0
+                    || last_deferred_deadline
+                        .map(|d| Instant::now() >= d)
+                        .unwrap_or(true);
+
+                let should_trigger = (state_changed || (needs_retry && failures < MAX_CONSECUTIVE_FAILURES))
+                    && (deferred == 0 || deferred_eligible)
+                    && debounce_deadline.is_none();
+
+                if should_trigger {
+                    // If this is a retry driven by deferral, set the next deferred deadline.
+                    if deferred > 0 && !state_changed {
+                        last_deferred_deadline =
+                            Some(Instant::now() + deferred_backoff);
+                    }
+                    let reason = NetworkChangeReason::Polling;
+                    emit_info!(
+                        System,
+                        SYS_NETWORK_STATE_CHANGED,
+                        "[NetworkCoordinator] State discrepancy or unaligned applied state detected via polling (sampled: {}, observed: {}, applied: {:?}). Starting debounce (1.5s).",
+                        sampled.masked(),
+                        last_observed.masked(),
+                        last_applied.as_ref().map(NetworkState::masked)
+                    );
+                    invalidate_ssid_cache();
+                    last_reason = Some(reason);
+                    debounce_deadline = Some(Instant::now() + Duration::from_millis(1500));
+                }
+            }
+
+            // 3. Debounce timer expired — network is now considered stable
+            _ = async {
+                match debounce_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            }, if debounce_deadline.is_some() => {
+                debounce_deadline = None;
+                if let Ok(mut m) = shared.metrics.lock() {
+                    m.debounce_expirations += 1;
+                }
+                let reason = last_reason.take().unwrap_or(NetworkChangeReason::Polling);
+                handle_stable_network_check(&app, &shared, reason);
+            }
+        }
+    }
+}
+
+/// Check if reconciliation is needed: true when `fresh_state` differs from
+/// the currently applied state (or no state has been applied yet).
+/// Pure function shared by production code and tests.
+#[must_use]
+pub fn needs_reconciliation(applied: &Option<NetworkState>, fresh: &NetworkState) -> bool {
+    applied.as_ref() != Some(fresh)
+}
+
+/// Evaluates state change after network has stabilized and schedules single-flight reconciliation.
+fn handle_stable_network_check(
+    app: &AppHandle,
+    shared: &CoordinatorShared,
+    reason: NetworkChangeReason,
+) {
+    let fresh_state = detect_network_state_uncached();
+
+    if let Ok(mut m) = shared.metrics.lock() {
+        m.state_detections += 1;
+    }
+
+    let (old_observed, observed_changed) = {
+        let mut guard = match shared.observed_state.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        let changed = *guard != fresh_state;
+        let old = guard.clone();
+        if changed {
+            *guard = fresh_state.clone();
+        }
+        drop(guard);
+        (old, changed)
+    };
+
+    if observed_changed {
+        if let Ok(mut m) = shared.metrics.lock() {
+            m.state_transitions += 1;
+        }
+
+        emit_info!(
+            System,
+            SYS_NETWORK_STATE_CHANGED,
+            "[NetworkCoordinator] Network state transition ({} -> {}) triggered by {reason}.",
+            old_observed.masked(),
+            fresh_state.masked()
+        );
+
+        // Emit event to frontend UI — use masked states to avoid leaking raw SSIDs
+        crate::backend_event::emit_to_main(
+            app,
+            "network-state-changed",
+            serde_json::json!({
+                "reason": reason,
+                "old_state": masked_network_state_json(&old_observed),
+                "new_state": masked_network_state_json(&fresh_state),
+            }),
+        );
+    }
+
+    // Check if reconciliation is required (i.e. fresh_state != applied_state)
+    let needs_reconcile = {
+        let applied_guard = match shared.applied_state.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        needs_reconciliation(&applied_guard, &fresh_state)
+    };
+
+    if !needs_reconcile {
+        emit_info!(
+            System,
+            SYS_NETWORK_STATE_CHANGED,
+            "[NetworkCoordinator] Debounce complete ({reason}) | Desired state matches applied state ({}) -> No-Op.",
+            fresh_state.masked()
+        );
+        return;
+    }
+
+    emit_info!(
+        System,
+        SYS_NETWORK_STATE_CHANGED,
+        "[NetworkCoordinator] Scheduling rule reconciliation to state {} triggered by {reason}.",
+        fresh_state.masked()
+    );
+
+    // Trigger single-flight rule apply
+    trigger_single_flight_apply(app, shared, reason, fresh_state);
+}
+
+/// Schedules `prism_apply` ensuring at most one execution is active at any time.
+fn trigger_single_flight_apply(
+    app: &AppHandle,
+    shared: &CoordinatorShared,
+    reason: NetworkChangeReason,
+    target_state: NetworkState,
+) {
+    if shared
+        .is_applying
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        if let Ok(mut m) = shared.metrics.lock() {
+            m.pending_reruns += 1;
+        }
+        emit_info!(
+            System,
+            SYS_NETWORK_STATE_CHANGED,
+            "[NetworkCoordinator] Apply task already in-flight; marking pending rerun for {reason}."
+        );
+        // Store pending_rerun FIRST, then re-check is_applying.
+        shared.pending_rerun.store(true, Ordering::SeqCst);
+        // Re-check: the worker may have released is_applying between the
+        // failed CAS and the store above.
+        if shared
+            .is_applying
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            shared.pending_rerun.store(false, Ordering::SeqCst);
+        } else {
+            return;
+        }
+    }
+
+    let app_clone = app.clone();
+    let applied_state_clone = Arc::clone(&shared.applied_state);
+    let is_applying_clone = Arc::clone(&shared.is_applying);
+    let pending_rerun_clone = Arc::clone(&shared.pending_rerun);
+    let consecutive_failures_clone = Arc::clone(&shared.consecutive_failures);
+    let consecutive_deferred_clone = Arc::clone(&shared.consecutive_deferred);
+    let metrics_clone = Arc::clone(&shared.metrics);
+
+    tokio::spawn(async move {
+        let mut current_reason = reason;
+        let mut active_target = target_state;
+        loop {
+            if let Ok(mut m) = metrics_clone.lock() {
+                m.apply_started += 1;
+            }
+
+            let outcome = run_prism_apply_task(&app_clone, &current_reason, &active_target).await;
+
+            match outcome {
+                ApplyOutcome::Applied => {
+                    // Apply succeeded: mark applied_state and reset both counters
+                    if let Ok(mut g) = applied_state_clone.lock() {
+                        *g = Some(active_target.clone());
+                    }
+                    consecutive_failures_clone.store(0, Ordering::SeqCst);
+                    consecutive_deferred_clone.store(0, Ordering::SeqCst);
+                    if let Ok(mut m) = metrics_clone.lock() {
+                        m.apply_succeeded += 1;
+                    }
+                }
+                ApplyOutcome::Failed => {
+                    consecutive_failures_clone.fetch_add(1, Ordering::SeqCst);
+                    consecutive_deferred_clone.store(0, Ordering::SeqCst);
+                    if let Ok(mut m) = metrics_clone.lock() {
+                        m.apply_failed += 1;
+                    }
+                }
+                ApplyOutcome::Deferred => {
+                    // Core not running — increment deferred counter for backoff.
+                    // Do NOT increment consecutive_failures.
+                    consecutive_deferred_clone.fetch_add(1, Ordering::SeqCst);
+                    if let Ok(mut m) = metrics_clone.lock() {
+                        m.apply_deferred += 1;
+                    }
+                }
+            }
+
+            if pending_rerun_clone.swap(false, Ordering::SeqCst) {
+                // Re-sample latest ground-truth network state before rerun
+                let latest = detect_network_state_uncached();
+                current_reason = NetworkChangeReason::Polling;
+                active_target = latest;
+                continue;
+            }
+
+            // Release is_applying first, then re-check pending_rerun to close the
+            // lost-wakeup window. A trigger arriving between the swap above and
+            // this store would otherwise set pending_rerun with no worker to
+            // consume it.
+            is_applying_clone.store(false, Ordering::SeqCst);
+            if !pending_rerun_clone.swap(false, Ordering::SeqCst) {
+                return;
+            }
+            // Re-acquire ownership; if another worker already took it, that
+            // worker will handle the rerun.
+            if is_applying_clone
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                return;
+            }
+            current_reason = NetworkChangeReason::Polling;
+            active_target = detect_network_state_uncached();
+        }
+    });
+}
+
+/// Layer 1: Validate HTTP transport status code (must be 2xx).
+#[must_use]
+pub fn validate_http_status(http_status: Option<u16>) -> bool {
+    http_status.is_some_and(super::is_http_success)
+}
+
+/// Layer 2: Validate application payload ACK (must explicitly confirm Some(true)).
+#[must_use]
+pub fn verify_hot_reload_ack(result_value: &serde_json::Value) -> Option<bool> {
+    result_value
+        .get("status")
+        .and_then(|s| s.get("hot_reload_success"))
+        .and_then(serde_json::Value::as_bool)
+        .or_else(|| {
+            result_value
+                .get("hot_reload_success")
+                .and_then(serde_json::Value::as_bool)
+        })
+}
+
+/// Parse a raw JSON response into a strongly-typed `CoreApplyResult` using strictly structured fields.
+/// ZERO string heuristics, ZERO fallback status guessing.
+#[must_use]
+pub fn parse_apply_result(value: &serde_json::Value) -> CoreApplyResult {
+    let http_status = value
+        .get("status")
+        .and_then(|s| s.get("http_status"))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|c| u16::try_from(c).ok())
+        .or_else(|| {
+            value
+                .get("http_status")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|c| u16::try_from(c).ok())
+        });
+
+    let hot_reload_success = verify_hot_reload_ack(value);
+
+    CoreApplyResult {
+        http_status,
+        hot_reload_success,
+    }
+}
+
+/// Composite validation: Ensures both Layer 1 (HTTP 2xx) AND Layer 2 (Application ACK)
+/// are strictly satisfied with fail-closed semantics.
+#[must_use]
+pub fn verify_core_apply_success(result: &CoreApplyResult) -> bool {
+    result.is_success()
+}
+
+/// Outcome of a Prism apply attempt.
+enum ApplyOutcome {
+    /// Apply succeeded — `applied_state` was updated and the failure counter reset.
+    Applied,
+    /// Apply failed (compile error, HTTP rejection, timeout) — increment the failure counter.
+    Failed,
+    /// Core is not running — do NOT increment the failure counter; reconcile later.
+    Deferred,
+}
+
+/// Executes Prism rule compilation and Mihomo hot-reload.
+async fn run_prism_apply_task(
+    app: &AppHandle,
+    reason: &NetworkChangeReason,
+    target_state: &NetworkState,
+) -> ApplyOutcome {
+    // Check if Mihomo core is running.  On macOS TUN the Child handle is
+    // cleared because the root-owned process is managed externally, so we
+    // use last_port() (set by both normal and TUN start paths) as the signal
+    // instead of process().is_some().
+    let is_core_running = {
+        if let Some(mihomo_state) = app.try_state::<crate::MihomoState>() {
+            if let Ok(guard) = mihomo_state.0.lock() {
+                guard.last_port().is_some()
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    };
+
+    if !is_core_running {
+        // Core is not running. Do not mark the state as applied; the
+        // coordinator must reconcile once the core is available.
+        emit_info!(
+            System,
+            SYS_NETWORK_STATE_CHANGED,
+            "[NetworkCoordinator] Core not running; deferring apply for {reason} transition to {}",
+            target_state.masked()
+        );
+        return ApplyOutcome::Deferred;
+    }
+
+    let prism_state = match app.try_state::<crate::prism::PrismState>() {
+        Some(s) => s,
+        None => return ApplyOutcome::Failed,
+    };
+
+    match tokio::time::timeout(APPLY_TIMEOUT, prism_state.apply_internal(None)).await {
+        Ok(Ok((outcome, _))) => {
+            let apply_ok = verify_core_apply_success(&outcome);
+
+            if !apply_ok {
+                emit_warn!(
+                    System,
+                    SYS_NETWORK_COORDINATOR_ERROR,
+                    "[NetworkCoordinator] Prism rules compiled and saved, but Mihomo hot-reload (PUT /configs) rejected. Scheduling reconciliation retry."
+                );
+                return ApplyOutcome::Failed;
+            }
+
+            emit_info!(
+                System,
+                SYS_NETWORK_COORDINATOR_APPLIED,
+                "[NetworkCoordinator] Prism rules successfully compiled, applied, and verified via Mihomo PUT /configs (HTTP 2xx) following {reason} transition to {}",
+                target_state.masked()
+            );
+            ApplyOutcome::Applied
+        }
+        Ok(Err(e)) => {
+            emit_warn!(
+                System,
+                SYS_NETWORK_COORDINATOR_ERROR,
+                "[NetworkCoordinator] Prism rule re-apply failed ({reason}): {e}"
+            );
+            ApplyOutcome::Failed
+        }
+        Err(_) => {
+            emit_warn!(
+                System,
+                SYS_NETWORK_COORDINATOR_ERROR,
+                "[NetworkCoordinator] Prism apply timed out after {}s ({reason}).",
+                APPLY_TIMEOUT.as_secs()
+            );
+            ApplyOutcome::Failed
+        }
+    }
+}
+
+/// Serialize a `NetworkState` into a JSON value with the SSID masked for privacy.
+fn masked_network_state_json(state: &NetworkState) -> serde_json::Value {
+    serde_json::json!({
+        "interface_type": state.interface_type,
+        "is_connected": state.is_connected,
+        "ssid": state.ssid.as_deref().map(|_| "***"),
+    })
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/detector.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/detector.rs
@@ -1,0 +1,335 @@
+//! Network state detector and Wi-Fi SSID sampling.
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+use super::types::{InterfaceType, NetworkState};
+
+/// SSID cache TTL — avoids spawning a subprocess on every patch compilation.
+const SSID_CACHE_TTL_SECS: u64 = 5;
+
+/// Cached SSID result (including `None`) with the instant it was observed.
+static SSID_CACHE: Mutex<Option<(Option<String>, Instant)>> = Mutex::new(None);
+
+/// Detect the current `WiFi` SSID with TTL caching.
+#[must_use]
+pub fn detect_ssid() -> Option<String> {
+    // Fast path: return cached value if still fresh.
+    if let Ok(cache) = SSID_CACHE.lock() {
+        if let Some((cached, instant)) = cache.as_ref() {
+            if instant.elapsed().as_secs() < SSID_CACHE_TTL_SECS {
+                return cached.clone();
+            }
+        }
+    }
+
+    let ssid = detect_ssid_uncached();
+
+    // Update cache (best-effort; lock failure is non-fatal).
+    if let Ok(mut cache) = SSID_CACHE.lock() {
+        *cache = Some((ssid.clone(), Instant::now()));
+    }
+
+    ssid
+}
+
+/// Explicitly invalidate the SSID cache (e.g. after a network change event).
+pub fn invalidate_ssid_cache() {
+    if let Ok(mut cache) = SSID_CACHE.lock() {
+        *cache = None;
+    }
+}
+
+/// Classify the current network state based on a detected SSID.
+/// Shared by both cached and uncached detection paths.
+#[must_use]
+fn classify_network_state(ssid: Option<String>) -> NetworkState {
+    if let Some(s) = ssid {
+        return NetworkState {
+            interface_type: InterfaceType::Wifi,
+            is_connected: true,
+            ssid: Some(s),
+        };
+    }
+
+    if detect_has_ethernet() {
+        return NetworkState {
+            interface_type: InterfaceType::Ethernet,
+            is_connected: true,
+            ssid: None,
+        };
+    }
+
+    NetworkState {
+        interface_type: InterfaceType::None,
+        is_connected: false,
+        ssid: None,
+    }
+}
+
+/// Sample the complete current network state with caching.
+#[must_use]
+pub fn detect_network_state() -> NetworkState {
+    classify_network_state(detect_ssid())
+}
+
+/// Sample the ground-truth network state without using any cached SSID value.
+///
+/// Bypasses the TTL cache and directly queries OS interfaces, then updates the
+/// cache with the fresh ground truth. Used by the Coordinator on debounce expiration.
+#[must_use]
+pub fn detect_network_state_uncached() -> NetworkState {
+    let ssid = detect_ssid_uncached();
+
+    // Refresh cache with the newly sampled ground truth
+    if let Ok(mut cache) = SSID_CACHE.lock() {
+        *cache = Some((ssid.clone(), Instant::now()));
+    }
+
+    classify_network_state(ssid)
+}
+
+/// Platform-specific SSID detection without caching (Windows).
+#[cfg(target_os = "windows")]
+#[must_use]
+pub fn detect_ssid_uncached() -> Option<String> {
+    use std::os::windows::process::CommandExt as _;
+    let output = std::process::Command::new("netsh")
+        .args(["wlan", "show", "interfaces"])
+        .creation_flags(crate::core_manager::CREATE_NO_WINDOW)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // Parse: "    SSID                   : MyWiFi"
+    // Skip:  "    BSSID                  : aa:bb:cc:dd:ee:ff"
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("SSID") && !line.starts_with("BSSID"))
+        .and_then(|line| line.split_once(':').map(|(_, v)| v.trim().to_owned()))
+        .filter(|s| !s.is_empty())
+}
+
+/// Platform-specific SSID detection without caching (macOS).
+#[cfg(target_os = "macos")]
+#[must_use]
+pub fn detect_ssid_uncached() -> Option<String> {
+    let iface = detect_macos_wifi_iface().unwrap_or_else(|| "en0".to_string());
+    let output = std::process::Command::new("networksetup")
+        .args(["-getairportnetwork", &iface])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .strip_prefix("Current Wi-Fi Network: ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// Find the macOS Wi-Fi interface via `networksetup -listallhardwareports`.
+#[cfg(target_os = "macos")]
+fn detect_macos_wifi_iface() -> Option<String> {
+    let output = std::process::Command::new("networksetup")
+        .args(["-listallhardwareports"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut found_wifi = false;
+    for line in text.lines().map(str::trim) {
+        if found_wifi {
+            if let Some(dev) = line.strip_prefix("Device: ") {
+                return Some(dev.trim().to_owned());
+            }
+        }
+        if line.starts_with("Hardware Port:") && line.contains("Wi-Fi") {
+            found_wifi = true;
+        }
+    }
+    None
+}
+
+/// Platform-specific SSID detection without caching (Linux).
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn detect_ssid_uncached() -> Option<String> {
+    if let Ok(output) = std::process::Command::new("nmcli")
+        .args(["-t", "-e", "no", "-f", "active,ssid", "dev", "wifi"])
+        .output()
+    {
+        if output.status.success() {
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                // nmcli -t terse format: "active:ssid"
+                // split_once splits at the FIRST colon only, preserving
+                // any colons inside the SSID (e.g. "Corp:Guest").
+                let (active, ssid) = line.split_once(':').unwrap_or((line, ""));
+                if active.trim() == "yes" {
+                    let ssid_trimmed = ssid.trim();
+                    if !ssid_trimmed.is_empty() {
+                        return Some(ssid_trimmed.to_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Ok(output) = std::process::Command::new("iwconfig").output() {
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in combined.lines() {
+            if let Some(rest) = line.split("ESSID:").nth(1) {
+                let trimmed = rest.trim();
+                if let Some(stripped) = trimmed.strip_prefix('"') {
+                    if let Some(end) = stripped.find('"') {
+                        if let Some(ssid) = stripped.get(..end) {
+                            if !ssid.is_empty() {
+                                return Some(ssid.to_owned());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Platform-specific SSID detection without caching (fallback).
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+#[must_use]
+pub fn detect_ssid_uncached() -> Option<String> {
+    None
+}
+
+/// Check if an Ethernet connection is active (Windows).
+///
+/// Uses `GetAdaptersAddresses` Win32 API instead of `netsh` text parsing,
+/// because `netsh` localizes the interface Name column (e.g. "以太网", "イーサネット")
+/// while the State column stays English.  Relying on Name matching would miss
+/// locales we haven't enumerated.  The API returns structured `IfType` and
+/// `OperStatus` enum values that are locale-invariant.
+#[cfg(target_os = "windows")]
+fn detect_has_ethernet() -> bool {
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        GetAdaptersAddresses, GAA_FLAG_SKIP_ANYCAST, GAA_FLAG_SKIP_DNS_SERVER,
+        GAA_FLAG_SKIP_MULTICAST, IP_ADAPTER_ADDRESSES_LH,
+    };
+    use windows_sys::Win32::NetworkManagement::Ndis::{IfOperStatusUp, IF_OPER_STATUS};
+
+    // AF_UNSPEC = 0 (query both IPv4 and IPv6 adapters)
+    const AF_UNSPEC: u32 = 0;
+    const IF_TYPE_ETHERNET_CSMACD: u32 = 6;
+
+    // Start with a reasonable buffer; grow if needed (ERROR_BUFFER_OVERFLOW = 111).
+    let mut size: u32 = 8192;
+    let mut attempts = 0;
+    while attempts < 3 {
+        let mut buf = vec![0u8; size as usize];
+        // sizepointer is InOut: must hold the buffer size on input,
+        // receives the required size on output.
+        let mut ret: u32 = size;
+        // SAFETY: GetAdaptersAddresses is a thread-safe Win32 API. The buffer is
+        // valid for the duration of the call. If it returns ERROR_BUFFER_OVERFLOW,
+        // the output is partial but `ret` holds the required size.
+        let result = unsafe {
+            GetAdaptersAddresses(
+                AF_UNSPEC,
+                GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER,
+                std::ptr::null(),
+                buf.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
+                &mut ret,
+            )
+        };
+        match result {
+            0 => {
+                // Success — walk the linked list of adapters.
+                let mut current = buf.as_ptr() as *const IP_ADAPTER_ADDRESSES_LH;
+                while !current.is_null() {
+                    // SAFETY: `current` points into the buffer returned by
+                    // GetAdaptersAddresses on success. The linked list stays valid
+                    // for the lifetime of the buffer.
+                    let adapter = unsafe { &*current };
+                    if adapter.IfType == IF_TYPE_ETHERNET_CSMACD
+                        && adapter.OperStatus == IfOperStatusUp as IF_OPER_STATUS
+                    {
+                        return true;
+                    }
+                    current = adapter.Next;
+                }
+                return false;
+            }
+            111 => {
+                // ERROR_BUFFER_OVERFLOW — reallocate with returned size.
+                size = ret.max(size * 2);
+            }
+            _ => return false,
+        }
+        attempts += 1;
+    }
+    false
+}
+
+/// Check if an Ethernet connection is active (macOS).
+#[cfg(target_os = "macos")]
+fn detect_has_ethernet() -> bool {
+    if let Ok(output) = std::process::Command::new("ifconfig").output() {
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let wifi_iface = detect_macos_wifi_iface().unwrap_or_else(|| "en0".to_owned());
+            let mut current: Option<String> = None;
+            for line in text.lines() {
+                if !line.starts_with(char::is_whitespace) {
+                    current = line.split(':').next().map(str::to_owned);
+                } else if line.contains("status: active") {
+                    if let Some(name) = current.as_deref() {
+                        if name.starts_with("en") && name != wifi_iface {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check if an Ethernet connection is active (Linux).
+#[cfg(target_os = "linux")]
+fn detect_has_ethernet() -> bool {
+    if let Ok(entries) = std::fs::read_dir("/sys/class/net") {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if (name.starts_with("eth") || name.starts_with("en"))
+                && !name.starts_with("wlan")
+                && !name.starts_with("wl")
+            {
+                let operstate = entry.path().join("operstate");
+                if let Ok(content) = std::fs::read_to_string(operstate) {
+                    if content.trim() == "up" {
+                        return true;
+                    }
+                    if content.trim() == "unknown"
+                        && std::fs::read_to_string(entry.path().join("carrier"))
+                            .is_ok_and(|c| c.trim() == "1")
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check if an Ethernet connection is active (fallback).
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn detect_has_ethernet() -> bool {
+    false
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/platform.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/platform.rs
@@ -1,0 +1,36 @@
+//! Platform-specific native network event listeners.
+
+use crate::network_coordinator::types::NetworkChangeReason;
+use tokio::sync::mpsc::Sender;
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+/// Start the native OS network change listener thread (if supported on this platform).
+pub fn start_native_listener(event_tx: Sender<NetworkChangeReason>) {
+    #[cfg(target_os = "windows")]
+    {
+        windows::start_windows_listener(event_tx);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        macos::start_macos_listener(event_tx);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        linux::start_linux_listener(event_tx);
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = event_tx;
+    }
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/platform/linux.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/platform/linux.rs
@@ -1,0 +1,9 @@
+//! Linux network event listener.
+
+use crate::network_coordinator::types::NetworkChangeReason;
+use tokio::sync::mpsc::Sender;
+
+/// Start Linux network state change listener.
+pub fn start_linux_listener(_event_tx: Sender<NetworkChangeReason>) {
+    // Linux polling fallback is active by default; NetworkManager D-Bus hook can be integrated here.
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/platform/macos.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/platform/macos.rs
@@ -1,0 +1,9 @@
+//! macOS network event listener.
+
+use crate::network_coordinator::types::NetworkChangeReason;
+use tokio::sync::mpsc::Sender;
+
+/// Start macOS network state change listener.
+pub fn start_macos_listener(_event_tx: Sender<NetworkChangeReason>) {
+    // macOS polling fallback is active by default; SCDynamicStore hook can be integrated here.
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/platform/windows.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/platform/windows.rs
@@ -1,0 +1,37 @@
+//! Windows native network change listener using IP Helper API (`NotifyAddrChange`).
+
+use std::time::Duration;
+use tokio::sync::mpsc::Sender;
+use windows_sys::Win32::Foundation::HANDLE;
+
+use crate::network_coordinator::types::NetworkChangeReason;
+
+#[link(name = "iphlpapi")]
+extern "system" {
+    fn NotifyAddrChange(handle: *mut HANDLE, overlapped: *mut core::ffi::c_void) -> u32;
+}
+
+/// Spawn a background thread that blocks on Windows `NotifyAddrChange` to detect IP / interface events.
+pub fn start_windows_listener(event_tx: Sender<NetworkChangeReason>) {
+    std::thread::Builder::new()
+        .name("zephyr-win-net-watcher".to_owned())
+        .spawn(move || {
+            let mut handle: HANDLE = std::ptr::null_mut();
+            loop {
+                // SAFETY: NotifyAddrChange with NULL overlapped synchronously blocks until an IP change occurs.
+                let ret = unsafe { NotifyAddrChange(&mut handle, std::ptr::null_mut()) };
+                if ret == 0 {
+                    let reason =
+                        NetworkChangeReason::NativeEvent("windows_notify_addr_change".to_owned());
+                    if event_tx.blocking_send(reason).is_err() {
+                        // Channel closed, app is shutting down
+                        break;
+                    }
+                } else {
+                    // Back off briefly before retrying to prevent hot loop on error
+                    std::thread::sleep(Duration::from_secs(2));
+                }
+            }
+        })
+        .ok();
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/tests.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/tests.rs
@@ -1,0 +1,690 @@
+//! Unit and timing/concurrency tests for Network Coordinator.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::detector::invalidate_ssid_cache;
+use super::types::{CoordinatorMetrics, InterfaceType, NetworkChangeReason, NetworkState};
+
+#[test]
+fn test_network_state_default() {
+    let state = NetworkState::default();
+    assert_eq!(state.interface_type, InterfaceType::None);
+    assert!(!state.is_connected);
+    assert!(state.ssid.is_none());
+    assert!(!state.is_wifi());
+}
+
+#[test]
+fn test_network_state_wifi() {
+    let state = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("MyOfficeWiFi".to_owned()),
+    };
+    assert!(state.is_wifi());
+    assert_eq!(state.ssid.as_deref(), Some("MyOfficeWiFi"));
+}
+
+#[test]
+fn test_network_state_ethernet() {
+    let state = NetworkState {
+        interface_type: InterfaceType::Ethernet,
+        is_connected: true,
+        ssid: None,
+    };
+    assert!(!state.is_wifi());
+    assert!(state.is_connected);
+}
+
+#[test]
+fn test_network_state_equality() {
+    let state1 = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("HomeNet".to_owned()),
+    };
+    let state2 = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("HomeNet".to_owned()),
+    };
+    let state3 = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("OfficeNet".to_owned()),
+    };
+    assert_eq!(state1, state2);
+    assert_ne!(state1, state3);
+}
+
+#[test]
+fn test_network_state_serialization() {
+    let state = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("ZephyrWiFi".to_owned()),
+    };
+    let json = serde_json::to_string(&state).unwrap();
+    let deserialized: NetworkState = serde_json::from_str(&json).unwrap();
+    assert_eq!(state, deserialized);
+}
+
+#[test]
+fn test_network_state_masking_privacy() {
+    let state_short = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("AP".to_owned()),
+    };
+    assert_eq!(state_short.masked(), "Wifi(***)");
+
+    let state_medium = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Office".to_owned()),
+    };
+    assert_eq!(state_medium.masked(), "Wifi(O***)");
+
+    let state_long = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("ZephyrOfficeWiFi".to_owned()),
+    };
+    assert_eq!(state_long.masked(), "Wifi(Ze***Fi)");
+
+    let state_eth = NetworkState {
+        interface_type: InterfaceType::Ethernet,
+        is_connected: true,
+        ssid: None,
+    };
+    assert_eq!(state_eth.masked(), "ethernet");
+}
+
+#[test]
+fn test_network_change_reason_display() {
+    let r1 = NetworkChangeReason::NativeEvent("win32".to_owned());
+    assert_eq!(r1.to_string(), "native_event(win32)");
+
+    let r2 = NetworkChangeReason::Polling;
+    assert_eq!(r2.to_string(), "polling");
+
+    let r3 = NetworkChangeReason::Resume;
+    assert_eq!(r3.to_string(), "resume");
+
+    let r4 = NetworkChangeReason::OnlineEvent;
+    assert_eq!(r4.to_string(), "online_event");
+
+    let r5 = NetworkChangeReason::Manual;
+    assert_eq!(r5.to_string(), "manual");
+}
+
+#[test]
+fn test_coordinator_metrics_defaults() {
+    let metrics = CoordinatorMetrics::default();
+    assert_eq!(metrics.events_received, 0);
+    assert_eq!(metrics.debounce_expirations, 0);
+    assert_eq!(metrics.state_detections, 0);
+    assert_eq!(metrics.state_transitions, 0);
+    assert_eq!(metrics.apply_started, 0);
+    assert_eq!(metrics.apply_succeeded, 0);
+    assert_eq!(metrics.apply_failed, 0);
+    assert_eq!(metrics.apply_deferred, 0);
+    assert_eq!(metrics.pending_reruns, 0);
+}
+
+#[test]
+fn test_invalidate_cache() {
+    invalidate_ssid_cache();
+    // After invalidation, the SSID cache flag is false. We cannot assert
+    // the SSID value (depends on hardware), but we verify the call doesn't
+    // panic and the cache is in the invalidated state.
+    // The real assertion is that the next detect_ssid() call performs a
+    // fresh hardware query rather than returning a cached value.
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Timing & Concurrency State Machine Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test(start_paused = true)]
+async fn test_debounce_burst_events_single_evaluation() {
+    // Simulates: 5 rapid events in 100ms -> Debounce cancels previous -> Exactly 1 final apply
+    let eval_count = Arc::new(AtomicU32::new(0));
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<NetworkChangeReason>(16);
+
+    let eval_count_clone = Arc::clone(&eval_count);
+    let handle = tokio::spawn(async move {
+        let mut debounce_deadline: Option<tokio::time::Instant> = None;
+        loop {
+            tokio::select! {
+                Some(_reason) = rx.recv() => {
+                    // Reset debounce window on every arrival
+                    debounce_deadline = Some(tokio::time::Instant::now() + Duration::from_millis(150));
+                }
+                _ = async {
+                    match debounce_deadline {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending().await,
+                    }
+                }, if debounce_deadline.is_some() => {
+                    let _ = debounce_deadline.take();
+                    eval_count_clone.fetch_add(1, Ordering::SeqCst);
+                    break;
+                }
+            }
+        }
+    });
+
+    // Send 5 rapid events spaced 20ms apart
+    for _ in 0..5 {
+        tx.send(NetworkChangeReason::NativeEvent("test".to_owned()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    handle.await.unwrap();
+    assert_eq!(
+        eval_count.load(Ordering::SeqCst),
+        1,
+        "Burst events should be debounced into a single evaluation"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_sliding_debounce_window_delays_execution() {
+    // Simulates: event at t=0, event at t=80, event at t=160 -> fires at t=160+150=310ms
+    let evaluated_at = Arc::new(Mutex::new(None::<tokio::time::Instant>));
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<NetworkChangeReason>(16);
+
+    let start_time = tokio::time::Instant::now();
+    let eval_time_clone = Arc::clone(&evaluated_at);
+
+    let handle = tokio::spawn(async move {
+        let mut debounce_deadline: Option<tokio::time::Instant> = None;
+        loop {
+            tokio::select! {
+                Some(_reason) = rx.recv() => {
+                    debounce_deadline = Some(tokio::time::Instant::now() + Duration::from_millis(150));
+                }
+                _ = async {
+                    match debounce_deadline {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending().await,
+                    }
+                }, if debounce_deadline.is_some() => {
+                    let _ = debounce_deadline.take();
+                    if let Ok(mut g) = eval_time_clone.lock() {
+                        *g = Some(tokio::time::Instant::now());
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    // First event at t=0
+    tx.send(NetworkChangeReason::NativeEvent("1".to_owned()))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Second event at t=80 (resets timer)
+    tx.send(NetworkChangeReason::NativeEvent("2".to_owned()))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Third event at t=160 (resets timer again)
+    tx.send(NetworkChangeReason::NativeEvent("3".to_owned()))
+        .await
+        .unwrap();
+
+    handle.await.unwrap();
+
+    let finish_time = evaluated_at.lock().unwrap().unwrap();
+    let total_elapsed = finish_time.duration_since(start_time);
+    assert!(
+        (Duration::from_millis(280)..=Duration::from_millis(340)).contains(&total_elapsed),
+        "Debounce window should slide and only execute after the last event has stabilized (elapsed: {total_elapsed:?}, expected ~310ms)"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_single_flight_coalescing_and_pending_rerun() {
+    // Simulates: Apply 1 starts -> while running, new event arrives -> Apply 2 runs immediately after Apply 1 completes
+    let is_applying = Arc::new(AtomicBool::new(false));
+    let pending_rerun = Arc::new(AtomicBool::new(false));
+    let total_apply_executions = Arc::new(AtomicU32::new(0));
+
+    let is_applying_clone = Arc::clone(&is_applying);
+    let pending_rerun_clone = Arc::clone(&pending_rerun);
+    let total_exec_clone = Arc::clone(&total_apply_executions);
+
+    // Initial trigger
+    assert!(is_applying_clone
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok());
+
+    let worker = tokio::spawn(async move {
+        loop {
+            // Simulate Prism compilation taking 100ms
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            total_exec_clone.fetch_add(1, Ordering::SeqCst);
+
+            if pending_rerun_clone.swap(false, Ordering::SeqCst) {
+                // Rerun detected
+                continue;
+            }
+
+            // Release is_applying first, then re-check pending_rerun — mirrors
+            // the production trigger_single_flight_apply ordering that closes
+            // the lost-wakeup window between the swap and the store.
+            is_applying_clone.store(false, Ordering::SeqCst);
+            if !pending_rerun_clone.swap(false, Ordering::SeqCst) {
+                return;
+            }
+            // Re-acquire; if another worker already took it, that worker handles the rerun.
+            if is_applying_clone
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                return;
+            }
+        }
+    });
+
+    // While Apply 1 is in progress (at t=30ms), a new event arrives
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    // Attempting to start another apply fails and sets pending_rerun
+    if is_applying
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        pending_rerun.store(true, Ordering::SeqCst);
+    }
+
+    worker.await.unwrap();
+
+    assert_eq!(
+        total_apply_executions.load(Ordering::SeqCst),
+        2,
+        "Should execute exactly 2 serial applies (initial + coalesced rerun)"
+    );
+    assert!(
+        !is_applying.load(Ordering::SeqCst),
+        "is_applying should be released back to false"
+    );
+}
+
+#[test]
+fn test_reconciliation_retry_on_apply_failure_semantic() {
+    // Simulates: Home-WiFi -> Office-WiFi transition where Apply #1 Fails
+    let observed_state = Arc::new(Mutex::new(NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Home-WiFi".to_owned()),
+    }));
+    let applied_state = Arc::new(Mutex::new(Some(NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Home-WiFi".to_owned()),
+    })));
+
+    // 1. Transition occurs: observed becomes Office-WiFi
+    let fresh_state = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Office-WiFi".to_owned()),
+    };
+    *observed_state.lock().unwrap() = fresh_state.clone();
+
+    // 2. Reconciliation check detects unaligned state (uses production code)
+    let needs_reconcile =
+        super::coordinator::needs_reconciliation(&applied_state.lock().unwrap(), &fresh_state);
+    assert!(
+        needs_reconcile,
+        "Should detect unaligned state requiring reconciliation"
+    );
+
+    // 3. Simulate Apply #1 FAILS (e.g. transient file lock or core starting)
+    let apply_succeeded = false;
+    if apply_succeeded {
+        *applied_state.lock().unwrap() = Some(fresh_state);
+    }
+    // applied_state is NOT updated; it remains Home-WiFi
+    assert_eq!(
+        applied_state
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .ssid
+            .as_deref(),
+        Some("Home-WiFi")
+    );
+
+    // 4. Next polling interval / tick samples Office-WiFi again
+    let sampled_on_next_tick = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Office-WiFi".to_owned()),
+    };
+    let retry_needed = super::coordinator::needs_reconciliation(
+        &applied_state.lock().unwrap(),
+        &sampled_on_next_tick,
+    );
+    assert!(
+        retry_needed,
+        "On next tick, system MUST automatically retry reconciliation because desired != applied!"
+    );
+
+    // 5. Simulate Apply #2 SUCCEEDS
+    let apply_retry_succeeded = true;
+    if apply_retry_succeeded {
+        *applied_state.lock().unwrap() = Some(sampled_on_next_tick.clone());
+    }
+    assert_eq!(
+        applied_state
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .ssid
+            .as_deref(),
+        Some("Office-WiFi")
+    );
+
+    // 6. Next polling tick: desired == applied -> No-Op
+    let no_op = !super::coordinator::needs_reconciliation(
+        &applied_state.lock().unwrap(),
+        &sampled_on_next_tick,
+    );
+    assert!(no_op, "Once reconciled, subsequent ticks must be No-Op");
+}
+
+#[test]
+fn test_ping_pong_state_reversion_no_op() {
+    // Simulates: Home-WiFi -> Office-WiFi -> Home-WiFi within debounce window
+    // If the applied state already matches the fresh sample, no reconciliation is needed.
+    let sampled_ground_truth = NetworkState {
+        interface_type: InterfaceType::Wifi,
+        is_connected: true,
+        ssid: Some("Home-WiFi".to_owned()),
+    };
+
+    let applied = Arc::new(Mutex::new(Some(sampled_ground_truth.clone())));
+    let no_op =
+        !super::coordinator::needs_reconciliation(&applied.lock().unwrap(), &sampled_ground_truth);
+
+    assert!(no_op, "Ping-pong reversion back to original state should be detected as No-Op with 0 apply triggers");
+}
+
+#[test]
+fn test_hot_reload_ack_fail_closed_semantics() {
+    use super::coordinator::verify_hot_reload_ack;
+
+    // 1. Valid nested ACK from Prism status
+    let valid_nested = serde_json::json!({
+        "patches": [],
+        "status": {
+            "files_saved": true,
+            "hot_reload_success": true,
+            "message": "Config applied and reloaded"
+        }
+    });
+    assert_eq!(verify_hot_reload_ack(&valid_nested), Some(true));
+
+    // 2. Valid top-level ACK
+    let valid_top = serde_json::json!({
+        "hot_reload_success": true
+    });
+    assert_eq!(verify_hot_reload_ack(&valid_top), Some(true));
+
+    // 3. Explicit false from Mihomo
+    let core_error_nested = serde_json::json!({
+        "status": {
+            "files_saved": true,
+            "hot_reload_success": false,
+            "message": "Config error"
+        }
+    });
+    assert_eq!(verify_hot_reload_ack(&core_error_nested), Some(false));
+
+    // 4. Missing ACK field entirely -> None
+    let missing_field = serde_json::json!({
+        "patches": ["patch1", "patch2"]
+    });
+    assert_eq!(verify_hot_reload_ack(&missing_field), None);
+
+    // 5. Malformed null status -> None
+    let null_status = serde_json::json!({
+        "status": null
+    });
+    assert_eq!(verify_hot_reload_ack(&null_status), None);
+
+    // 6. Invalid non-boolean type -> None
+    let string_boolean = serde_json::json!({
+        "status": {
+            "hot_reload_success": "true" // String instead of bool
+        }
+    });
+    assert_eq!(verify_hot_reload_ack(&string_boolean), None);
+}
+
+#[test]
+fn test_layered_protocol_verification_matrix() {
+    use super::coordinator::{parse_apply_result, validate_http_status, verify_core_apply_success};
+    use super::types::CoreApplyResult;
+
+    // Layer 1: HTTP transport status codes
+    assert!(validate_http_status(Some(200)), "HTTP 200 is valid 2xx");
+    assert!(validate_http_status(Some(204)), "HTTP 204 is valid 2xx");
+    assert!(validate_http_status(Some(299)), "HTTP 299 is valid 2xx");
+    assert!(
+        !validate_http_status(Some(400)),
+        "HTTP 400 must be rejected"
+    );
+    assert!(
+        !validate_http_status(Some(500)),
+        "HTTP 500 must be rejected"
+    );
+    assert!(
+        !validate_http_status(Some(502)),
+        "HTTP 502 must be rejected"
+    );
+    assert!(
+        !validate_http_status(None),
+        "None HTTP status must be rejected (fail-closed)"
+    );
+
+    // ── 4-Quadrant Truth Table Tests ─────────────────────────────────────────
+
+    // 1. (HTTP 204, ACK true) => SUCCESS
+    let case1 = CoreApplyResult {
+        http_status: Some(204),
+        hot_reload_success: Some(true),
+    };
+    assert!(
+        verify_core_apply_success(&case1),
+        "HTTP 204 + ACK true must be SUCCESS"
+    );
+
+    // 2. (HTTP 204, ACK false) => FAIL (Mihomo responded but failed to apply rules)
+    let case2 = CoreApplyResult {
+        http_status: Some(204),
+        hot_reload_success: Some(false),
+    };
+    assert!(
+        !verify_core_apply_success(&case2),
+        "HTTP 204 + ACK false must be FAIL"
+    );
+
+    // 3. (HTTP 500, ACK true) => FAIL (Contradictory payload claiming success during 500)
+    let case3 = CoreApplyResult {
+        http_status: Some(500),
+        hot_reload_success: Some(true),
+    };
+    assert!(
+        !verify_core_apply_success(&case3),
+        "HTTP 500 + ACK true must be FAIL"
+    );
+
+    // 4. (HTTP None, ACK true) => FAIL (Unreachable REST API claiming ACK)
+    let case4 = CoreApplyResult {
+        http_status: None,
+        hot_reload_success: Some(true),
+    };
+    assert!(
+        !verify_core_apply_success(&case4),
+        "HTTP None + ACK true must be FAIL"
+    );
+
+    // 5. (HTTP 204, ACK None) => FAIL (Missing ACK field)
+    let case5 = CoreApplyResult {
+        http_status: Some(204),
+        hot_reload_success: None,
+    };
+    assert!(
+        !verify_core_apply_success(&case5),
+        "HTTP 204 + ACK None must be FAIL"
+    );
+
+    // 6. (HTTP None, ACK None) => FAIL (Total outage)
+    let case6 = CoreApplyResult {
+        http_status: None,
+        hot_reload_success: None,
+    };
+    assert!(
+        !verify_core_apply_success(&case6),
+        "HTTP None + ACK None must be FAIL"
+    );
+
+    // ── JSON Parser Orthogonal Extraction Tests ──────────────────────────────
+    // Parser must NEVER fake http_status from hot_reload_success
+    let ack_only_false = serde_json::json!({
+        "status": {
+            "hot_reload_success": false
+        }
+    });
+    let parsed_ack_only_false = parse_apply_result(&ack_only_false);
+    assert_eq!(
+        parsed_ack_only_false.http_status, None,
+        "Must NOT fake HTTP 500 from hot_reload_success=false"
+    );
+    assert_eq!(parsed_ack_only_false.hot_reload_success, Some(false));
+    assert!(!verify_core_apply_success(&parsed_ack_only_false));
+
+    let ack_only_true = serde_json::json!({
+        "status": {
+            "hot_reload_success": true
+        }
+    });
+    let parsed_ack_only_true = parse_apply_result(&ack_only_true);
+    assert_eq!(
+        parsed_ack_only_true.http_status, None,
+        "Must NOT fake HTTP 200 from hot_reload_success=true"
+    );
+    assert_eq!(parsed_ack_only_true.hot_reload_success, Some(true));
+    assert!(
+        !verify_core_apply_success(&parsed_ack_only_true),
+        "Missing HTTP status must fail closed"
+    );
+
+    // Full structured 204 + true
+    let full_valid_json = serde_json::json!({
+        "status": {
+            "http_status": 204,
+            "hot_reload_success": true
+        }
+    });
+    let parsed_full = parse_apply_result(&full_valid_json);
+    assert_eq!(parsed_full.http_status, Some(204));
+    assert_eq!(parsed_full.hot_reload_success, Some(true));
+    assert!(verify_core_apply_success(&parsed_full));
+}
+
+// Use multi_thread flavor to guarantee the Barrier(2) can have two
+// spawn_blocking closures running simultaneously on different threads.
+// On current_thread runtime the closures could run sequentially on the
+// same pooled worker, making the test pass even without thread isolation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_http_status_is_thread_confined_with_raii_cleanup() {
+    use crate::prism::host::{
+        set_current_apply_http_status, take_current_apply_http_status, HttpStatusGuard,
+    };
+    use std::sync::Barrier;
+
+    // Barrier ensures both closures hold their own status simultaneously,
+    // proving thread-local isolation rather than sequential reuse.
+    let barrier = Arc::new(Barrier::new(2));
+    let barrier_a = Arc::clone(&barrier);
+    let barrier_b = Arc::clone(&barrier);
+
+    // 1. Task A on thread 1 sets HTTP 204 via HttpStatusGuard
+    let handle_a = tokio::task::spawn_blocking(move || {
+        let guard = HttpStatusGuard::enter();
+        set_current_apply_http_status(Some(204));
+        // Wait for Task B to also set its status, then verify isolation.
+        barrier_a.wait();
+        let status_a = guard.take();
+        assert_eq!(status_a, Some(204));
+        assert_eq!(take_current_apply_http_status(), None);
+        status_a
+    });
+
+    // 2. Task B on thread 2 sets HTTP 500 via HttpStatusGuard
+    let handle_b = tokio::task::spawn_blocking(move || {
+        let guard = HttpStatusGuard::enter();
+        set_current_apply_http_status(Some(500));
+        // Wait for Task A to also set its status, then verify isolation.
+        barrier_b.wait();
+        let status_b = guard.take();
+        assert_eq!(status_b, Some(500));
+        assert_eq!(take_current_apply_http_status(), None);
+        status_b
+    });
+
+    let res_a = handle_a.await.unwrap();
+    let res_b = handle_b.await.unwrap();
+
+    assert_eq!(res_a, Some(204), "Request A must receive its own 204");
+    assert_eq!(res_b, Some(500), "Request B must receive its own 500");
+
+    // 3. Test RAII Drop cleanup on simulated error / early return (?)
+    tokio::task::spawn_blocking(|| {
+        {
+            let _guard = HttpStatusGuard::enter();
+            set_current_apply_http_status(Some(500));
+            // Simulate early return without guard.take() (e.g. ext.apply()? returned Err)
+        } // _guard drops here and MUST clean up TLS
+        assert_eq!(
+            take_current_apply_http_status(),
+            None,
+            "HttpStatusGuard Drop must guarantee TLS cleanup even on early error returns"
+        );
+    })
+    .await
+    .unwrap();
+
+    // 4. Test worker thread reuse:
+    // Even if previous dirty state existed, new guard's enter() unconditionally resets TLS to None
+    tokio::task::spawn_blocking(|| {
+        // Step 4a: Force dirty state
+        set_current_apply_http_status(Some(502));
+
+        // Step 4b: New guard enters on the same thread
+        let fresh_guard = HttpStatusGuard::enter();
+
+        // Step 4c: If no status was written during this execution, take() must return None (never 502)
+        assert_eq!(
+            fresh_guard.take(),
+            None,
+            "Worker reuse must unconditionally start clean with None"
+        );
+    })
+    .await
+    .unwrap();
+}

--- a/apps/desktop/src-tauri/src/network_coordinator/types.rs
+++ b/apps/desktop/src-tauri/src/network_coordinator/types.rs
@@ -1,0 +1,177 @@
+//! Network state and coordinator data structures.
+
+use serde::{Deserialize, Serialize};
+
+/// Type of network interface currently active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InterfaceType {
+    /// Wireless 802.11 Wi-Fi connection
+    Wifi,
+    /// Wired 802.3 Ethernet connection
+    Ethernet,
+    /// Cellular / Mobile broadband connection
+    Cellular,
+    /// Other / Virtual / VPN interface
+    Other,
+    /// No active network interface detected
+    None,
+}
+
+impl std::fmt::Display for InterfaceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Wifi => write!(f, "wifi"),
+            Self::Ethernet => write!(f, "ethernet"),
+            Self::Cellular => write!(f, "cellular"),
+            Self::Other => write!(f, "other"),
+            Self::None => write!(f, "none"),
+        }
+    }
+}
+
+/// Snapshot of the system's current network connectivity state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkState {
+    /// Primary active interface type.
+    pub interface_type: InterfaceType,
+    /// Whether the host has network connectivity.
+    pub is_connected: bool,
+    /// Wi-Fi SSID name (if connected via Wi-Fi).
+    pub ssid: Option<String>,
+}
+
+impl Default for NetworkState {
+    fn default() -> Self {
+        Self {
+            interface_type: InterfaceType::None,
+            is_connected: false,
+            ssid: None,
+        }
+    }
+}
+
+impl NetworkState {
+    /// Check if the network state represents a valid connected Wi-Fi with non-empty SSID.
+    #[must_use]
+    pub fn is_wifi(&self) -> bool {
+        self.is_connected
+            && self.interface_type == InterfaceType::Wifi
+            && self.ssid.as_deref().is_some_and(|ssid| !ssid.is_empty())
+    }
+
+    /// Return a privacy-redacted representation of the network state suitable for diagnostic logs.
+    #[must_use]
+    pub fn masked(&self) -> String {
+        match (&self.interface_type, &self.ssid) {
+            (InterfaceType::Wifi, Some(ssid)) => {
+                let masked_ssid = mask_ssid(ssid);
+                format!("Wifi({masked_ssid})")
+            }
+            (itype, _) => format!("{itype}"),
+        }
+    }
+}
+
+/// Mask SSID for diagnostic log privacy (e.g. "`MyHomeNetwork`" -> "`My***rk`").
+fn mask_ssid(ssid: &str) -> String {
+    let chars: Vec<char> = ssid.chars().collect();
+    let len = chars.len();
+    if len <= 2 {
+        "***".to_owned()
+    } else if len <= 6 {
+        let first = chars.first().copied().unwrap_or('*');
+        format!("{first}***")
+    } else {
+        let first: String = chars.iter().take(2).collect();
+        let last: String = chars
+            .iter()
+            .rev()
+            .take(2)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        format!("{first}***{last}")
+    }
+}
+
+/// Telemetry metrics for the Network Change Coordinator.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoordinatorMetrics {
+    /// Total raw events received across all sources.
+    pub events_received: u64,
+    /// Number of times the debounce window successfully stabilized and expired.
+    pub debounce_expirations: u64,
+    /// Total uncached hardware state queries performed.
+    pub state_detections: u64,
+    /// Number of transitions where observed network state changed.
+    pub state_transitions: u64,
+    /// Number of Prism rule applications initiated.
+    pub apply_started: u64,
+    /// Number of Prism rule applications completed successfully.
+    pub apply_succeeded: u64,
+    /// Number of Prism rule applications that encountered an error.
+    pub apply_failed: u64,
+    /// Number of applies deferred because the core was not running (not counted as failures).
+    pub apply_deferred: u64,
+    /// Number of coalesced rerun requests scheduled.
+    pub pending_reruns: u64,
+}
+
+/// Reason / trigger source for network state re-evaluation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkChangeReason {
+    /// OS native event (e.g. IP interface change, WLAN notification)
+    NativeEvent(String),
+    /// Low-frequency periodic polling heartbeat
+    Polling,
+    /// System resume from sleep / suspend
+    Resume,
+    /// Frontend browser window.online event
+    OnlineEvent,
+    /// User or frontend manual refresh request
+    Manual,
+}
+
+impl std::fmt::Display for NetworkChangeReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NativeEvent(src) => write!(f, "native_event({src})"),
+            Self::Polling => write!(f, "polling"),
+            Self::Resume => write!(f, "resume"),
+            Self::OnlineEvent => write!(f, "online_event"),
+            Self::Manual => write!(f, "manual"),
+        }
+    }
+}
+
+/// Strongly-typed outcome of a Mihomo core rule application.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoreApplyResult {
+    /// HTTP transport status code returned by Mihomo REST API (None if connection failed or unknown).
+    pub http_status: Option<u16>,
+    /// Application payload acknowledgement confirming hot-reload success (None if missing/unknown).
+    pub hot_reload_success: Option<bool>,
+}
+
+/// Check whether an HTTP status code is a 2xx success.
+/// Shared by `CoreApplyResult::is_success`, `validate_http_status`,
+/// `PrismState::apply_internal`, and `ZephyrPrismHost::apply_config`.
+#[must_use]
+pub fn is_http_success(code: u16) -> bool {
+    (200..=299).contains(&code)
+}
+
+impl CoreApplyResult {
+    /// Check whether rule application was completely successful at both transport and application layers.
+    /// Follows strict fail-closed semantics: requires `http_status` in `200..=299` AND `hot_reload_success == Some(true)`.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(
+            (self.http_status, self.hot_reload_success),
+            (Some(code), Some(true)) if is_http_success(code)
+        )
+    }
+}

--- a/apps/desktop/src-tauri/src/prism.rs
+++ b/apps/desktop/src-tauri/src/prism.rs
@@ -27,7 +27,7 @@ use crate::core_manager::ensure_app_storage;
 
 mod commands_core;
 mod failover_commands;
-mod host;
+pub(crate) mod host;
 mod kv_commands;
 pub mod overrides;
 pub mod pipeline;
@@ -186,6 +186,69 @@ impl PrismState {
         let result = f(ext);
         drop(lock);
         result
+    }
+
+    /// Internal apply method executed on a blocking thread to avoid starving async command threads.
+    pub async fn apply_internal(
+        &self,
+        options: Option<clash_prism_extension::ApplyOptions>,
+    ) -> Result<
+        (
+            crate::network_coordinator::CoreApplyResult,
+            serde_json::Value,
+        ),
+        String,
+    > {
+        let opts = options.unwrap_or_default();
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            // RAII Scope Guard: Guarantees TLS is cleared before execution and on early exit/Drop
+            let guard = host::HttpStatusGuard::enter();
+
+            let mut lock = lock_critical(&inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)?;
+            let ext = lock
+                .extension
+                .as_ref()
+                .ok_or_else(|| "Prism not initialized".to_owned())?;
+            let result = ext.apply(opts)?;
+            if let Ok(val) = serde_json::to_value(&result.trace) {
+                lock.last_trace = val.as_array().cloned().unwrap_or_default();
+            }
+            drop(lock);
+
+            // Extract strictly thread-confined transport status code via RAII guard.
+            // The thread-local bridge is set by ZephyrPrismHost::apply_config, which
+            // derives hot_reload_success from the HTTP status code.  We use that
+            // directly because ApplyResult (returned by ext.apply) does not contain
+            // the ApplyStatus struct — only output_config, stats, trace, and annotations.
+            let http_status = guard.take();
+            let hot_reload_success =
+                http_status.is_some_and(crate::network_coordinator::is_http_success);
+
+            let core_result = crate::network_coordinator::CoreApplyResult {
+                http_status,
+                hot_reload_success: Some(hot_reload_success),
+            };
+
+            // Enrich the serialized JSON with the status fields so downstream
+            // consumers (e.g. prism_apply command response) can access them.
+            let mut val =
+                serde_json::to_value(result).map_err(|e| format!("Serialize failed: {e}"))?;
+            if let Some(obj) = val.as_object_mut() {
+                let mut status_obj = serde_json::Map::new();
+                status_obj.insert(
+                    "hot_reload_success".to_owned(),
+                    serde_json::json!(hot_reload_success),
+                );
+                if let Some(code) = http_status {
+                    status_obj.insert("http_status".to_owned(), serde_json::json!(code));
+                }
+                obj.insert("status".to_owned(), serde_json::Value::Object(status_obj));
+            }
+            Ok((core_result, val))
+        })
+        .await
+        .map_err(|e| format!("Task join failed: {e}"))?
     }
 
     pub(crate) fn get_prism_workspace(&self) -> Result<std::path::PathBuf, String> {

--- a/apps/desktop/src-tauri/src/prism/commands_core.rs
+++ b/apps/desktop/src-tauri/src/prism/commands_core.rs
@@ -43,27 +43,7 @@ pub async fn prism_apply(
     state: State<'_, PrismState>,
     options: Option<ApplyOptions>,
 ) -> Result<serde_json::Value, String> {
-    let opts = options.unwrap_or_default();
-    let inner = std::sync::Arc::clone(&state.inner);
-    // Run in blocking thread pool to avoid occupying Tauri's async command threads.
-    // This allows other invoke() calls (e.g. proxy toggle, settings) to proceed
-    // while Prism compiles large rule sets.
-    tokio::task::spawn_blocking(move || {
-        let mut lock = lock_critical(&inner, BackendModule::Prism, codes::PRISM_LOCK_FAILED)?;
-        let ext = lock
-            .extension
-            .as_ref()
-            .ok_or_else(|| "Prism not initialized".to_owned())?;
-        let result = ext.apply(opts)?;
-        // Cache trace for fast lookup by handleViewChanges / prism_get_last_trace.
-        if let Ok(val) = serde_json::to_value(&result.trace) {
-            lock.last_trace = val.as_array().cloned().unwrap_or_default();
-        }
-        drop(lock);
-        serde_json::to_value(result).map_err(|e| format!("Serialize failed: {e}"))
-    })
-    .await
-    .map_err(|e| format!("Task join failed: {e}"))?
+    state.apply_internal(options).await.map(|(_, val)| val)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/prism/host.rs
+++ b/apps/desktop/src-tauri/src/prism/host.rs
@@ -12,158 +12,67 @@ use zephyr_core::config::sanitizer::validate_path_within_dir;
 use super::prism_data_dir;
 use super::types::sanitize_filename;
 
-// ── WiFi SSID detection (for `__when__.ssid` condition) ──────────────────
+// ── Thread-confined HTTP status bridge for ext.apply() ───────────────────
+// (WiFi SSID detection now lives in network_coordinator)
 
-/// SSID cache TTL — avoids spawning a subprocess on every patch compilation.
-const SSID_CACHE_TTL_SECS: u64 = 5;
+use std::cell::Cell;
 
-/// Cached SSID result (including `None`) with the instant it was observed.
-/// Caching `None` avoids re-spawning subprocesses when `WiFi` is disconnected.
-static SSID_CACHE: std::sync::Mutex<Option<(Option<String>, std::time::Instant)>> =
-    std::sync::Mutex::new(None);
+thread_local! {
+    static CURRENT_APPLY_HTTP_STATUS: Cell<Option<u16>> = const { Cell::new(None) };
+}
 
-/// Detect the current `WiFi` SSID via platform-specific commands.
+pub(crate) fn set_current_apply_http_status(status: Option<u16>) {
+    CURRENT_APPLY_HTTP_STATUS.with(|c| c.set(status));
+}
+
+#[must_use]
+pub(crate) fn take_current_apply_http_status() -> Option<u16> {
+    CURRENT_APPLY_HTTP_STATUS.with(Cell::take)
+}
+
+/// RAII Scope Guard for thread-confined HTTP status bridge during `ext.apply()`.
 ///
-/// Results are cached for `SSID_CACHE_TTL_SECS` to avoid excessive subprocess
-/// spawning during frequent recompilations (e.g. rapid rule edits).
-fn detect_ssid() -> Option<String> {
-    // Fast path: return cached value if still fresh.
-    if let Ok(cache) = SSID_CACHE.lock() {
-        if let Some((cached, instant)) = cache.as_ref() {
-            if instant.elapsed().as_secs() < SSID_CACHE_TTL_SECS {
-                return cached.clone();
-            }
+/// ### Hard Architectural Invariants:
+/// 1. **Same-Thread Synchronous Execution**: `clash_prism_extension::Apply` and
+///    `ZephyrPrismHost::apply_config` MUST execute synchronously on the exact same OS thread
+///    as `HttpStatusGuard::enter()`. The thread-local bridge assumes no internal thread hopping
+///    occurs inside `ext.apply()`.
+/// 2. **Single-Flight Concurrency**: Mihomo `PUT /configs` is serialized by the Coordinator's
+///    single-flight state machine, preventing concurrent overlapping rule applications.
+/// 3. **Guaranteed RAII Cleanup**: Whether `ext.apply()` completes normally, returns `Err(?)`
+///    via early return, or unwinds, `Drop` unconditionally clears the thread-local storage,
+///    preventing Tokio worker thread reuse pollution.
+pub(crate) struct HttpStatusGuard {
+    taken: bool,
+    // !Send marker: enforces at compile time that the guard cannot cross
+    // thread boundaries. The thread-local `CURRENT_APPLY_HTTP_STATUS` is
+    // only valid on the thread that called `enter()`.
+    _marker: std::marker::PhantomData<*const ()>,
+}
+
+impl HttpStatusGuard {
+    #[must_use]
+    pub fn enter() -> Self {
+        CURRENT_APPLY_HTTP_STATUS.with(|c| c.set(None));
+        Self {
+            taken: false,
+            _marker: std::marker::PhantomData,
         }
     }
 
-    let ssid = detect_ssid_uncached();
-
-    // Update cache (best-effort; lock failure is non-fatal).
-    if let Ok(mut cache) = SSID_CACHE.lock() {
-        *cache = Some((ssid.clone(), std::time::Instant::now()));
+    #[must_use]
+    pub fn take(mut self) -> Option<u16> {
+        self.taken = true;
+        take_current_apply_http_status()
     }
-
-    ssid
 }
 
-/// Platform-specific SSID detection without caching.
-#[cfg(target_os = "windows")]
-fn detect_ssid_uncached() -> Option<String> {
-    use std::os::windows::process::CommandExt as _;
-    let output = std::process::Command::new("netsh")
-        .args(["wlan", "show", "interfaces"])
-        .creation_flags(crate::core_manager::CREATE_NO_WINDOW)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    // Parse: "    SSID                   : MyWiFi"
-    // Skip:  "    BSSID                  : aa:bb:cc:dd:ee:ff"
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::trim)
-        .find(|line| line.starts_with("SSID") && !line.starts_with("BSSID"))
-        .and_then(|line| line.split_once(':').map(|(_, v)| v.trim().to_owned()))
-        .filter(|s| !s.is_empty())
-}
-
-/// Platform-specific SSID detection without caching.
-#[cfg(target_os = "macos")]
-fn detect_ssid_uncached() -> Option<String> {
-    // Resolve the Wi-Fi interface name (not always en0).
-    let iface = detect_macos_wifi_iface().unwrap_or_else(|| "en0".to_string());
-    let output = std::process::Command::new("networksetup")
-        .args(["-getairportnetwork", &iface])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    // Output: "Current Wi-Fi Network: MyWiFi"
-    String::from_utf8_lossy(&output.stdout)
-        .strip_prefix("Current Wi-Fi Network: ")
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(String::from)
-}
-
-/// Find the macOS Wi-Fi interface via `networksetup -listallhardwareports`.
-#[cfg(target_os = "macos")]
-fn detect_macos_wifi_iface() -> Option<String> {
-    let output = std::process::Command::new("networksetup")
-        .args(["-listallhardwareports"])
-        .output()
-        .ok()?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    let mut found_wifi = false;
-    for line in text.lines().map(str::trim) {
-        if found_wifi {
-            // The line after "Wi-Fi" contains "Device: enX"
-            if let Some(dev) = line.strip_prefix("Device: ") {
-                return Some(dev.trim().to_owned());
-            }
-        }
-        if line.starts_with("Hardware Port:") && line.contains("Wi-Fi") {
-            found_wifi = true;
+impl Drop for HttpStatusGuard {
+    fn drop(&mut self) {
+        if !self.taken {
+            let _ = take_current_apply_http_status();
         }
     }
-    None
-}
-
-/// Platform-specific SSID detection without caching.
-#[cfg(target_os = "linux")]
-fn detect_ssid_uncached() -> Option<String> {
-    // Try nmcli first (most common on modern Linux desktops).
-    // `-t -f active,ssid` produces terse output: "yes:MyWiFi\n:OtherNet"
-    // `-e no` disables escaping so SSIDs containing `:` or `\` are preserved.
-    if let Ok(output) = std::process::Command::new("nmcli")
-        .args(["-t", "-e", "no", "-f", "active,ssid", "dev", "wifi"])
-        .output()
-    {
-        if output.status.success() {
-            for line in String::from_utf8_lossy(&output.stdout).lines() {
-                // Active row starts with "yes:" — split on first ':' to get SSID
-                let (active, ssid) = line.split_once(':').unwrap_or((line, ""));
-                if active.trim() == "yes" {
-                    let ssid_trimmed = ssid.trim();
-                    if !ssid_trimmed.is_empty() {
-                        return Some(ssid_trimmed.to_owned());
-                    }
-                }
-            }
-        }
-    }
-
-    // Fallback: iwconfig (prints to stdout on some systems, stderr on others).
-    if let Ok(output) = std::process::Command::new("iwconfig").output() {
-        let combined = format!(
-            "{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        for line in combined.lines() {
-            // Parse: '    ESSID:"MyWiFi"'
-            if let Some(rest) = line.split("ESSID:").nth(1) {
-                let trimmed = rest.trim();
-                if let Some(stripped) = trimmed.strip_prefix('"') {
-                    if let Some(end) = stripped.find('"') {
-                        let ssid = &stripped[..end];
-                        if !ssid.is_empty() {
-                            return Some(ssid.to_owned());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Platform-specific SSID detection without caching.
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-fn detect_ssid_uncached() -> Option<String> {
-    None
 }
 
 pub(crate) struct ZephyrPrismHost {
@@ -177,13 +86,13 @@ impl ZephyrPrismHost {
 
     /// Synchronous HTTP PUT to localhost --- no tokio dependency.
     /// Used by `apply_config` which is a sync trait method callable from any thread.
-    fn http_put(url: &str, body: &str, bearer: &str) -> bool {
+    fn http_put(url: &str, body: &str, bearer: &str) -> Option<u16> {
         use std::io::{Read as _, Write as _};
         use std::net::TcpStream;
 
         let parsed = match url::Url::parse(url) {
             Ok(u) => u,
-            Err(_) => return false,
+            Err(_) => return None,
         };
 
         let host = parsed.host_str().unwrap_or("127.0.0.1");
@@ -198,7 +107,7 @@ impl ZephyrPrismHost {
             std::time::Duration::from_secs(2),
         ) {
             Ok(s) => s,
-            Err(_) => return false,
+            Err(_) => return None,
         };
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
@@ -226,7 +135,7 @@ impl ZephyrPrismHost {
         );
 
         if stream.write_all(request.as_bytes()).is_err() {
-            return false;
+            return None;
         }
 
         // Read response status line (first line only)
@@ -243,12 +152,22 @@ impl ZephyrPrismHost {
             }
         }
 
-        // Check for HTTP 2xx status (200-299). Require 3 ASCII digits to avoid
-        // treating truncated or malformed responses as success.
-        response.starts_with(b"HTTP/")
-            && response
-                .get(9..12)
-                .is_some_and(|s| s.first() == Some(&b'2') && s.iter().all(u8::is_ascii_digit))
+        // Parse 3-digit HTTP status code (e.g. "HTTP/1.1 204 No Content" -> 204)
+        // Tokenize by whitespace to support any HTTP version (HTTP/1.0, HTTP/1.1, HTTP/2).
+        let head = response
+            .split(|b| *b == b'\r' || *b == b'\n')
+            .next()
+            .unwrap_or(&[]);
+        let line = match std::str::from_utf8(head) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+        if !line.starts_with("HTTP/") {
+            return None;
+        }
+        line.split_whitespace()
+            .nth(1)
+            .and_then(|tok| tok.parse::<u16>().ok())
     }
 }
 
@@ -286,15 +205,23 @@ impl PrismHost for ZephyrPrismHost {
         // Synchronous HTTP PUT --- apply_config is a sync trait method that may be
         // called from non-tokio threads (e.g. WebView2 COM callbacks). Using
         // std::net avoids the "no reactor running" panic from block_on().
-        let hot_reload_success = Self::http_put(&url, &body, &secret);
+        let http_status_code = Self::http_put(&url, &body, &secret);
+        set_current_apply_http_status(http_status_code);
+        let hot_reload_success =
+            http_status_code.is_some_and(crate::network_coordinator::is_http_success);
 
         Ok(ApplyStatus {
             files_saved: true,
             hot_reload_success,
-            message: if hot_reload_success {
-                "Config applied and reloaded".to_owned()
-            } else {
-                "Config saved. Restart core to apply.".to_owned()
+            message: match http_status_code {
+                Some(code) if crate::network_coordinator::is_http_success(code) => {
+                    format!("Config applied and reloaded (HTTP {code})")
+                }
+                Some(code) => {
+                    format!("Core rejected reload with HTTP {code}. Restart core to apply.")
+                }
+                None => "Config saved. Failed to connect to core REST API. Restart core to apply."
+                    .to_owned(),
             },
             restarted: false,
         })
@@ -459,6 +386,6 @@ impl PrismHost for ZephyrPrismHost {
     }
 
     fn get_ssid(&self) -> Option<String> {
-        detect_ssid()
+        crate::network_coordinator::detect_ssid()
     }
 }

--- a/apps/desktop/src/integration.test.js
+++ b/apps/desktop/src/integration.test.js
@@ -36,6 +36,7 @@ describe('Backend ↔ Frontend IPC command contract', () => {
         'CORE', 'CONFIG_FILES', 'SYS_PROXY', 'TUN', 'TRAY', 'UPDATER',
         'SHORTCUTS', 'SCHEDULER', 'SETTINGS', 'MISC', 'CRYPTO', 'SUBSCRIPTION', 'PRISM', 'RULE',
         'PLUGIN', 'SCRIPT', 'SMART', 'FAILOVER', 'KV', 'TRACE_ADVANCED', 'OVERRIDE', 'NETWORK_OPTIM',
+        'NETWORK_COORDINATOR',
     ]);
     const backendCommands = Object.values(COMMANDS).filter(
         v => typeof v === 'string' && v.length > 0
@@ -192,6 +193,7 @@ describe('UI → shared/index.js COMMANDS reference contract', () => {
             'CORE', 'CONFIG_FILES', 'SYS_PROXY', 'TUN', 'TRAY', 'UPDATER',
             'SHORTCUTS', 'SCHEDULER', 'SETTINGS', 'MISC', 'CRYPTO', 'SUBSCRIPTION', 'PRISM', 'RULE',
             'PLUGIN', 'SCRIPT', 'SMART', 'FAILOVER', 'KV', 'TRACE_ADVANCED', 'OVERRIDE', 'NETWORK_OPTIM',
+            'NETWORK_COORDINATOR',
         ]);
         for (const [key, value] of Object.entries(COMMANDS)) {
             if (NAMESPACE_REFS.has(key)) continue; // namespace refs, not strings

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -36,6 +36,7 @@ if (typeof Element.prototype.replaceChildren !== 'function') {
 
 import {
   invoke,
+  listen,
   setBaseUrl,
   setSecret,
   setCoreReachable,
@@ -492,6 +493,31 @@ async function initApp() {
 
   registerDefaultShortcuts().catch((err) => {
     apiLogger.warn('Failed to register default shortcuts', err);
+  });
+
+  // 7c. Network online & state change listener
+  const onOnline = () => {
+    invoke(COMMANDS.NOTIFY_NETWORK_CHANGE, { source: 'browser_online' }).catch(() => {});
+  };
+  const onOffline = () => {
+    invoke(COMMANDS.NOTIFY_NETWORK_CHANGE, { source: 'browser_offline' }).catch(() => {});
+  };
+  window.addEventListener('online', onOnline);
+  window.addEventListener('offline', onOffline);
+  registerCleanup(() => {
+    window.removeEventListener('online', onOnline);
+    window.removeEventListener('offline', onOffline);
+  });
+  listen('network-state-changed', (event) => {
+    const payload = event?.payload;
+    apiLogger.info(
+      `[Zephyr] Network state changed: reason=${payload?.reason} ` +
+      `type=${payload?.new_state?.interface_type} connected=${payload?.new_state?.is_connected}`
+    );
+  }).then((unlisten) => {
+    registerCleanup(() => { unlisten(); });
+  }).catch((err) => {
+    apiLogger.warn('Failed to init network state change listener', err);
   });
 
   apiLogger.info(`[Zephyr] UI modules: +${(performance.now() - tUI).toFixed(0)}ms`);

--- a/deny.toml
+++ b/deny.toml
@@ -7,9 +7,9 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows
 [advisories]
 # cargo-deny does not support ignoreUntil/expiry fields (unlike osv-scanner.toml).
 # Review-by dates below mirror the OSV ignoreUntil = 2027-12-31 for periodic
-# re-evaluation.  Ignored advisories are fully suppressed from cargo-deny
-# output — they are NOT surfaced as warnings.  See osv-scanner.toml for the
-# time-bounded suppressions of the same advisory IDs.
+# re-evaluation.  Ignored advisories are NOT fully suppressed — cargo-deny still
+# emits an advisory-ignored note when encountering them.  See osv-scanner.toml
+# for the time-bounded suppressions of the same advisory IDs.
 # Review by: 2027-12-31
 ignore = [
   "RUSTSEC-2026-0097",
@@ -27,6 +27,13 @@ ignore = [
   # glib 0.18.x — unsound VariantStrIter (RUSTSEC-2024-0429)
   # Locked by gtk-rs GTK3; fix requires glib >=0.20.0 (GTK4 migration)
   "RUSTSEC-2024-0429",
+  # h2 unbounded empty DATA frames (RUSTSEC-2026-0258)
+  # Transitive via hyper/h2; upgrade blocked by Tauri's reqwest/hyper stack.
+  # Track: https://rustsec.org/advisories/RUSTSEC-2026-0258.html
+  "RUSTSEC-2026-0258",
+  # event-listener unsound StackSlot (RUSTSEC-2026-0221)
+  # Transitive via async-channel (Tauri); fix requires event-listener >=5.5.0
+  "RUSTSEC-2026-0221",
   # Unmaintained-only advisories (bincode, proc-macro-error, paste, unic-*)
   # are NOT listed here — `unmaintained = "workspace"` below handles them:
   # transitive unmaintained deps are allowed (non-failing) automatically.
@@ -54,6 +61,15 @@ ignore = [
 #
 # RUSTSEC-2026-0185: quinn-proto remote memory exhaustion
 #   Fixed by upgrading quinn-proto 0.11.14 → 0.11.16 (>=0.11.15)
+#
+# RUSTSEC-2026-0258: h2 unbounded empty DATA frames
+#   Transitive via hyper/h2 (Tauri's reqwest stack); upgrade to h2 >=0.4.16 blocked
+#   by current hyper/reqwest versions. Tracked until upstream stack updates.
+#   Track: https://rustsec.org/advisories/RUSTSEC-2026-0258.html
+#
+# RUSTSEC-2026-0221: event-listener unsound StackSlot (Send/Soundness)
+#   Transitive via async-channel (Tauri); fix requires event-listener >=5.5.0
+#   Track: https://rustsec.org/advisories/RUSTSEC-2026-0221.html
 #
 # gtk-rs (0411-0420) and glib (0429) are intentionally suppressed from cargo-deny
 # output.  They are visible only in this config file, not in tool reports.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -113,3 +113,15 @@ ignoreUntil = 2027-12-31
 reason = "rand 0.8 unsound; transitive via tauri ecosystem, our code pins rand 0.10.1"
 
 # RUSTSEC-2026-0098 / RUSTSEC-2026-0099: RESOLVED — rustls-webpki 0.103.13 (>=0.103.12)
+
+# ── Rust: upstream-blocked vulnerability fixes (transitive deps) ──
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0258"
+ignoreUntil = 2027-12-31
+reason = "h2 unbounded empty DATA frames; transitive via hyper/h2 (Tauri reqwest stack), upgrade blocked"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0221"
+ignoreUntil = 2027-12-31
+reason = "event-listener unsound StackSlot; transitive via async-channel (Tauri), fix requires event-listener >=5.5.0"

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -332,6 +332,15 @@ export const NETWORK_OPTIM = Object.freeze({
 });
 
 // ---------------------------------------------------------------------------
+// Network Coordinator
+// ---------------------------------------------------------------------------
+
+export const NETWORK_COORDINATOR = Object.freeze({
+    GET_NETWORK_STATE: "get_network_state",
+    NOTIFY_NETWORK_CHANGE: "notify_network_change",
+});
+
+// ---------------------------------------------------------------------------
 // Convenience: all command names in one flat object
 // ---------------------------------------------------------------------------
 
@@ -358,9 +367,11 @@ export const COMMANDS = Object.freeze({
     ...TRACE_ADVANCED,
     ...OVERRIDE,
     ...NETWORK_OPTIM,
+    ...NETWORK_COORDINATOR,
     // Preserve namespace access for code that uses COMMANDS.NAMESPACE.X
     CORE, CONFIG_FILES, SYS_PROXY, TUN, TRAY,
     UPDATER, SHORTCUTS, SCHEDULER, SETTINGS, MISC, CRYPTO,
     SUBSCRIPTION, PRISM, RULE, PLUGIN, SCRIPT, SMART,
     FAILOVER, KV, TRACE_ADVANCED, OVERRIDE, NETWORK_OPTIM,
+    NETWORK_COORDINATOR,
 });


### PR DESCRIPTION
## Network Change Coordinator 鈥?Fail-Closed Protocol Verification

### Review fixes applied (round 6)

Based on feedback from Qodo and CodeRabbit on PR #1317:

1. **State transition inherits failure exhaustion** (Qodo #1) 鈥?A genuine state change (sampled != last_observed) now resets consecutive_failures to zero, so the new network's first apply failure isn't immediately suppressed by the previous state's accumulated failures.

2. **Deferred backoff delays new transitions** (Qodo #2) 鈥?Real state changes are now exempt from the deferred backoff gate. Previously, a network transition while the core was stopped could be delayed by up to 60 seconds. Now state_changed bypasses the deferred_eligible check entirely.

3. **get_network_state leaks raw SSID to frontend** (CodeRabbit) 鈥?The Tauri command returned the full NetworkState including the raw SSID, bypassing the masking policy used in 
etwork-state-changed events. Now masks the SSID with "***" before returning to the frontend.

4. **Debounce test missing upper bound** (CodeRabbit) 鈥?	est_sliding_debounce_window_delays_execution only asserted >= 280ms, so an implementation that fires at 5 seconds would pass. Added upper bound: 280ms..=340ms.

5. **Barrier test not concurrent** (CodeRabbit) 鈥?#[tokio::test] uses current-thread runtime by default, where two spawn_blocking closures could run sequentially on the same pooled worker. Changed to #[tokio::test(flavor = "multi_thread", worker_threads = 2)] to guarantee concurrent execution with the Barrier(2).

### Previously fixed (rounds 1-5)

- Core-down deferrals: tri-state ApplyOutcome (Applied/Failed/Deferred)
- Deferred exponential backoff with consecutive_deferred counter
- Failure cap: state changes always trigger, retries are capped
- Resume core restart: post-restart Manual notification clears pplied_state
- Windows Ethernet detection: GetAdaptersAddresses API (locale-invariant)
- 	est-util feature in [dev-dependencies]
- 
eeds_reconciliation() pure function shared by code and tests
- 	ry_notify() non-blocking notification
- split_once for Linux nmcli SSID parsing
- Unicode line separator (U+2028/U+2029) filtering
- pply_deferred metric + test assertion
- is_http_success helper for unified 2xx checking

### Not fixed (with justification)

- **hot_reload_success derived from HTTP status** 鈥?Mihomo PUT /configs returns only an HTTP status code, no JSON body ACK. No independent second signal exists.
- **Apply timeout releases single-flight gate** (Qodo #4) 鈥?spawn_blocking tasks cannot be cancelled in Tokio; Prism mutex serializes naturally.
- **	ry_notify drops on full channel** (Qodo #3) 鈥?Channel capacity is 32; resume path cannot fill it.
- **Sync network detection on async runtime** (CodeRabbit) 鈥?Subprocess calls <100ms, every 5s.
- **NotifyAddrChange via windows-sys** (CodeRabbit) 鈥?Current FFI binding works correctly.
- **Cache Ethernet probe** (CodeRabbit) 鈥?Significant refactor; current 5s polling cost is negligible.
- **Timing tests validate copies** (CodeRabbit) 鈥?Would require extracting the actor loop into a testable trait; out of scope.
- **udit.toml expiry** (CodeRabbit) 鈥?Configuration comment, not functional.
- **deny.toml comment** (CodeRabbit) 鈥?Documentation comment.
- **Bearer validation** (CodeRabbit) 鈥?secret is internally generated.
- **Stale port implies running** (Qodo) 鈥?last_port cleared on stop.
- **pply_internal target_state** (Qodo) 鈥?Prism API design; would require Prism changes.