### PR TITLE
fix(ci): enforce HTTPS protocol, pin action SHAs, and allowlist AGPL action for SonarCloud

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
-          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog
+          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog, pkg:githubactions/vedantmgoyal2009/winget-releaser
 
   # ============================================================
   # Job 6: PR 依赖审查（仅 PR 触发）
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           deny-licenses: GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
-          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog
+          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog, pkg:githubactions/vedantmgoyal2009/winget-releaser
           fail-on-severity: high
 
   # ============================================================

--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -20,10 +20,10 @@ jobs:
           X64_ZIP_URL="https://github.com/Juwan-Hwang/Zephyr/releases/download/${TAG}/Zephyr_x64-portable.zip"
           ARM64_ZIP_URL="https://github.com/Juwan-Hwang/Zephyr/releases/download/${TAG}/Zephyr_arm64-portable.zip"
 
-          curl -sL -o win_x64.zip "$X64_ZIP_URL"
+          curl -fsSL --proto =https --proto-redir =https -o win_x64.zip "$X64_ZIP_URL"
           WIN_X64_SHA=$(sha256sum win_x64.zip | cut -d' ' -f1)
 
-          curl -sL -o win_arm64.zip "$ARM64_ZIP_URL"
+          curl -fsSL --proto =https --proto-redir =https -o win_arm64.zip "$ARM64_ZIP_URL"
           WIN_ARM64_SHA=$(sha256sum win_arm64.zip | cut -d' ' -f1)
 
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Zephyr
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Submit Winget Package Update
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         if: env.WINGET_TOKEN != ''
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN || secrets.GH_PAT || secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes SonarCloud Quality Gate failure (C Security Rating on New Code) and CI failures from dependency review.

### Changes

**update-scoop.yml**
- Changed curl -sL to curl -fsSL --proto =https --proto-redir =https (L23, L26)
  - --proto =https: enforce HTTPS for initial request (SonarCloud S5332)
  - --proto-redir =https: enforce HTTPS for redirect targets (Qodo review feedback)
  - -f: fail on HTTP errors to prevent hashing 404 pages (CodeRabbit review feedback)

**update-winget.yml**
- Pinned actions/checkout@v4 to commit SHA 11bd71901bbe5b1630ceea73d27597364c9af683 (#v4.2.2)
- Pinned vedantmgoyal2009/winget-releaser@v2 to commit SHA 4ffc7888bffd451b357355dc214d43bb9f23917e (#v2)
  - Prevents supply-chain attacks via tag retagging (SonarCloud S7857)

**security.yml**
- Added pkg:githubactions/vedantmgoyal2009/winget-releaser to allow-dependencies-licenses in both dependency-review-action instances
  - winget-releaser uses AGPL-3.0, which is denied by default; this allowlists it explicitly (same pattern as trufflesecurity/trufflehog)

### Review Feedback Addressed
- Qodo: Added --proto-redir =https to constrain redirect protocols
- CodeRabbit: Added -f flag to fail on HTTP errors before computing hashes

### Pattern Consistency
These patterns match existing conventions in release.yml (curl -fsSL --proto =https) and security.yml (SHA-pinned actions).