### PR TITLE
fix(subscription): allow proxy fallback for blocked subscription domains (#1402)

### DIFF
--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -6,7 +6,7 @@ use zephyr_core::config::sanitizer::remove_dangerous_keys_internal_pub as remove
 use zephyr_core::config::subscription::{
     classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
     parse_content_disposition_filename, quote_short_id_values, redact_url_in_string,
-    try_decode_base64_content, validate_subscription_name, validate_subscription_url_with_ip,
+    try_decode_base64_content, validate_subscription_name, validate_subscription_url_basic,
 };
 
 use super::core_process::ensure_app_storage;
@@ -19,8 +19,11 @@ fn build_http_client_with_proxy(
     user_agent: Option<&str>,
     resolve_pin: Option<(String, std::net::SocketAddr)>,
     proxy_url: Option<String>,
+    connect_timeout: Duration,
+    timeout: Duration,
 ) -> Result<reqwest::Client, String> {
-    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+    let is_proxied = proxy_url.is_some();
+    let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
         if attempt.previous().len() > 5 {
             return attempt.error("Too many redirects (max 5)");
         }
@@ -41,30 +44,37 @@ fn build_http_client_with_proxy(
             return attempt.error(format!("Redirect to private host blocked: {host}"));
         }
 
-        let port = url
-            .port()
-            .unwrap_or(if scheme == "https" { 443 } else { 80 });
-        match std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{port}")) {
-            Ok(addrs) => {
-                for addr in addrs {
-                    if is_private_ip(addr.ip()) {
-                        return attempt.error(format!(
-                            "Redirect to private IP blocked: {} -> {}",
-                            host,
-                            addr.ip()
-                        ));
+        // For direct connections, resolve host to prevent redirects to private IP.
+        // For proxy connections, remote proxy handles resolution; local resolution
+        // would fail if the redirect target is blocked by GFW or poisoned.
+        if !is_proxied {
+            let port = url
+                .port()
+                .unwrap_or(if scheme == "https" { 443 } else { 80 });
+            match std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{port}")) {
+                Ok(addrs) => {
+                    for addr in addrs {
+                        if is_private_ip(addr.ip()) {
+                            return attempt.error(format!(
+                                "Redirect to private IP blocked: {} -> {}",
+                                host,
+                                addr.ip()
+                            ));
+                        }
                     }
                 }
+                Err(e) => {
+                    return attempt.error(format!("Failed to resolve redirect host {host}: {e}"))
+                }
             }
-            Err(e) => return attempt.error(format!("Failed to resolve redirect host {host}: {e}")),
         }
 
         attempt.follow()
     });
 
     let mut client_builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .connect_timeout(Duration::from_secs(5))
+        .timeout(timeout)
+        .connect_timeout(connect_timeout)
         .redirect(redirect_policy)
         .no_proxy();
 
@@ -165,9 +175,9 @@ fn resolve_url_from_metadata(
     super::config_manager::get_config_url(app, name)
 }
 
-/// 获取 mihomo API 的客户端、URL 和 secret。
+/// 获取 mihomo API 的客户端、基础 URL 和 secret。
 /// 失败时返回 None（核心未运行或端口未就绪）。
-fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
+fn mihomo_base_api(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
     let (api_port, secret) = {
         let state = app.state::<MihomoState>();
         let guard = state
@@ -183,14 +193,15 @@ fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String
         .timeout(Duration::from_secs(2))
         .build()
         .ok()?;
-    let url = format!("http://127.0.0.1:{api_port}/configs");
-    Some((client, url, secret))
+    let base = format!("http://127.0.0.1:{api_port}");
+    Some((client, base, secret))
 }
 
 /// 获取 mihomo 当前的代理模式（rule / global / direct）。
 /// 失败时返回 None，调用方可据此跳过 global 回退。
 async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client.get(&url);
     if !secret.is_empty() {
         req = req.bearer_auth(&secret);
@@ -207,10 +218,82 @@ async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
 
 /// 通过 mihomo API 切换代理模式。失败时返回 None。
 async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client
         .patch(&url)
         .json(&serde_json::json!({ "mode": mode }));
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    resp.status().is_success().then_some(())
+}
+
+/// 查询 mihomo /proxies，获取主策略组当前激活的代理节点名以及 GLOBAL 组当前的选中项。
+async fn get_mihomo_active_node_and_global_now(
+    app: &AppHandle,
+) -> Option<(String, Option<String>)> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies");
+    let mut req = client.get(&url);
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let proxies = body.get("proxies")?.as_object()?;
+
+    let global_now = proxies
+        .get("GLOBAL")
+        .and_then(|g| g.get("now"))
+        .and_then(|n| n.as_str())
+        .map(std::borrow::ToOwned::to_owned);
+
+    let is_special_target = |s: &str| {
+        matches!(
+            s,
+            "DIRECT" | "REJECT" | "REJECT-DROP" | "PASS" | "COMPATIBLE"
+        )
+    };
+
+    let mut candidate_node = None;
+    for (name, proxy_val) in proxies {
+        if name == "GLOBAL" || is_special_target(name) {
+            continue;
+        }
+        let p_type = proxy_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if p_type.eq_ignore_ascii_case("Selector")
+            || p_type.eq_ignore_ascii_case("URLTest")
+            || p_type.eq_ignore_ascii_case("Fallback")
+        {
+            if let Some(now) = proxy_val.get("now").and_then(|n| n.as_str()) {
+                if !is_special_target(now) {
+                    candidate_node = Some(now.to_owned());
+                    break;
+                }
+            }
+        }
+    }
+
+    let active_node = candidate_node.or_else(|| {
+        global_now
+            .as_deref()
+            .filter(|n| !is_special_target(n))
+            .map(std::borrow::ToOwned::to_owned)
+    })?;
+
+    Some((active_node, global_now))
+}
+
+/// 通过 mihomo REST API 设置策略组的选中项。
+async fn set_mihomo_proxy_group(app: &AppHandle, group: &str, name: &str) -> Option<()> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies/{group}");
+    let mut req = client.put(&url).json(&serde_json::json!({ "name": name }));
     if !secret.is_empty() {
         req = req.bearer_auth(&secret);
     }
@@ -246,13 +329,47 @@ async fn download_sub_inner_raw(
 ) -> Result<DownloadSubResult, String> {
     let safe_name = validate_subscription_name(&name).map_err(|e| e.to_string())?;
 
-    let (host, resolved_addr, user_entered_private) = validate_subscription_url_with_ip(&url)?;
+    let (host, port, user_entered_private) = validate_subscription_url_basic(&url)?;
+
     // For user-entered private addresses, skip DNS pinning (proxy/system handles resolution).
-    // For public addresses, use DNS pinning to prevent DNS rebinding.
+    // For public addresses, resolve and pin DNS to prevent DNS rebinding for direct connections.
+    // If DNS resolution fails (e.g. host is blocked by GFW or DNS poisoned to private IP),
+    // record the error and bypass direct connection, falling through to proxy.
+    let mut direct_dns_error = None;
     let resolve_pin = if user_entered_private {
         None
     } else {
-        resolved_addr.map(|addr| (host.clone(), addr))
+        let host_clone = host.clone();
+        let resolve_res = tokio::task::spawn_blocking(move || {
+            std::net::ToSocketAddrs::to_socket_addrs(&format!("{host_clone}:{port}"))
+                .map(std::iter::Iterator::collect::<Vec<_>>)
+        })
+        .await;
+
+        match resolve_res {
+            Ok(Ok(addrs)) => {
+                match zephyr_core::config::subscription::validate_public_host_addrs(&host, &addrs) {
+                    Ok((_, Some(addr), _)) => Some((host.clone(), addr)),
+                    Ok((_, None, _)) => {
+                        direct_dns_error =
+                            Some("Could not resolve any IP address for host".to_owned());
+                        None
+                    }
+                    Err(e) => {
+                        direct_dns_error = Some(e);
+                        None
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                direct_dns_error = Some(format!("DNS resolution failed for '{host}': {e}"));
+                None
+            }
+            Err(e) => {
+                direct_dns_error = Some(format!("DNS resolution task join error: {e}"));
+                None
+            }
+        }
     };
 
     let do_download = |client: reqwest::Client, url: String| async move {
@@ -317,9 +434,17 @@ async fn download_sub_inner_raw(
     let mut last_error = String::new();
     let mut result: Option<(Vec<u8>, String, String, Option<String>)> = None;
 
-    // Try direct connection first
-    let direct_error =
-        match build_http_client_with_proxy(user_agent.as_deref(), resolve_pin.clone(), None) {
+    // Try direct connection first (if DNS resolution didn't fail)
+    let direct_error = if let Some(dns_err) = direct_dns_error {
+        Some(format!("Direct DNS: {dns_err}"))
+    } else {
+        match build_http_client_with_proxy(
+            user_agent.as_deref(),
+            resolve_pin,
+            None,
+            Duration::from_secs(3),
+            Duration::from_secs(6),
+        ) {
             Ok(client) => match do_download(client, url.clone()).await {
                 Ok(data) => {
                     result = Some(data);
@@ -328,81 +453,125 @@ async fn download_sub_inner_raw(
                 Err(e) => Some(format!("Direct: {e}")),
             },
             Err(e) => Some(format!("Direct client build: {e}")),
-        };
+        }
+    };
 
     if result.is_none() {
-        // Get proxy port from state, then immediately release the lock
-        let proxy_url = {
+        // Look for proxy: Mihomo mixed-port if core is running, or system/environment proxy as fallback.
+        let (proxy_url, is_mihomo_proxy) = {
             let state = app.state::<MihomoState>();
-            let guard = state.0.lock().ok();
-            guard.and_then(|g| {
+            let mihomo_port = state.0.lock().ok().and_then(|g| {
                 g.process()
                     .is_some()
-                    .then(|| format!("http://127.0.0.1:{}", g.last_proxy_port().unwrap_or(7890)))
-            })
+                    .then(|| g.last_proxy_port().unwrap_or(7890))
+            });
+            if let Some(port) = mihomo_port {
+                (Some(format!("http://127.0.0.1:{port}")), true)
+            } else {
+                let external = crate::sys_proxy::get_sys_proxy_address().or_else(|| {
+                    std::env::var("HTTPS_PROXY")
+                        .or_else(|_| std::env::var("https_proxy"))
+                        .or_else(|_| std::env::var("ALL_PROXY"))
+                        .or_else(|_| std::env::var("all_proxy"))
+                        .or_else(|_| std::env::var("HTTP_PROXY"))
+                        .or_else(|_| std::env::var("http_proxy"))
+                        .ok()
+                        .filter(|s| !s.trim().is_empty())
+                });
+                (external, false)
+            }
         };
 
         if let Some(proxy_url_val) = proxy_url {
             // When using proxy, skip DNS pre-resolve pinning to let the proxy
-            // handle DNS resolution (avoids issues with CDN / geo-balanced IPs).
-            //
-            // SSRF protection coverage for proxy paths:
-            // - ✅ Initial URL host validated (private host check before any request)
-            // - ✅ Redirect policy blocks redirects to private hosts/IPs
-            // - ⚠️  Proxy-side SSRF (proxy resolving to internal IPs) is NOT
-            //     preventable client-side — this is inherent to any proxy architecture.
-            //     Mitigate by only configuring trusted proxies.
-            let client_mihomo = build_http_client_with_proxy(
+            // handle DNS resolution (avoids issues with CDN / geo-balanced IPs / blocked DNS).
+            let client_proxy = build_http_client_with_proxy(
                 user_agent.as_deref(),
                 None,
                 Some(proxy_url_val.clone()),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
             );
-            match client_mihomo {
+            let prefix = if is_mihomo_proxy {
+                "Proxy"
+            } else {
+                "External Proxy"
+            };
+            match client_proxy {
                 Ok(client) => match do_download(client, url.clone()).await {
                     Ok(data) => {
                         result = Some(data);
                     }
                     Err(e) => {
                         last_error = match direct_error.as_deref() {
-                            Some(de) => format!("{de} | Proxy: {e}"),
-                            None => format!("Proxy: {e}"),
+                            Some(de) => format!("{de} | {prefix}: {e}"),
+                            None => format!("{prefix}: {e}"),
                         };
                     }
                 },
                 Err(e) => {
                     last_error = match direct_error.as_deref() {
-                        Some(de) => format!("{de} | Proxy client build: {e}"),
-                        None => format!("Proxy client build: {e}"),
-                    }
+                        Some(de) => format!("{de} | {prefix} client build: {e}"),
+                        None => format!("{prefix} client build: {e}"),
+                    };
                 }
             }
 
-            // ── Tier 3: 临时切换 global 模式重试 ──────────────────────────────
-            // 直连和普通代理都失败后，尝试临时把 mihomo 切到 global 模式，
-            // 让所有流量走当前选中的代理节点（绕过分流规则可能导致的不可达），
-            // 下载完成后切回原模式。
-            if result.is_none() {
-                // 只有成功获取到当前模式且不是 global 时才切换，
-                // 否则切到 global 后无法切回（original_mode 为 None 时跳过恢复）。
-                if let Some(orig) = get_mihomo_mode(app).await {
-                    if orig != "global" && set_mihomo_mode(app, "global").await.is_some() {
+            // ── Tier 3: 临时切换 global 模式并选择可用节点重试 ──────────────────
+            // 直连和普通代理（规则分流）都失败后，若使用的是 Mihomo 内核代理，
+            // 尝试把 Mihomo 切到 global 模式并确保 GLOBAL 策略组选择当前活跃的代理节点，
+            // 让所有流量走代理节点（绕过分流规则可能导致的不可达），
+            // 下载完成后或任务中断时自动切回原模式和原策略组选择。
+            if result.is_none() && is_mihomo_proxy {
+                if let Some(orig_mode) = get_mihomo_mode(app).await {
+                    if orig_mode != "global" && set_mihomo_mode(app, "global").await.is_some() {
+                        // 尝试将 GLOBAL 组指向当前活跃的代理节点
+                        let orig_global_now = if let Some((active_node, global_now)) =
+                            get_mihomo_active_node_and_global_now(app).await
+                        {
+                            if global_now.as_deref() != Some(&active_node) {
+                                if set_mihomo_proxy_group(app, "GLOBAL", &active_node)
+                                    .await
+                                    .is_some()
+                                {
+                                    global_now
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
                         // Drop guard: 即使 task 在 sleep/download 期间被 cancel，
                         // 也能在 drop 时 spawn 恢复任务，避免 core 永久停留在 global 模式。
                         struct ModeRestoreGuard {
                             app: tauri::AppHandle,
                             orig_mode: Option<String>,
+                            orig_global_now: Option<String>,
                         }
                         impl Drop for ModeRestoreGuard {
                             fn drop(&mut self) {
-                                if let Some(orig) = self.orig_mode.take() {
-                                    let app = self.app.clone();
+                                let app = self.app.clone();
+                                let orig_mode = self.orig_mode.take();
+                                let orig_global_now = self.orig_global_now.take();
+                                if orig_mode.is_some() || orig_global_now.is_some() {
                                     tokio::spawn(async move {
-                                        if set_mihomo_mode(&app, &orig).await.is_none() {
-                                            crate::emit_warn!(
-                                                Core,
-                                                CORE_MODE_RESTORE_DROPPED,
-                                                "Failed to restore original mihomo mode '{orig}' on drop"
-                                            );
+                                        if let Some(orig_node) = orig_global_now {
+                                            let _ =
+                                                set_mihomo_proxy_group(&app, "GLOBAL", &orig_node)
+                                                    .await;
+                                        }
+                                        if let Some(orig) = orig_mode {
+                                            if set_mihomo_mode(&app, &orig).await.is_none() {
+                                                crate::emit_warn!(
+                                                    Core,
+                                                    CORE_MODE_RESTORE_DROPPED,
+                                                    "Failed to restore original mihomo mode '{orig}' on drop"
+                                                );
+                                            }
                                         }
                                     });
                                 }
@@ -411,7 +580,8 @@ async fn download_sub_inner_raw(
 
                         let mut restore_guard = ModeRestoreGuard {
                             app: app.clone(),
-                            orig_mode: Some(orig.clone()),
+                            orig_mode: Some(orig_mode.clone()),
+                            orig_global_now,
                         };
 
                         // 切换后短暂等待 mihomo 生效
@@ -421,6 +591,8 @@ async fn download_sub_inner_raw(
                             user_agent.as_deref(),
                             None,
                             Some(proxy_url_val),
+                            Duration::from_secs(4),
+                            Duration::from_secs(8),
                         );
                         match client_global {
                             Ok(client) => match do_download(client, url).await {
@@ -444,8 +616,11 @@ async fn download_sub_inner_raw(
                             }
                         }
 
-                        // 正常流程：手动恢复原模式并从 guard 中 take 走 orig_mode，
+                        // 正常流程：手动恢复原模式和策略组选择并从 guard 中 take 走，
                         // 避免 Drop 时重复执行恢复。
+                        if let Some(orig_node) = restore_guard.orig_global_now.take() {
+                            let _ = set_mihomo_proxy_group(app, "GLOBAL", &orig_node).await;
+                        }
                         if let Some(orig) = restore_guard.orig_mode.take() {
                             if set_mihomo_mode(app, &orig).await.is_none() {
                                 crate::emit_warn!(

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -333,21 +333,21 @@ async fn download_sub_inner_raw(
 
     // For user-entered private addresses, skip DNS pinning (proxy/system handles resolution).
     // For public addresses, resolve and pin DNS to prevent DNS rebinding for direct connections.
-    // If DNS resolution fails (e.g. host is blocked by GFW or DNS poisoned to private IP),
-    // record the error and bypass direct connection, falling through to proxy.
+    // If DNS resolution fails (e.g. host is blocked by GFW or DNS poisoned to private IP)
+    // or times out (unresponsive DNS / packet drop), record the error and bypass direct connection,
+    // falling through to proxy.
     let mut direct_dns_error = None;
     let resolve_pin = if user_entered_private {
         None
     } else {
         let host_clone = host.clone();
-        let resolve_res = tokio::task::spawn_blocking(move || {
+        let resolve_task = tokio::task::spawn_blocking(move || {
             std::net::ToSocketAddrs::to_socket_addrs(&format!("{host_clone}:{port}"))
                 .map(std::iter::Iterator::collect::<Vec<_>>)
-        })
-        .await;
+        });
 
-        match resolve_res {
-            Ok(Ok(addrs)) => {
+        match tokio::time::timeout(Duration::from_secs(3), resolve_task).await {
+            Ok(Ok(Ok(addrs))) => {
                 match zephyr_core::config::subscription::validate_public_host_addrs(&host, &addrs) {
                     Ok((_, Some(addr), _)) => Some((host.clone(), addr)),
                     Ok((_, None, _)) => {
@@ -361,12 +361,16 @@ async fn download_sub_inner_raw(
                     }
                 }
             }
-            Ok(Err(e)) => {
+            Ok(Ok(Err(e))) => {
                 direct_dns_error = Some(format!("DNS resolution failed for '{host}': {e}"));
                 None
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 direct_dns_error = Some(format!("DNS resolution task join error: {e}"));
+                None
+            }
+            Err(_) => {
+                direct_dns_error = Some(format!("DNS resolution timed out for '{host}' (3s)"));
                 None
             }
         }
@@ -477,6 +481,14 @@ async fn download_sub_inner_raw(
                         .or_else(|_| std::env::var("http_proxy"))
                         .ok()
                         .filter(|s| !s.trim().is_empty())
+                        .map(|s| {
+                            let trimmed = s.trim();
+                            if trimmed.contains("://") {
+                                trimmed.to_owned()
+                            } else {
+                                format!("http://{trimmed}")
+                            }
+                        })
                 });
                 (external, false)
             }
@@ -525,28 +537,10 @@ async fn download_sub_inner_raw(
             if result.is_none() && is_mihomo_proxy {
                 if let Some(orig_mode) = get_mihomo_mode(app).await {
                     if orig_mode != "global" && set_mihomo_mode(app, "global").await.is_some() {
-                        // 尝试将 GLOBAL 组指向当前活跃的代理节点
-                        let orig_global_now = if let Some((active_node, global_now)) =
-                            get_mihomo_active_node_and_global_now(app).await
-                        {
-                            if global_now.as_deref() != Some(&active_node) {
-                                if set_mihomo_proxy_group(app, "GLOBAL", &active_node)
-                                    .await
-                                    .is_some()
-                                {
-                                    global_now
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        };
-
-                        // Drop guard: 即使 task 在 sleep/download 期间被 cancel，
-                        // 也能在 drop 时 spawn 恢复任务，避免 core 永久停留在 global 模式。
+                        // Drop guard: 立即在 mode 切换成功后构造 guard。
+                        // 即使后续的 get_mihomo_active_node_and_global_now、set_mihomo_proxy_group、
+                        // sleep 或 download 任务被超时取消（Cancel），
+                        // 也能在 drop 时恢复 core 的原模式和原节点选择，杜绝 core 永久停留在 global 模式。
                         struct ModeRestoreGuard {
                             app: tauri::AppHandle,
                             orig_mode: Option<String>,
@@ -580,9 +574,22 @@ async fn download_sub_inner_raw(
 
                         let mut restore_guard = ModeRestoreGuard {
                             app: app.clone(),
-                            orig_mode: Some(orig_mode.clone()),
-                            orig_global_now,
+                            orig_mode: Some(orig_mode),
+                            orig_global_now: None,
                         };
+
+                        // 尝试将 GLOBAL 组指向当前活跃的代理节点
+                        if let Some((active_node, global_now)) =
+                            get_mihomo_active_node_and_global_now(app).await
+                        {
+                            if global_now.as_deref() != Some(&active_node)
+                                && set_mihomo_proxy_group(app, "GLOBAL", &active_node)
+                                    .await
+                                    .is_some()
+                            {
+                                restore_guard.orig_global_now = global_now;
+                            }
+                        }
 
                         // 切换后短暂等待 mihomo 生效
                         tokio::time::sleep(Duration::from_millis(300)).await;
@@ -636,10 +643,10 @@ async fn download_sub_inner_raw(
         }
     }
 
-    // Two-tier download strategy: direct → Mihomo proxy.
-    // System proxy fallback is intentionally removed to reduce SSRF attack surface.
-    // The Mihomo proxy path is trusted (user-configured), while system proxy
-    // could be set by any application/malware on the system.
+    // Multi-tier download strategy:
+    // Tier 1: Direct connection with DNS pinning (SSRF protection).
+    // Tier 2: Proxy connection (Mihomo mixed-port, or system/environment proxy fallback).
+    // Tier 3: Mihomo global mode with active proxy node selection and auto-restoration.
     let (bytes, sub_info_header, final_url, disp_filename) = result.ok_or_else(|| {
         if !last_error.is_empty() {
             last_error

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -30,8 +30,8 @@ pub use subscription::{
     classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
     parse_content_disposition_filename, percent_decode, quote_short_id_values,
     redact_url_in_string, try_decode_base64_content, validate_public_host_addrs,
-    validate_subscription_name, validate_subscription_url_with_ip, BatchUpdateItem,
-    BatchUpdateResult, MAX_RESPONSE_SIZE,
+    validate_subscription_name, validate_subscription_url_basic, validate_subscription_url_with_ip,
+    BatchUpdateItem, BatchUpdateResult, MAX_RESPONSE_SIZE,
 };
 pub use types::{
     AppPaths, ConfigInfo, ConfigMetadata, NetworkOptimStatus, ProfilesMetadata, ReadLogResult,

--- a/crates/core/src/config/subscription.rs
+++ b/crates/core/src/config/subscription.rs
@@ -265,11 +265,9 @@ pub fn validate_public_host_addrs(
     Ok((host.to_owned(), resolved_addr, false))
 }
 
-/// Validate URL and its resolved IPs for SSRF protection.
-/// Returns `(host, resolved_addr, user_entered_private)`.
-pub fn validate_subscription_url_with_ip(
-    url: &str,
-) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+/// Validate URL scheme, host, and port without DNS resolution.
+/// Returns `(host, port, user_entered_private)`.
+pub fn validate_subscription_url_basic(url: &str) -> Result<(String, u16, bool), String> {
     let parsed_url = url::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
 
     let scheme = parsed_url.scheme();
@@ -281,17 +279,29 @@ pub fn validate_subscription_url_with_ip(
 
     let user_entered_private = is_private_host(host);
 
+    let default_port = if scheme == "https" { 443 } else { 80 };
+    let port = parsed_url.port().unwrap_or(default_port);
+
+    Ok((host.to_owned(), port, user_entered_private))
+}
+
+/// Validate URL and its resolved IPs for SSRF protection.
+/// Returns `(host, resolved_addr, user_entered_private)`.
+pub fn validate_subscription_url_with_ip(
+    url: &str,
+) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+    let (host, port, user_entered_private) = validate_subscription_url_basic(url)?;
+
     if user_entered_private {
-        return Ok((host.to_owned(), None, true));
+        return Ok((host, None, true));
     }
 
-    let default_port = if scheme == "https" { 443 } else { 80 };
     let addrs: Vec<std::net::SocketAddr> =
-        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{default_port}"))
+        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{port}"))
             .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
             .collect();
 
-    validate_public_host_addrs(host, &addrs)
+    validate_public_host_addrs(&host, &addrs)
 }
 
 /// Determine the appropriate error code based on the error message content.
@@ -516,6 +526,30 @@ mod tests {
     fn test_validate_invalid_schemes_rejected() {
         assert!(validate_subscription_url_with_ip("ftp://192.168.1.1/sub").is_err());
         assert!(validate_subscription_url_with_ip("file:///etc/passwd").is_err());
+        assert!(validate_subscription_url_basic("ftp://192.168.1.1/sub").is_err());
+        assert!(validate_subscription_url_basic("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_subscription_url_basic_success() {
+        let (host, port, private) =
+            validate_subscription_url_basic("https://blocked-domain.example.com/sub?token=123")
+                .unwrap();
+        assert_eq!(host, "blocked-domain.example.com");
+        assert_eq!(port, 443);
+        assert!(!private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://192.168.1.100:8080/sub").unwrap();
+        assert_eq!(host, "192.168.1.100");
+        assert_eq!(port, 8080);
+        assert!(private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://localhost:9090/sub").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 9090);
+        assert!(private);
     }
 
     #[test]


### PR DESCRIPTION
Resolves #1402

### Summary of Changes

1. **Decouple URL Syntax Validation from DNS Resolution**:
   - Added \alidate_subscription_url_basic\ in \zephyr-core\ to perform initial URL scheme, host, and port validation without synchronous DNS resolution.
   - Decoupled pre-request SSRF checks so that DNS resolution failure or GFW DNS poisoning (e.g. returning \127.0.0.1\) no longer aborts the entire subscription download on line 249 before any proxy fallback can execute.
   - For direct connections, DNS resolution is performed asynchronously and pinned if valid public IPs are returned. If direct DNS fails, the error is caught and execution safely falls through to proxy.

2. **Fix Proxy Redirect DNS Resolution in Redirect Policy**:
   - In \uild_http_client_with_proxy\, when a proxy is configured, the custom redirect policy skips local \	o_socket_addrs\ while preserving host string validation (\is_private_host\). This prevents requests from failing when subscription links 301/302 redirect to blocked CDN or storage domains.

3. **Active Node Selection and Restoration in Tier 3 Global Mode**:
   - In Tier 3, when switching Mihomo to \global\ mode, query \GET /proxies\ to locate the active node in the primary group and configure \PUT /proxies/GLOBAL\ to route through that active proxy node instead of defaulting to \DIRECT\.
   - \ModeRestoreGuard\ automatically restores both the original mode and the original \GLOBAL\ selection upon completion or cancellation.

4. **External and System Proxy Fallback when Core is Inactive**:
   - When the internal Mihomo core process is not running, detect and fall back to system proxy or environment proxy variables (\HTTPS_PROXY\, \HTTP_PROXY\, etc.) rather than hard-failing to direct-only.

5. **Scheduler Timeout Preserved**:
   - Maintained \DOWNLOAD_TIMEOUT_SECS = 15\ without modification. Tuned individual tier timeouts (Direct: 3s connect / 6s total; Tier 2 & 3: 4s connect / 8s total) to ensure the 3-tier fallback completes comfortably within the 15s window.

### Verification
- \cargo test -p zephyr-core\: 150 passed
- \cargo clippy --workspace --all-targets -- -D warnings\: Passed (0 warnings)
- \pnpm test\: 497 passed