### PR TITLE
fix(security): resolve code scanning security and code quality alerts

### DIFF
--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -2480,7 +2480,7 @@ mod tests {
         assert_eq!(secret.len(), 32, "secret must be exactly 32 characters");
         assert!(
             secret.chars().all(|c| c.is_ascii_alphanumeric()),
-            "secret must be alphanumeric: {secret}"
+            "secret must be alphanumeric"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/core/crypto.rs
+++ b/apps/desktop/src-tauri/src/core/crypto.rs
@@ -854,10 +854,15 @@ pub mod test_helpers {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::test_helpers::*;
+    use rand::RngExt as _;
+
+    fn random_test_key() -> [u8; 32] {
+        rand::rng().random()
+    }
 
     #[test]
     fn test_encrypt_decrypt_roundtrip() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let plaintext = "Hello, World!";
         let encrypted = obfuscate_with_key(plaintext, &key);
         assert_ne!(encrypted, plaintext);
@@ -867,7 +872,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_empty_string() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let encrypted = obfuscate_with_key("", &key);
         let decrypted = deobfuscate_with_key(&encrypted, &key);
         assert_eq!(decrypted, "");
@@ -875,7 +880,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_long_string() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let plaintext = "a".repeat(10000);
         let encrypted = obfuscate_with_key(&plaintext, &key);
         let decrypted = deobfuscate_with_key(&encrypted, &key);
@@ -884,7 +889,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_unicode() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let plaintext =
             "\u{4f60}\u{597d}\u{4e16}\u{754c} \u{1f30d} \u{3053}\u{3093}\u{306b}\u{3061}\u{306f}";
         let encrypted = obfuscate_with_key(plaintext, &key);
@@ -894,7 +899,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_produces_different_ciphertexts() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let plaintext = "same input";
         let e1 = obfuscate_with_key(plaintext, &key);
         let e2 = obfuscate_with_key(plaintext, &key);
@@ -903,8 +908,8 @@ mod tests {
 
     #[test]
     fn test_decrypt_wrong_key_fails() {
-        let key1 = [1u8; 32];
-        let key2 = [2u8; 32];
+        let key1 = random_test_key();
+        let key2 = random_test_key();
         let plaintext = "secret data";
         let encrypted = obfuscate_with_key(plaintext, &key1);
         let decrypted = deobfuscate_with_key(&encrypted, &key2);
@@ -913,8 +918,8 @@ mod tests {
 
     #[test]
     fn test_decrypt_wrong_key_returns_empty() {
-        let key1 = [1u8; 32];
-        let key2 = [2u8; 32];
+        let key1 = random_test_key();
+        let key2 = random_test_key();
         let plaintext = "secret data";
         let encrypted = obfuscate_with_key(plaintext, &key1);
         let decrypted = deobfuscate_with_key(&encrypted, &key2);
@@ -923,29 +928,40 @@ mod tests {
 
     #[test]
     fn test_decrypt_invalid_base64() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let decrypted = deobfuscate_with_key("not-valid-base64!!!", &key);
         assert_eq!(decrypted, "");
     }
 
     #[test]
     fn test_decrypt_garbage_input() {
-        let key = [0u8; 32];
+        let key = random_test_key();
         let decrypted = deobfuscate_with_key("", &key);
         assert_eq!(decrypted, "");
     }
 
     #[test]
     fn test_derive_key_deterministic() {
-        let k1 = derive_key("test-machine-id");
-        let k2 = derive_key("test-machine-id");
+        let machine_id: String = rand::rng()
+            .sample_iter(rand::distr::Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        let k1 = derive_key(&machine_id);
+        let k2 = derive_key(&machine_id);
         assert_eq!(k1, k2);
     }
 
     #[test]
     fn test_derive_key_different_inputs() {
-        let k1 = derive_key("machine-a");
-        let k2 = derive_key("machine-b");
+        let m1: String = rand::rng()
+            .sample_iter(rand::distr::Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        let m2: String = format!("{m1}_different");
+        let k1 = derive_key(&m1);
+        let k2 = derive_key(&m2);
         assert_ne!(k1, k2);
     }
 
@@ -959,7 +975,12 @@ mod tests {
 
     #[test]
     fn test_derive_key_roundtrip() {
-        let key = derive_key("roundtrip-test");
+        let machine_id: String = rand::rng()
+            .sample_iter(rand::distr::Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        let key = derive_key(&machine_id);
         let plaintext = "derived key integration test";
         let encrypted = obfuscate_with_key(plaintext, &key);
         let decrypted = deobfuscate_with_key(&encrypted, &key);
@@ -969,7 +990,12 @@ mod tests {
     #[test]
     fn test_encrypt_with_derived_key_different_from_zero_key() {
         let zero_key = [0u8; 32];
-        let derived = derive_key("non-zero");
+        let machine_id: String = rand::rng()
+            .sample_iter(rand::distr::Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        let derived = derive_key(&machine_id);
         assert_ne!(zero_key, derived);
     }
 }

--- a/landing.html
+++ b/landing.html
@@ -11,6 +11,7 @@
   <meta name="keywords" content="Zephyr, Mihomo, Clash Meta, Tauri, Rust, 代理客户端, 桌面客户端, 开源, 安全代理, 跨平台, macOS, Windows, Linux, 代理工具, 隐私保护, mihomo gui, clash 替代品" />
   <meta name="author" content="Juwan" />
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+  <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
   <link rel="canonical" href="https://juwan-hwang.github.io/Zephyr/" />
   <link rel="apple-touch-icon" href="./app-icon.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="./app-icon.png" />
@@ -37,7 +38,9 @@
   <meta property="og:site_name" content="Zephyr" />
   <meta property="og:locale" content="zh_CN" />
   <meta property="og:locale:alternate" content="en_US" />
+  <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
   <link rel="alternate" hreflang="zh-CN" href="https://juwan-hwang.github.io/Zephyr/" />
+  <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
   <link rel="alternate" hreflang="en" href="https://juwan-hwang.github.io/Zephyr/?lang=en" />
 
   <!-- Twitter Card -->
@@ -208,6 +211,7 @@
 
   <!-- Preconnect to GitHub (performance hint) -->
   <link rel="preconnect" href="https://github.com" crossorigin />
+  <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
   <link rel="dns-prefetch" href="https://github.com" />
 
   <!-- Fonts -->

--- a/packages/scripts/check-i18n.js
+++ b/packages/scripts/check-i18n.js
@@ -357,6 +357,9 @@ function getRequiredPluralCategories(locale) {
 function resolvePath(root, path) {
     let cur = /** @type {unknown} */ (root);
     for (const part of path.split('.')) {
+        if (part === '__proto__' || part === 'constructor' || part === 'prototype') {
+            return undefined;
+        }
         if (cur && typeof cur === 'object' && Object.hasOwn(cur, part)) {
             cur = cur[part];
         } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   vite: 8.1.4
   brace-expansion: 5.0.9
   ws: 8.21.1
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   undici: 7.29.0
   tar: 7.5.21
 
@@ -2045,8 +2045,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4615,7 +4615,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4796,7 +4796,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ overrides:
   # nanoid 5.x is ESM-only; postcss (and other CommonJS consumers) require
   # the 3.x line.  Pin to latest 3.x to get security patches without
   # breaking CJS compatibility.
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   # undici: CRLF injection (CVE-2026-15157), cookie injection (CVE-2026-16729),
   # cache poisoning (CVE-2026-13697, CVE-2026-14643), response desync
   # (CVE-2026-16728).  Transitive dep of @cyclonedx/cdxgen & cheerio.


### PR DESCRIPTION
## Summary
This pull request addresses open GitHub Code Scanning alerts (CodeQL, Semgrep, and OSSF Scorecard / Dependency alerts) across the repository:

### 1. CodeQL `rust/hard-coded-cryptographic-value` (Alerts #411 – #422)
- **Path**: `apps/desktop/src-tauri/src/core/crypto.rs`
- **Fix**: Replaced static dummy key arrays (`[0u8; 32]`, `[1u8; 32]`, `[2u8; 32]`) and literal seed strings in unit tests with dynamic random keys and randomized seed inputs generated at runtime via `rand::rng().random()`.

### 2. CodeQL `rust/cleartext-logging` (Alert #410)
- **Path**: `apps/desktop/src-tauri/src/core/core_process.rs`
- **Fix**: Removed `{secret}` string interpolation from the assertion error message in `generate_secret_is_32_alphanumeric` test so secrets are never printed in test output.

### 3. Semgrep `html.security.audit.missing-integrity.missing-integrity` (Alerts #406 – #409)
- **Path**: `landing.html`
- **Fix**: Added inline `<!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->` suppression comments for `<link rel="canonical">`, `<link rel="alternate">`, and `<link rel="dns-prefetch">` metadata/prefetch tags which are non-executable subresources.

### 4. Semgrep `javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop` (Alert #390)
- **Path**: `packages/scripts/check-i18n.js`
- **Fix**: Added explicit prototype pollution guards (`__proto__`, `constructor`, `prototype`) in `resolvePath` before traversing dotted property paths.

### 5. Dependency Vulnerability GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (Alert #183)
- **Path**: `pnpm-workspace.yaml`, `pnpm-lock.yaml`
- **Fix**: Upgraded `nanoid@3` override from `3.3.17` to `3.3.18` to patch the infinite loop DoS vulnerability.

### 6. Repository-Level Scorecard Alerts (#323, #325)
- **Note**: Alerts #323 (`BranchProtectionID`) and #325 (`CodeReviewID`) are repository administrative settings managed in GitHub web repo settings (branch protection rules, required PR approvals).

## Verification
- `cargo check --workspace --exclude zephyr-core-ffi` passed.
- `cargo clippy --all-targets -- -D warnings` passed with 0 warnings.
- `cargo fmt --all -- --check` passed.
- `pnpm -r lint` (ESLint) passed with 0 errors.
- `pnpm -r typecheck` (tsc) passed with 0 errors.
- `pnpm check:i18n` passed with 0 errors.
- `pnpm --filter @zephyr/desktop test` passed all 497 tests in 22 test suites.
