### PR TITLE
fix(ci): gate umask 0022 to Linux-only via env to avoid template-injection in Tauri builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,14 @@ jobs:
         shell: bash
 
       - name: Build Tauri app (Full)
-        run: pnpm --filter @zephyr/desktop tauri build ${{ matrix.args }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          BUILD_ARGS: ${{ matrix.args }}
+        run: |
+          if [[ "$PLATFORM" == ubuntu-* ]]; then umask 0022; fi
+          read -ra BUILD_ARGS_ARRAY <<< "$BUILD_ARGS"
+          pnpm --filter @zephyr/desktop tauri build "${BUILD_ARGS_ARRAY[@]}"
+        shell: bash
 
       - name: Collect Windows Full artifacts
         if: matrix.platform == 'windows-latest'
@@ -328,7 +335,14 @@ jobs:
         shell: bash
 
       - name: Build Tauri app (Lite)
-        run: pnpm --filter @zephyr/desktop tauri build ${{ matrix.args }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          BUILD_ARGS: ${{ matrix.args }}
+        run: |
+          if [[ "$PLATFORM" == ubuntu-* ]]; then umask 0022; fi
+          read -ra BUILD_ARGS_ARRAY <<< "$BUILD_ARGS"
+          pnpm --filter @zephyr/desktop tauri build "${BUILD_ARGS_ARRAY[@]}"
+        shell: bash
 
       - name: Collect Windows Lite artifacts
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
### Summary
Enforces `umask 0022` before invoking `tauri build` on Linux in `.github/workflows/release.yml`.

### Root Cause
Without explicit `umask 0022`, files inside AppDir/SquashFS (notably `AppRun.wrapped`) could be packaged with restrictive permissions (`0770` / `o-rwx`), causing `Permission denied` errors in sandboxed or unprivileged environments such as Firejail (used by AppImageHub / `appimage.github.io` automated CI tests).

### Changes
- Gate `umask 0022` to Linux-only (ubuntu-* platforms) via shell conditional: `if [[ "$PLATFORM" == ubuntu-* ]]; then umask 0022; fi`
- Pass `matrix.platform` and `matrix.args` through step `env` (`PLATFORM`, `BUILD_ARGS`) instead of inline `${{ }}` interpolation 鈥?eliminates actionlint SC2193 and zizmor template-injection warnings.
- This keeps the step unified (no split into Linux/non-Linux steps), avoiding `umask` execution on Windows/macOS where Unix permissions are irrelevant.

### Verification
- `cargo fmt --all -- --check` pass
- `cargo clippy --all-targets -- -D warnings` pass
- YAML validated
- Builds on Linux will produce standard `0755` permissions for binaries and `0644` for data assets.