### PR TITLE
fix(subscription): allow proxy fallback for blocked subscription domains

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-reqwest = { version = "0.13", features = ["json", "stream", "gzip", "brotli", "deflate", "blocking"] }
+reqwest = { version = "0.13", features = ["json", "stream", "gzip", "brotli", "deflate", "blocking", "socks"] }
 zip = "8.6"
 flate2 = "1"
 tar = "0.4"

--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -217,6 +217,12 @@ pub mod codes {
     pub const CORE_MODE_RESTORE_DROPPED: u16 = 1010;
     /// Panic was caught by `catch_unwind` in a core operation.
     pub const CORE_PANIC_GUARD: u16 = 1011;
+    /// Mihomo GLOBAL group restore after subscription update failed.
+    pub const CORE_GLOBAL_RESTORE_FAILED: u16 = 1012;
+    /// Mihomo GLOBAL group restore failed in Drop guard (deferred path).
+    pub const CORE_GLOBAL_RESTORE_DROPPED: u16 = 1013;
+    /// Mihomo GLOBAL group switch before subscription update failed.
+    pub const CORE_GLOBAL_SWITCH_FAILED: u16 = 1014;
 
     // Subscription: 2000-2999
     pub const SUB_UPDATE_FAILED: u16 = 2001;

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -6,7 +6,8 @@ use zephyr_core::config::sanitizer::remove_dangerous_keys_internal_pub as remove
 use zephyr_core::config::subscription::{
     classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
     parse_content_disposition_filename, quote_short_id_values, redact_url_in_string,
-    try_decode_base64_content, validate_subscription_name, validate_subscription_url_with_ip,
+    select_global_candidate, try_decode_base64_content, validate_subscription_name,
+    validate_subscription_url_basic,
 };
 
 use super::core_process::ensure_app_storage;
@@ -19,8 +20,10 @@ fn build_http_client_with_proxy(
     user_agent: Option<&str>,
     resolve_pin: Option<(String, std::net::SocketAddr)>,
     proxy_url: Option<String>,
+    connect_timeout: Duration,
+    timeout: Duration,
 ) -> Result<reqwest::Client, String> {
-    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+    let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
         if attempt.previous().len() > 5 {
             return attempt.error("Too many redirects (max 5)");
         }
@@ -41,6 +44,9 @@ fn build_http_client_with_proxy(
             return attempt.error(format!("Redirect to private host blocked: {host}"));
         }
 
+        // Validate resolved IP addresses to block redirects to private IPs (SSRF protection).
+        // Resolution failures are fatal for both direct and proxy connections, ensuring
+        // unresolvable or internal hostnames cannot bypass SSRF validation.
         let port = url
             .port()
             .unwrap_or(if scheme == "https" { 443 } else { 80 });
@@ -56,15 +62,17 @@ fn build_http_client_with_proxy(
                     }
                 }
             }
-            Err(e) => return attempt.error(format!("Failed to resolve redirect host {host}: {e}")),
+            Err(e) => {
+                return attempt.error(format!("Failed to resolve redirect host {host}: {e}"));
+            }
         }
 
         attempt.follow()
     });
 
     let mut client_builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .connect_timeout(Duration::from_secs(5))
+        .timeout(timeout)
+        .connect_timeout(connect_timeout)
         .redirect(redirect_policy)
         .no_proxy();
 
@@ -165,9 +173,9 @@ fn resolve_url_from_metadata(
     super::config_manager::get_config_url(app, name)
 }
 
-/// 获取 mihomo API 的客户端、URL 和 secret。
+/// 获取 mihomo API 的客户端、基础 URL 和 secret。
 /// 失败时返回 None（核心未运行或端口未就绪）。
-fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
+fn mihomo_base_api(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
     let (api_port, secret) = {
         let state = app.state::<MihomoState>();
         let guard = state
@@ -180,17 +188,18 @@ fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String
 
     let client = reqwest::Client::builder()
         .no_proxy()
-        .timeout(Duration::from_secs(2))
+        .timeout(Duration::from_millis(1000))
         .build()
         .ok()?;
-    let url = format!("http://127.0.0.1:{api_port}/configs");
-    Some((client, url, secret))
+    let base = format!("http://127.0.0.1:{api_port}");
+    Some((client, base, secret))
 }
 
 /// 获取 mihomo 当前的代理模式（rule / global / direct）。
 /// 失败时返回 None，调用方可据此跳过 global 回退。
 async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client.get(&url);
     if !secret.is_empty() {
         req = req.bearer_auth(&secret);
@@ -207,7 +216,8 @@ async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
 
 /// 通过 mihomo API 切换代理模式。失败时返回 None。
 async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client
         .patch(&url)
         .json(&serde_json::json!({ "mode": mode }));
@@ -218,10 +228,421 @@ async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
     resp.status().is_success().then_some(())
 }
 
+/// 查询 mihomo /proxies，获取主策略组当前激活的代理节点名以及 GLOBAL 组当前的选中项。
+async fn get_mihomo_active_node_and_global_now(
+    app: &AppHandle,
+) -> Option<(String, Option<String>)> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies");
+    let mut req = client.get(&url);
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let proxies = body.get("proxies")?.as_object()?;
+    select_global_candidate(proxies)
+}
+
+/// 通过 mihomo REST API 设置策略组的选中项。
+async fn set_mihomo_proxy_group(app: &AppHandle, group: &str, name: &str) -> Option<()> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies/{group}");
+    let mut req = client.put(&url).json(&serde_json::json!({ "name": name }));
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    resp.status().is_success().then_some(())
+}
+
+/// 全局互斥锁，确保并发的订阅下载任务在尝试临时切换 Mihomo global 模式时不发生竞态。
+static GLOBAL_MODE_LOCK: std::sync::LazyLock<std::sync::Arc<tokio::sync::Mutex<()>>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::sync::Mutex::new(())));
+
+/// 全局 DNS 信号量，限制并发阻塞式 DNS 解析任务最多为 4 个，防止并发刷新时占满 Tokio 阻塞线程池。
+static DNS_SEMAPHORE: std::sync::LazyLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::sync::Semaphore::new(4)));
+
+/// 缓存的系统代理探测结果项。
+struct SysProxyCacheEntry {
+    cached_at: std::time::Instant,
+    proxy: Option<String>,
+}
+
+/// 系统代理发现互斥锁与缓存，限制全应用同时最多仅有 1 个系统代理发现任务在执行，
+/// 避免并发刷新时累积阻塞 worker 或系统子进程，并缓存最近 5 秒内的探测结果。
+static SYS_PROXY_DISCOVERY_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+static SYS_PROXY_CACHE: std::sync::LazyLock<std::sync::RwLock<Option<SysProxyCacheEntry>>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(None));
+
+async fn get_bounded_sys_proxy_address(timeout_dur: Duration) -> Option<String> {
+    if let Ok(guard) = SYS_PROXY_CACHE.read() {
+        if let Some(entry) = guard.as_ref() {
+            if entry.cached_at.elapsed() < Duration::from_secs(5) {
+                return entry.proxy.clone();
+            }
+        }
+    }
+
+    let _lock = tokio::time::timeout(timeout_dur, SYS_PROXY_DISCOVERY_LOCK.lock())
+        .await
+        .ok()?;
+
+    if let Ok(guard) = SYS_PROXY_CACHE.read() {
+        if let Some(entry) = guard.as_ref() {
+            if entry.cached_at.elapsed() < Duration::from_secs(5) {
+                return entry.proxy.clone();
+            }
+        }
+    }
+
+    let res = tokio::time::timeout(
+        timeout_dur,
+        tokio::task::spawn_blocking(crate::sys_proxy::get_sys_proxy_address),
+    )
+    .await
+    .ok()
+    .and_then(Result::ok)
+    .flatten();
+
+    if let Ok(mut guard) = SYS_PROXY_CACHE.write() {
+        *guard = Some(SysProxyCacheEntry {
+            cached_at: std::time::Instant::now(),
+            proxy: res.clone(),
+        });
+    }
+
+    res
+}
+
+/// 恢复 Mihomo 的原模式和原 GLOBAL 策略组选择。
+/// 支持在 inline 流程中受 deadline 约束，若时间耗尽则提前退出，返回尚未恢复的项，
+/// 由 `ModeRestoreGuard` 的 `Drop` 实现接管在后台异步完成。
+async fn restore_mihomo_state(
+    app: &AppHandle,
+    mut orig_global_now: Option<String>,
+    mut orig_mode: Option<String>,
+    deadline: Option<std::time::Instant>,
+    on_drop: bool,
+) -> (Option<String>, Option<String>) {
+    // 1. 先恢复原模式（如 rule），使用户常规流量立即脱离 global 路由
+    if let Some(orig) = orig_mode.take() {
+        let mut ok = false;
+        for attempt in 0..2 {
+            let call_timeout = if let Some(dl) = deadline {
+                let rem = dl.saturating_duration_since(std::time::Instant::now());
+                if rem < Duration::from_millis(300) {
+                    break;
+                }
+                Duration::from_millis(1000).min(rem)
+            } else {
+                Duration::from_millis(1000)
+            };
+
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+
+            if tokio::time::timeout(call_timeout, set_mihomo_mode(app, &orig))
+                .await
+                .ok()
+                .flatten()
+                .is_some()
+            {
+                ok = true;
+                break;
+            }
+        }
+
+        if ok {
+            orig_mode = None;
+        } else {
+            if on_drop {
+                crate::emit_warn!(
+                    Core,
+                    CORE_MODE_RESTORE_DROPPED,
+                    "Failed to restore original mihomo mode '{orig}' on drop"
+                );
+            } else {
+                crate::emit_warn!(
+                    Core,
+                    CORE_MODE_RESTORE_FAILED,
+                    "Failed to restore original mihomo mode '{orig}'"
+                );
+            }
+            orig_mode = Some(orig);
+        }
+    }
+
+    // 2. 模式恢复后再恢复原 GLOBAL 策略组选择
+    if let Some(orig_node) = orig_global_now.take() {
+        let mut ok = false;
+        for attempt in 0..2 {
+            let call_timeout = if let Some(dl) = deadline {
+                let rem = dl.saturating_duration_since(std::time::Instant::now());
+                if rem < Duration::from_millis(300) {
+                    break;
+                }
+                Duration::from_millis(1000).min(rem)
+            } else {
+                Duration::from_millis(1000)
+            };
+
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+
+            if tokio::time::timeout(
+                call_timeout,
+                set_mihomo_proxy_group(app, "GLOBAL", &orig_node),
+            )
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+            {
+                ok = true;
+                break;
+            }
+        }
+
+        if ok {
+            orig_global_now = None;
+        } else {
+            if on_drop {
+                crate::emit_warn!(
+                    Core,
+                    CORE_GLOBAL_RESTORE_DROPPED,
+                    "Failed to restore original GLOBAL proxy group selection '{orig_node}' on drop"
+                );
+            } else {
+                crate::emit_warn!(
+                    Core,
+                    CORE_GLOBAL_RESTORE_FAILED,
+                    "Failed to restore original GLOBAL proxy group selection '{orig_node}'"
+                );
+            }
+            orig_global_now = Some(orig_node);
+        }
+    }
+
+    (orig_global_now, orig_mode)
+}
+
+/// Drop guard: 在发出 mode 切换前先行构造 guard。
+/// 即使后续的 `set_mihomo_mode`、`get_mihomo_active_node_and_global_now`、
+/// `set_mihomo_proxy_group`、sleep 或 download 任务被超时取消（Cancel），
+/// 也能在 drop 时恢复 core 的原模式和原节点选择，并在恢复执行期间持续持有互斥锁。
+struct ModeRestoreGuard {
+    app: tauri::AppHandle,
+    orig_mode: Option<String>,
+    orig_global_now: Option<String>,
+    lock_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl Drop for ModeRestoreGuard {
+    fn drop(&mut self) {
+        let app = self.app.clone();
+        let orig_mode = self.orig_mode.take();
+        let orig_global_now = self.orig_global_now.take();
+        let lock_guard = self.lock_guard.take();
+        if orig_mode.is_some() || orig_global_now.is_some() {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _held_lock = lock_guard;
+                    restore_mihomo_state(&app, orig_global_now, orig_mode, None, true).await;
+                });
+            } else {
+                drop(lock_guard);
+                crate::emit_warn!(
+                    Core,
+                    CORE_MODE_RESTORE_DROPPED,
+                    "No Tokio runtime available in Drop; mihomo mode '{orig_mode:?}' and GLOBAL selection '{orig_global_now:?}' were not restored"
+                );
+            }
+        }
+    }
+}
+
 #[derive(serde::Serialize)]
 pub struct DownloadSubResult {
     pub name: String,
     pub message: String,
+}
+
+fn append_error(acc: &mut String, msg: &str) {
+    if !acc.is_empty() {
+        acc.push_str(" | ");
+    }
+    acc.push_str(msg);
+}
+
+async fn do_download_stream(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<(Vec<u8>, String, String, Option<String>), String> {
+    let resp = client.get(url).send().await.map_err(|e| {
+        if e.is_timeout() {
+            format!("Request timeout: {e}")
+        } else if e.is_connect() {
+            format!("Connection failed: {e}")
+        } else if e.is_request() {
+            format!("Request error: {e}")
+        } else if e.is_body() {
+            format!("Body error: {e}")
+        } else if e.is_decode() {
+            format!("Decode error: {e}")
+        } else {
+            format!("Network error: {e}")
+        }
+    })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let url_display = super::config_manager::mask_url(resp.url().as_ref());
+        return Err(format!("HTTP {status} from {url_display}"));
+    }
+
+    if let Some(content_length) = resp.content_length() {
+        if usize::try_from(content_length).unwrap_or(0) > MAX_RESPONSE_SIZE {
+            return Err(format!(
+                "Response too large: {content_length} bytes (max {MAX_RESPONSE_SIZE} bytes)"
+            ));
+        }
+    }
+
+    let sub_info_header = resp
+        .headers()
+        .get("subscription-userinfo")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+
+    let final_url = url.to_owned();
+
+    let disp_filename = resp
+        .headers()
+        .get("content-disposition")
+        .and_then(|h| h.to_str().ok())
+        .and_then(parse_content_disposition_filename);
+
+    let bytes = read_response_body(resp).await?;
+
+    Ok((bytes, sub_info_header, final_url, disp_filename))
+}
+
+async fn try_global_mode_tier(
+    app: &AppHandle,
+    m_url: &str,
+    url: &str,
+    user_agent: Option<&str>,
+    total_deadline: std::time::Instant,
+) -> Result<(Vec<u8>, String, String, Option<String>), String> {
+    let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+    if remaining < Duration::from_millis(5000) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    }
+
+    let lock_wait = remaining.min(Duration::from_millis(1500));
+    let lock_guard = tokio::time::timeout(lock_wait, GLOBAL_MODE_LOCK.clone().lock_owned())
+        .await
+        .map_err(|_timeout| "Global-mode: Skipped due to lock contention".to_owned())?;
+
+    let orig_mode = get_mihomo_mode(app)
+        .await
+        .ok_or_else(|| "Global-mode: Failed to get current Mihomo mode".to_owned())?;
+
+    let (active_node, global_now) = get_mihomo_active_node_and_global_now(app)
+        .await
+        .ok_or_else(|| "Global-mode: No eligible proxy node found in GLOBAL group".to_owned())?;
+
+    let need_mode_switch = orig_mode != "global";
+    let need_node_switch = global_now.as_deref() != Some(active_node.as_str());
+
+    if !need_mode_switch && !need_node_switch {
+        return Err("Global-mode: Already in global mode with active node selected".to_owned());
+    }
+
+    // Re-check cumulative deadline before mutating any core state
+    let rem_before_mutate = total_deadline.saturating_duration_since(std::time::Instant::now());
+    if rem_before_mutate < Duration::from_millis(2500) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    }
+
+    let mut restore_guard = ModeRestoreGuard {
+        app: app.clone(),
+        orig_mode: None,
+        orig_global_now: None,
+        lock_guard: Some(lock_guard),
+    };
+
+    if need_node_switch {
+        // 先在原模式下切换 GLOBAL 策略组的目标节点；
+        // 若切换失败，尚未进入 global 模式，用户当前流量不会受到任何影响。
+        restore_guard.orig_global_now = global_now;
+        if set_mihomo_proxy_group(app, "GLOBAL", &active_node)
+            .await
+            .is_none()
+        {
+            crate::emit_warn!(
+                Core,
+                CORE_GLOBAL_SWITCH_FAILED,
+                "Failed to switch GLOBAL proxy group to '{active_node}'"
+            );
+            return Err(format!(
+                "Global-mode: Failed to select node '{active_node}'"
+            ));
+        }
+    }
+
+    if need_mode_switch {
+        restore_guard.orig_mode = Some(orig_mode);
+        if set_mihomo_mode(app, "global").await.is_none() {
+            return Err("Global-mode: Failed to switch Mihomo mode to global".to_owned());
+        }
+    }
+
+    // 切换后短暂等待 mihomo 生效
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let rem_dl = total_deadline.saturating_duration_since(std::time::Instant::now());
+    let (conn_to, req_to) = if rem_dl < Duration::from_millis(800) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    } else {
+        (
+            Duration::from_millis(1500).min(rem_dl),
+            Duration::from_millis(2500).min(rem_dl),
+        )
+    };
+
+    let client =
+        build_http_client_with_proxy(user_agent, None, Some(m_url.to_owned()), conn_to, req_to)
+            .map_err(|e| format!("Global-mode client build: {e}"))?;
+
+    let download_res = do_download_stream(&client, url).await;
+
+    // 正常流程：尝试恢复原模式和策略组选择。
+    // 仅在明确恢复成功后才从 restore_guard 中清除对应字段；
+    // 若恢复请求失败、超时或受 deadline 限制中断，guard 内部保留原值，
+    // Drop 守卫将在后台继续重试恢复，并在恢复期间继续持有互斥锁。
+    let (rem_node, rem_mode) = restore_mihomo_state(
+        app,
+        restore_guard.orig_global_now.take(),
+        restore_guard.orig_mode.take(),
+        Some(total_deadline),
+        false,
+    )
+    .await;
+    restore_guard.orig_global_now = rem_node;
+    restore_guard.orig_mode = rem_mode;
+    drop(restore_guard);
+
+    download_res.map_err(|e| format!("Global-mode: {e}"))
 }
 
 pub(crate) async fn download_sub_inner(
@@ -246,81 +667,133 @@ async fn download_sub_inner_raw(
 ) -> Result<DownloadSubResult, String> {
     let safe_name = validate_subscription_name(&name).map_err(|e| e.to_string())?;
 
-    let (host, resolved_addr, user_entered_private) = validate_subscription_url_with_ip(&url)?;
+    let (host, port, user_entered_private) = validate_subscription_url_basic(&url)?;
+
+    // Outer scheduler timeout is 15s. We set a cumulative internal budget of 11.5s
+    // across all tiers and DNS resolution to guarantee completion, cleanup, YAML parsing,
+    // and transactional file saving before outer scheduler cancellation.
+    let total_deadline = std::time::Instant::now() + Duration::from_millis(11500);
+
     // For user-entered private addresses, skip DNS pinning (proxy/system handles resolution).
-    // For public addresses, use DNS pinning to prevent DNS rebinding.
+    // For public addresses, resolve and pin DNS to prevent DNS rebinding for direct connections.
+    // If DNS resolution fails (e.g. host is blocked by GFW or DNS poisoned to private IP)
+    // or times out (unresponsive DNS / packet drop), record the error and bypass direct connection,
+    // falling through to proxy.
+    let mut direct_dns_error = None;
     let resolve_pin = if user_entered_private {
         None
     } else {
-        resolved_addr.map(|addr| (host.clone(), addr))
+        let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining < Duration::from_millis(1000) {
+            direct_dns_error = Some("Skipped DNS resolution due to deadline exhaustion".to_owned());
+            None
+        } else {
+            let dns_timeout = Duration::from_millis(1500).min(remaining);
+            let host_clone = host.clone();
+            let resolve_future = async {
+                let deadline = tokio::time::Instant::now() + dns_timeout;
+                let permit = tokio::time::timeout_at(deadline, DNS_SEMAPHORE.clone().acquire_owned())
+                    .await
+                    .map_err(|_err| {
+                        format!("DNS resolution timed out waiting for permit for '{host}' ({dns_timeout:?})")
+                    })?
+                    .map_err(|e| e.to_string())?;
+
+                let remaining_dns = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining_dns.is_zero() {
+                    return Err(format!(
+                        "DNS resolution timed out for '{host}' ({dns_timeout:?})"
+                    ));
+                }
+
+                let handle = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    std::net::ToSocketAddrs::to_socket_addrs(&format!("{host_clone}:{port}"))
+                        .map(std::iter::Iterator::collect::<Vec<_>>)
+                });
+                let abort_handle = handle.abort_handle();
+                tokio::select! {
+                    res = handle => match res {
+                        Ok(Ok(addrs)) => Ok(addrs),
+                        Ok(Err(e)) => Err(format!("DNS resolution failed for '{host}': {e}")),
+                        Err(e) => Err(format!("DNS resolution task join error: {e}")),
+                    },
+                    _ = tokio::time::sleep_until(deadline) => {
+                        abort_handle.abort();
+                        Err(format!("DNS resolution timed out for '{host}' ({dns_timeout:?})"))
+                    }
+                }
+            };
+
+            match resolve_future.await {
+                Ok(addrs) => {
+                    match zephyr_core::config::subscription::validate_public_host_addrs(
+                        &host, &addrs,
+                    ) {
+                        Ok((_, Some(addr), _)) => Some((host.clone(), addr)),
+                        Ok((_, None, _)) => {
+                            direct_dns_error =
+                                Some("Could not resolve any IP address for host".to_owned());
+                            None
+                        }
+                        Err(e) => {
+                            // SSRF rejection is a security policy decision, not a transient transport failure.
+                            // Reject immediately instead of retrying through proxy tiers.
+                            return Err(e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    direct_dns_error = Some(e);
+                    None
+                }
+            }
+        }
     };
 
-    let do_download = |client: reqwest::Client, url: String| async move {
-        let resp = client.get(&url).send().await.map_err(|e| {
-            if e.is_timeout() {
-                format!("Request timeout: {e}")
-            } else if e.is_connect() {
-                format!("Connection failed: {e}")
-            } else if e.is_request() {
-                format!("Request error: {e}")
-            } else if e.is_body() {
-                format!("Body error: {e}")
-            } else if e.is_decode() {
-                format!("Decode error: {e}")
-            } else {
-                format!("Network error: {e}")
-            }
-        })?;
+    let has_mihomo = {
+        let state = app.state::<MihomoState>();
+        let guard = state
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.process().is_some()
+    };
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let url_display = super::config_manager::mask_url(resp.url().as_ref());
-            return Err(format!("HTTP {status} from {url_display}"));
+    let get_tier_timeout = |max_total_ms: u64, max_conn_ms: u64| -> Option<(Duration, Duration)> {
+        let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining < Duration::from_millis(800) {
+            return None;
         }
-
-        if let Some(content_length) = resp.content_length() {
-            if usize::try_from(content_length).unwrap_or(0) > MAX_RESPONSE_SIZE {
-                return Err(format!(
-                    "Response too large: {content_length} bytes (max {MAX_RESPONSE_SIZE} bytes)"
-                ));
-            }
-        }
-
-        let sub_info_header = resp
-            .headers()
-            .get("subscription-userinfo")
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("")
-            .to_owned();
-
-        // Use original URL for metadata storage, not profile-web-page-url
-        // profile-web-page-url often points to HTML pages, not the actual subscription endpoint
-        let final_url = url.clone();
-
-        // Try to extract filename from Content-Disposition header
-        let disp_filename = resp
-            .headers()
-            .get("content-disposition")
-            .and_then(|h| h.to_str().ok())
-            .and_then(parse_content_disposition_filename);
-
-        let bytes = read_response_body(resp).await?;
-
-        Ok::<(Vec<u8>, String, String, Option<String>), String>((
-            bytes,
-            sub_info_header,
-            final_url,
-            disp_filename,
-        ))
+        let connect_timeout = Duration::from_millis(max_conn_ms).min(remaining);
+        let request_timeout = Duration::from_millis(max_total_ms).min(remaining);
+        Some((connect_timeout, request_timeout))
     };
 
     let mut last_error = String::new();
     let mut result: Option<(Vec<u8>, String, String, Option<String>)> = None;
 
-    // Try direct connection first
-    let direct_error =
-        match build_http_client_with_proxy(user_agent.as_deref(), resolve_pin.clone(), None) {
-            Ok(client) => match do_download(client, url.clone()).await {
+    // Try direct connection first (if DNS resolution didn't fail)
+    // If Mihomo is running, allow 3500ms for data transfer, with connect timeout capped at 1500ms so
+    // blocked domains fail fast and leave sufficient budget for proxy tiers.
+    // If Mihomo is stopped, allocate up to 8500ms so slow direct servers can complete without failing.
+    let (direct_req_ms, direct_conn_ms) = if has_mihomo {
+        (3500, 1500)
+    } else {
+        (8500, 3000)
+    };
+
+    let direct_error = if let Some(dns_err) = direct_dns_error {
+        Some(format!("Direct DNS: {dns_err}"))
+    } else if let Some((conn_to, req_to)) = get_tier_timeout(direct_req_ms, direct_conn_ms) {
+        match build_http_client_with_proxy(
+            user_agent.as_deref(),
+            resolve_pin,
+            None,
+            conn_to,
+            req_to,
+        ) {
+            Ok(client) => match do_download_stream(&client, &url).await {
                 Ok(data) => {
                     result = Some(data);
                     None
@@ -328,132 +801,158 @@ async fn download_sub_inner_raw(
                 Err(e) => Some(format!("Direct: {e}")),
             },
             Err(e) => Some(format!("Direct client build: {e}")),
-        };
+        }
+    } else {
+        Some("Direct: Skipped due to deadline exhaustion".to_owned())
+    };
 
     if result.is_none() {
-        // Get proxy port from state, then immediately release the lock
-        let proxy_url = {
+        if let Some(de) = direct_error.as_deref() {
+            append_error(&mut last_error, de);
+        }
+
+        // Resolve Mihomo mixed-port proxy and ambient (system / environment) proxy as distinct candidates.
+        let mihomo_proxy_url = {
             let state = app.state::<MihomoState>();
-            let guard = state.0.lock().ok();
-            guard.and_then(|g| {
-                g.process()
-                    .is_some()
-                    .then(|| format!("http://127.0.0.1:{}", g.last_proxy_port().unwrap_or(7890)))
+            let guard = state
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guard.process().is_some().then(|| {
+                format!(
+                    "http://127.0.0.1:{}",
+                    guard.last_proxy_port().unwrap_or(7890)
+                )
             })
         };
 
-        if let Some(proxy_url_val) = proxy_url {
-            // When using proxy, skip DNS pre-resolve pinning to let the proxy
-            // handle DNS resolution (avoids issues with CDN / geo-balanced IPs).
-            //
-            // SSRF protection coverage for proxy paths:
-            // - ✅ Initial URL host validated (private host check before any request)
-            // - ✅ Redirect policy blocks redirects to private hosts/IPs
-            // - ⚠️  Proxy-side SSRF (proxy resolving to internal IPs) is NOT
-            //     preventable client-side — this is inherent to any proxy architecture.
-            //     Mitigate by only configuring trusted proxies.
-            let client_mihomo = build_http_client_with_proxy(
-                user_agent.as_deref(),
-                None,
-                Some(proxy_url_val.clone()),
-            );
-            match client_mihomo {
-                Ok(client) => match do_download(client, url.clone()).await {
+        // ── Tier 2: Mihomo proxy (mixed-port) ──────────────────────────────────
+        if let Some(m_url) = &mihomo_proxy_url {
+            if let Some((conn_to, req_to)) = get_tier_timeout(2500, 1500) {
+                let client_proxy = build_http_client_with_proxy(
+                    user_agent.as_deref(),
+                    None,
+                    Some(m_url.clone()),
+                    conn_to,
+                    req_to,
+                );
+                match client_proxy {
+                    Ok(client) => match do_download_stream(&client, &url).await {
+                        Ok(data) => {
+                            result = Some(data);
+                        }
+                        Err(e) => {
+                            append_error(&mut last_error, &format!("Proxy: {e}"));
+                        }
+                    },
+                    Err(e) => {
+                        append_error(&mut last_error, &format!("Proxy client build: {e}"));
+                    }
+                }
+            } else {
+                append_error(&mut last_error, "Proxy: Skipped due to deadline exhaustion");
+            }
+
+            // ── Tier 3: 临时切换 global 模式并选择可用节点重试 ──────────────────
+            // 直连和普通代理（规则分流）都失败后，若使用的是 Mihomo 内核代理，
+            // 尝试把 Mihomo 切到 global 模式并确保 GLOBAL 策略组选择当前活跃的代理节点，
+            // 让所有流量走代理节点（绕过分流规则可能导致的不可达），
+            // 下载完成后或任务中断时自动切回原模式和原策略组选择。
+            // 使用全局异步互斥锁防止并发下载任务在全局模式切换和还原期间发生竞态。
+            if result.is_none() {
+                match try_global_mode_tier(app, m_url, &url, user_agent.as_deref(), total_deadline)
+                    .await
+                {
                     Ok(data) => {
                         result = Some(data);
                     }
-                    Err(e) => {
-                        last_error = match direct_error.as_deref() {
-                            Some(de) => format!("{de} | Proxy: {e}"),
-                            None => format!("Proxy: {e}"),
-                        };
-                    }
-                },
-                Err(e) => {
-                    last_error = match direct_error.as_deref() {
-                        Some(de) => format!("{de} | Proxy client build: {e}"),
-                        None => format!("Proxy client build: {e}"),
+                    Err(err) => {
+                        append_error(&mut last_error, &err);
                     }
                 }
             }
+        }
 
-            // ── Tier 3: 临时切换 global 模式重试 ──────────────────────────────
-            // 直连和普通代理都失败后，尝试临时把 mihomo 切到 global 模式，
-            // 让所有流量走当前选中的代理节点（绕过分流规则可能导致的不可达），
-            // 下载完成后切回原模式。
-            if result.is_none() {
-                // 只有成功获取到当前模式且不是 global 时才切换，
-                // 否则切到 global 后无法切回（original_mode 为 None 时跳过恢复）。
-                if let Some(orig) = get_mihomo_mode(app).await {
-                    if orig != "global" && set_mihomo_mode(app, "global").await.is_some() {
-                        // Drop guard: 即使 task 在 sleep/download 期间被 cancel，
-                        // 也能在 drop 时 spawn 恢复任务，避免 core 永久停留在 global 模式。
-                        struct ModeRestoreGuard {
-                            app: tauri::AppHandle,
-                            orig_mode: Option<String>,
-                        }
-                        impl Drop for ModeRestoreGuard {
-                            fn drop(&mut self) {
-                                if let Some(orig) = self.orig_mode.take() {
-                                    let app = self.app.clone();
-                                    tokio::spawn(async move {
-                                        if set_mihomo_mode(&app, &orig).await.is_none() {
-                                            crate::emit_warn!(
-                                                Core,
-                                                CORE_MODE_RESTORE_DROPPED,
-                                                "Failed to restore original mihomo mode '{orig}' on drop"
-                                            );
-                                        }
-                                    });
-                                }
-                            }
-                        }
+        // ── Tier 4: 环境代理 / 系统代理回退 ──────────────────────────────────
+        // 若 Mihomo 未启动，或 Mihomo 代理与全局模式均无法拉取订阅，
+        // 则在存在且不与 Mihomo 重复的有效本地回环代理（如系统代理或环境变量代理）时进行最终重试。
+        if result.is_none() {
+            let sub_scheme = url::Url::parse(&url)
+                .ok()
+                .map(|u| u.scheme().to_ascii_lowercase());
+            let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining >= Duration::from_millis(1000) {
+                let sys_proxy_timeout = Duration::from_millis(800).min(remaining);
+                let sys_proxy = get_bounded_sys_proxy_address(sys_proxy_timeout).await;
 
-                        let mut restore_guard = ModeRestoreGuard {
-                            app: app.clone(),
-                            orig_mode: Some(orig.clone()),
+                let ambient_proxy_url = sys_proxy
+                    .as_deref()
+                    .and_then(|raw| {
+                        zephyr_core::config::subscription::validate_ambient_proxy_url_for_scheme(
+                            raw,
+                            sub_scheme.as_deref(),
+                        )
+                    })
+                    .or_else(|| {
+                        let get_valid_env_proxy = |key: &str| {
+                            std::env::var(key).ok().as_deref().and_then(|raw| {
+                                zephyr_core::config::subscription::validate_ambient_proxy_url_for_scheme(
+                                    raw,
+                                    sub_scheme.as_deref(),
+                                )
+                            })
                         };
-
-                        // 切换后短暂等待 mihomo 生效
-                        tokio::time::sleep(Duration::from_millis(300)).await;
-
-                        let client_global = build_http_client_with_proxy(
-                            user_agent.as_deref(),
-                            None,
-                            Some(proxy_url_val),
-                        );
-                        match client_global {
-                            Ok(client) => match do_download(client, url).await {
-                                Ok(data) => {
-                                    result = Some(data);
-                                }
-                                Err(e) => {
-                                    last_error = if last_error.is_empty() {
-                                        format!("Global-mode: {e}")
-                                    } else {
-                                        format!("{last_error} | Global-mode: {e}")
-                                    };
-                                }
-                            },
-                            Err(e) => {
-                                last_error = if last_error.is_empty() {
-                                    format!("Global-mode client build: {e}")
-                                } else {
-                                    format!("{last_error} | Global-mode client build: {e}")
-                                };
-                            }
+                        if sub_scheme.as_deref() == Some("https") {
+                            get_valid_env_proxy("HTTPS_PROXY")
+                                .or_else(|| get_valid_env_proxy("https_proxy"))
+                                .or_else(|| get_valid_env_proxy("ALL_PROXY"))
+                                .or_else(|| get_valid_env_proxy("all_proxy"))
+                                .or_else(|| get_valid_env_proxy("HTTP_PROXY"))
+                                .or_else(|| get_valid_env_proxy("http_proxy"))
+                        } else {
+                            get_valid_env_proxy("HTTP_PROXY")
+                                .or_else(|| get_valid_env_proxy("http_proxy"))
+                                .or_else(|| get_valid_env_proxy("ALL_PROXY"))
+                                .or_else(|| get_valid_env_proxy("all_proxy"))
+                                .or_else(|| get_valid_env_proxy("HTTPS_PROXY"))
+                                .or_else(|| get_valid_env_proxy("https_proxy"))
                         }
+                    });
 
-                        // 正常流程：手动恢复原模式并从 guard 中 take 走 orig_mode，
-                        // 避免 Drop 时重复执行恢复。
-                        if let Some(orig) = restore_guard.orig_mode.take() {
-                            if set_mihomo_mode(app, &orig).await.is_none() {
-                                crate::emit_warn!(
-                                    Core,
-                                    CORE_MODE_RESTORE_FAILED,
-                                    "Failed to restore original mihomo mode '{orig}'"
-                                );
+                if let Some(amb_url) = ambient_proxy_url {
+                    if Some(&amb_url) != mihomo_proxy_url.as_ref() {
+                        if let Some((conn_to, req_to)) = get_tier_timeout(2500, 1500) {
+                            let client_ambient = build_http_client_with_proxy(
+                                user_agent.as_deref(),
+                                None,
+                                Some(amb_url),
+                                conn_to,
+                                req_to,
+                            );
+                            match client_ambient {
+                                Ok(client) => match do_download_stream(&client, &url).await {
+                                    Ok(data) => {
+                                        result = Some(data);
+                                    }
+                                    Err(e) => {
+                                        append_error(
+                                            &mut last_error,
+                                            &format!("Ambient Proxy: {e}"),
+                                        );
+                                    }
+                                },
+                                Err(e) => {
+                                    append_error(
+                                        &mut last_error,
+                                        &format!("Ambient Proxy client build: {e}"),
+                                    );
+                                }
                             }
+                        } else {
+                            append_error(
+                                &mut last_error,
+                                "Ambient Proxy: Skipped due to deadline exhaustion",
+                            );
                         }
                     }
                 }
@@ -461,10 +960,11 @@ async fn download_sub_inner_raw(
         }
     }
 
-    // Two-tier download strategy: direct → Mihomo proxy.
-    // System proxy fallback is intentionally removed to reduce SSRF attack surface.
-    // The Mihomo proxy path is trusted (user-configured), while system proxy
-    // could be set by any application/malware on the system.
+    // Multi-tier download strategy:
+    // Tier 1: Direct connection with DNS pinning (SSRF protection).
+    // Tier 2: Mihomo mixed-port proxy connection.
+    // Tier 3: Mihomo global mode with active proxy node selection and auto-restoration.
+    // Tier 4: Ambient proxy (system / environment proxy fallback).
     let (bytes, sub_info_header, final_url, disp_filename) = result.ok_or_else(|| {
         if !last_error.is_empty() {
             last_error

--- a/apps/desktop/src-tauri/src/sys_proxy.rs
+++ b/apps/desktop/src-tauri/src/sys_proxy.rs
@@ -767,7 +767,7 @@ pub fn get_sys_proxy_address() -> Option<String> {
             if enable == 1 {
                 if let Ok(server) = key.get_value::<String, _>("ProxyServer") {
                     if !server.is_empty() {
-                        if server.contains("://") {
+                        if server.contains("://") || server.contains('=') {
                             return Some(server);
                         }
                         return Some(format!("http://{server}"));
@@ -781,10 +781,11 @@ pub fn get_sys_proxy_address() -> Option<String> {
     {
         let services = get_network_services();
         for service in services {
-            if let Ok(output) = Command::new("networksetup")
-                .args(["-getwebproxy", &service])
-                .output()
-            {
+            let parse_proxy = |proto: &str| -> Option<(String, String)> {
+                let output = Command::new("networksetup")
+                    .args([proto, &service])
+                    .output()
+                    .ok()?;
                 let text = String::from_utf8_lossy(&output.stdout);
                 let mut enabled = false;
                 let mut host = String::new();
@@ -792,18 +793,43 @@ pub fn get_sys_proxy_address() -> Option<String> {
 
                 for line in text.lines() {
                     let trimmed = line.trim();
-                    if trimmed.starts_with("Enabled:") {
-                        enabled = trimmed.contains("Yes");
-                    } else if trimmed.starts_with("Server:") {
-                        host = trimmed.split(':').nth(1).unwrap_or("").trim().to_owned();
-                    } else if trimmed.starts_with("Port:") {
-                        port = trimmed.split(':').nth(1).unwrap_or("").trim().to_owned();
+                    if let Some((key, val)) = trimmed.split_once(':') {
+                        let k = key.trim();
+                        let v = val.trim();
+                        if k.eq_ignore_ascii_case("Enabled") {
+                            enabled = v.contains("Yes");
+                        } else if k.eq_ignore_ascii_case("Server") {
+                            if v.parse::<std::net::Ipv6Addr>().is_ok() {
+                                host = format!("[{v}]");
+                            } else {
+                                host = v.to_owned();
+                            }
+                        } else if k.eq_ignore_ascii_case("Port") {
+                            port = v.to_owned();
+                        }
                     }
                 }
 
                 if enabled && !host.is_empty() && !port.is_empty() {
-                    return Some(format!("http://{host}:{port}"));
+                    Some((host, port))
+                } else {
+                    None
                 }
+            };
+
+            let mut parts = Vec::new();
+            if let Some((h, p)) = parse_proxy("-getwebproxy") {
+                parts.push(format!("http={h}:{p}"));
+            }
+            if let Some((h, p)) = parse_proxy("-getsecurewebproxy") {
+                parts.push(format!("https={h}:{p}"));
+            }
+            if let Some((h, p)) = parse_proxy("-getsocksfirewallproxy") {
+                parts.push(format!("socks={h}:{p}"));
+            }
+
+            if !parts.is_empty() {
+                return Some(parts.join(";"));
             }
         }
         None
@@ -817,28 +843,44 @@ pub fn get_sys_proxy_address() -> Option<String> {
             {
                 let mode = String::from_utf8_lossy(&output.stdout).trim().to_owned();
                 if mode == "'manual'" {
-                    if let Ok(host_output) = Command::new("gsettings")
-                        .args(["get", "org.gnome.system.proxy.http", "host"])
-                        .output()
-                    {
-                        let host = String::from_utf8_lossy(&host_output.stdout)
-                            .trim()
-                            .trim_matches('\'')
-                            .to_owned();
-                        if !host.is_empty() {
-                            if let Ok(port_output) = Command::new("gsettings")
-                                .args(["get", "org.gnome.system.proxy.http", "port"])
-                                .output()
-                            {
-                                let port = String::from_utf8_lossy(&port_output.stdout)
-                                    .trim()
-                                    .trim_matches('\'')
-                                    .to_owned();
-                                if !port.is_empty() {
-                                    return Some(format!("http://{host}:{port}"));
+                    let mut parts = Vec::new();
+                    let mut check_gnome_proxy = |schema: &str, tag: &str| {
+                        if let Ok(host_output) = Command::new("gsettings")
+                            .args(["get", schema, "host"])
+                            .output()
+                        {
+                            let raw_host = String::from_utf8_lossy(&host_output.stdout)
+                                .trim()
+                                .trim_matches('\'')
+                                .to_owned();
+                            if !raw_host.is_empty() {
+                                let host = if raw_host.parse::<std::net::Ipv6Addr>().is_ok() {
+                                    format!("[{raw_host}]")
+                                } else {
+                                    raw_host
+                                };
+                                if let Ok(port_output) = Command::new("gsettings")
+                                    .args(["get", schema, "port"])
+                                    .output()
+                                {
+                                    let port = String::from_utf8_lossy(&port_output.stdout)
+                                        .trim()
+                                        .trim_matches('\'')
+                                        .to_owned();
+                                    if !port.is_empty() && port != "0" {
+                                        parts.push(format!("{tag}={host}:{port}"));
+                                    }
                                 }
                             }
                         }
+                    };
+
+                    check_gnome_proxy("org.gnome.system.proxy.http", "http");
+                    check_gnome_proxy("org.gnome.system.proxy.https", "https");
+                    check_gnome_proxy("org.gnome.system.proxy.socks", "socks");
+
+                    if !parts.is_empty() {
+                        return Some(parts.join(";"));
                     }
                 }
             }
@@ -858,26 +900,46 @@ pub fn get_sys_proxy_address() -> Option<String> {
             {
                 let ptype = String::from_utf8_lossy(&output.stdout).trim().to_owned();
                 if ptype == "1" {
-                    if let Ok(proxy_output) = Command::new(kread_cmd)
-                        .args([
-                            "--file",
-                            "kioslaverc",
-                            "--group",
-                            "Proxy Settings",
-                            "--key",
-                            "httpProxy",
-                        ])
-                        .output()
-                    {
-                        let proxy = String::from_utf8_lossy(&proxy_output.stdout)
-                            .trim()
-                            .to_owned();
-                        if !proxy.is_empty() {
-                            if proxy.starts_with("http://") || proxy.starts_with("https://") {
-                                return Some(proxy);
+                    let mut parts = Vec::new();
+                    let mut check_kde_proxy = |key: &str, tag: &str| {
+                        if let Ok(proxy_output) = Command::new(kread_cmd)
+                            .args([
+                                "--file",
+                                "kioslaverc",
+                                "--group",
+                                "Proxy Settings",
+                                "--key",
+                                key,
+                            ])
+                            .output()
+                        {
+                            let proxy = String::from_utf8_lossy(&proxy_output.stdout)
+                                .trim()
+                                .to_owned();
+                            if !proxy.is_empty() {
+                                let normalized = match proxy.rsplit_once(' ') {
+                                    Some((head, tail))
+                                        if tail.parse::<u16>().is_ok() && !head.is_empty() =>
+                                    {
+                                        format!("{}:{tail}", head.trim_end())
+                                    }
+                                    _ => proxy.to_string(),
+                                };
+                                if normalized.contains('=') {
+                                    parts.push(normalized);
+                                } else {
+                                    parts.push(format!("{tag}={normalized}"));
+                                }
                             }
-                            return Some(format!("http://{proxy}"));
                         }
+                    };
+
+                    check_kde_proxy("httpProxy", "http");
+                    check_kde_proxy("httpsProxy", "https");
+                    check_kde_proxy("socksProxy", "socks");
+
+                    if !parts.is_empty() {
+                        return Some(parts.join(";"));
                     }
                 }
             }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -29,9 +29,9 @@ pub use sanitizer::{
 pub use subscription::{
     classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
     parse_content_disposition_filename, percent_decode, quote_short_id_values,
-    redact_url_in_string, try_decode_base64_content, validate_public_host_addrs,
-    validate_subscription_name, validate_subscription_url_with_ip, BatchUpdateItem,
-    BatchUpdateResult, MAX_RESPONSE_SIZE,
+    redact_url_in_string, try_decode_base64_content, validate_ambient_proxy_url,
+    validate_public_host_addrs, validate_subscription_name, validate_subscription_url_basic,
+    validate_subscription_url_with_ip, BatchUpdateItem, BatchUpdateResult, MAX_RESPONSE_SIZE,
 };
 pub use types::{
     AppPaths, ConfigInfo, ConfigMetadata, NetworkOptimStatus, ProfilesMetadata, ReadLogResult,

--- a/crates/core/src/config/subscription.rs
+++ b/crates/core/src/config/subscription.rs
@@ -220,7 +220,12 @@ pub fn is_private_host(host: &str) -> bool {
         return true;
     }
 
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    let unbracketed = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = unbracketed.parse::<IpAddr>() {
         return is_private_ip(ip);
     }
 
@@ -265,11 +270,9 @@ pub fn validate_public_host_addrs(
     Ok((host.to_owned(), resolved_addr, false))
 }
 
-/// Validate URL and its resolved IPs for SSRF protection.
-/// Returns `(host, resolved_addr, user_entered_private)`.
-pub fn validate_subscription_url_with_ip(
-    url: &str,
-) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+/// Validate URL scheme, host, and port without DNS resolution.
+/// Returns `(host, port, user_entered_private)`.
+pub fn validate_subscription_url_basic(url: &str) -> Result<(String, u16, bool), String> {
     let parsed_url = url::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
 
     let scheme = parsed_url.scheme();
@@ -281,17 +284,158 @@ pub fn validate_subscription_url_with_ip(
 
     let user_entered_private = is_private_host(host);
 
-    if user_entered_private {
-        return Ok((host.to_owned(), None, true));
+    let default_port = if scheme == "https" { 443 } else { 80 };
+    let port = parsed_url.port().unwrap_or(default_port);
+
+    Ok((host.to_owned(), port, user_entered_private))
+}
+
+/// Validate an ambient environment or system proxy URL.
+/// Security: Only permit local loopback proxies (`127.0.0.1` / `localhost` / `::1`)
+/// and reject cleartext credentialed `http://` proxies to prevent SSRF and credential leaks.
+/// Also supports semicolon/whitespace-separated entries and scheme-prefixed entries
+/// commonly found in Windows/macOS/Linux system proxy configurations (e.g. `http=127.0.0.1:7890;https=...`).
+#[must_use]
+pub fn validate_ambient_proxy_url(raw: &str) -> Option<String> {
+    validate_ambient_proxy_url_for_scheme(raw, None)
+}
+
+/// Validate an ambient environment or system proxy URL, selecting candidate matching an optional destination scheme.
+#[must_use]
+pub fn validate_ambient_proxy_url_for_scheme(
+    raw: &str,
+    target_scheme: Option<&str>,
+) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
     }
 
-    let default_port = if scheme == "https" { 443 } else { 80 };
+    struct Candidate {
+        tag: Option<String>,
+        url: String,
+    }
+
+    let mut candidates = Vec::new();
+
+    for segment in trimmed.split([';', ' ', '\n', '\r']) {
+        let mut seg = segment.trim();
+        if seg.is_empty() {
+            continue;
+        }
+
+        // Strip extraneous "http://" or "https://" prefix if followed by a scheme prefix (e.g. "http://http=127.0.0.1:7890")
+        if let Some(rest) = seg
+            .strip_prefix("http://")
+            .or_else(|| seg.strip_prefix("https://"))
+        {
+            if rest.contains('=') {
+                seg = rest;
+            }
+        }
+
+        // Handle potential scheme prefixes like "http=host:port", "https=host:port", "socks=...", "socks5=..."
+        let (tag, default_scheme, inner) = if let Some((prefix, rest)) = seg.split_once('=') {
+            let p_lower = prefix.trim().to_ascii_lowercase();
+            if matches!(p_lower.as_str(), "socks" | "socks5") {
+                (Some("socks".to_owned()), "socks5", rest.trim())
+            } else if p_lower == "socks5h" {
+                (Some("socks".to_owned()), "socks5h", rest.trim())
+            } else if p_lower == "socks4" {
+                (Some("socks".to_owned()), "socks4", rest.trim())
+            } else if p_lower == "socks4a" {
+                (Some("socks".to_owned()), "socks4a", rest.trim())
+            } else if matches!(p_lower.as_str(), "https" | "http" | "all") {
+                let tag = p_lower.clone();
+                (Some(tag), "http", rest.trim())
+            } else {
+                // Unknown protocol key (e.g. "ftp="): not usable as an HTTP/SOCKS proxy.
+                continue;
+            }
+        } else {
+            (None, "http", seg)
+        };
+
+        let candidate = if inner.contains("://") {
+            inner.to_owned()
+        } else {
+            format!("{default_scheme}://{inner}")
+        };
+
+        if let Ok(parsed) = url::Url::parse(&candidate) {
+            if !matches!(
+                parsed.scheme(),
+                "http" | "https" | "socks4" | "socks4a" | "socks5" | "socks5h"
+            ) {
+                continue;
+            }
+            let is_loopback = parsed.host_str().is_some_and(|h| {
+                h.eq_ignore_ascii_case("localhost") || h == "127.0.0.1" || h == "[::1]"
+            });
+            if !is_loopback {
+                continue;
+            }
+            let has_credentials = !parsed.username().is_empty() || parsed.password().is_some();
+            if has_credentials && parsed.scheme() == "http" {
+                continue;
+            }
+            candidates.push(Candidate {
+                tag,
+                url: candidate,
+            });
+        }
+    }
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    if let Some(target) = target_scheme {
+        let t_lower = target.to_ascii_lowercase();
+        // 1. Direct scheme match (e.g. tag == "https" when requesting HTTPS)
+        if let Some(c) = candidates
+            .iter()
+            .find(|c| c.tag.as_deref() == Some(&t_lower))
+        {
+            return Some(c.url.clone());
+        }
+        // 2. "all" match
+        if let Some(c) = candidates.iter().find(|c| c.tag.as_deref() == Some("all")) {
+            return Some(c.url.clone());
+        }
+        // 3. "socks" match
+        if let Some(c) = candidates
+            .iter()
+            .find(|c| c.tag.as_deref() == Some("socks"))
+        {
+            return Some(c.url.clone());
+        }
+        // 4. Unprefixed candidate
+        if let Some(c) = candidates.iter().find(|c| c.tag.is_none()) {
+            return Some(c.url.clone());
+        }
+    }
+
+    candidates.into_iter().next().map(|c| c.url)
+}
+
+/// Validate URL and its resolved IPs for SSRF protection.
+/// Returns `(host, resolved_addr, user_entered_private)`.
+pub fn validate_subscription_url_with_ip(
+    url: &str,
+) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+    let (host, port, user_entered_private) = validate_subscription_url_basic(url)?;
+
+    if user_entered_private {
+        return Ok((host, None, true));
+    }
+
     let addrs: Vec<std::net::SocketAddr> =
-        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{default_port}"))
+        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{port}"))
             .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
             .collect();
 
-    validate_public_host_addrs(host, &addrs)
+    validate_public_host_addrs(&host, &addrs)
 }
 
 /// Determine the appropriate error code based on the error message content.
@@ -422,6 +566,102 @@ pub struct BatchUpdateItem {
     pub name: String,
 }
 
+/// 从 mihomo /proxies 返回的字典中提取全局模式候选节点及当前 GLOBAL 选中项。
+/// 纯函数，便于独立单元测试。
+pub fn select_global_candidate(
+    proxies: &serde_json::Map<String, serde_json::Value>,
+) -> Option<(String, Option<String>)> {
+    let global_obj = proxies.get("GLOBAL");
+    let global_now = global_obj
+        .and_then(|g| g.get("now"))
+        .and_then(|n| n.as_str())
+        .map(std::borrow::ToOwned::to_owned);
+
+    let is_special_target = |s: &str| {
+        matches!(
+            s,
+            "DIRECT" | "REJECT" | "REJECT-DROP" | "PASS" | "COMPATIBLE"
+        )
+    };
+
+    let global_all: Vec<&str> = global_obj
+        .and_then(|g| g.get("all"))
+        .and_then(|a| a.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    // 递归解析候选节点/策略组，确保最终生效的叶子节点不是 DIRECT / REJECT 等特殊目标。
+    // 递归深度限制为 8 层以防止配置中存在循环依赖。
+    let resolves_to_effective_proxy = |start_name: &str| -> bool {
+        let mut curr = start_name;
+        for _ in 0..8 {
+            if is_special_target(curr) {
+                return false;
+            }
+            if let Some(p_obj) = proxies.get(curr) {
+                let p_type = p_obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if p_type.eq_ignore_ascii_case("Selector")
+                    || p_type.eq_ignore_ascii_case("URLTest")
+                    || p_type.eq_ignore_ascii_case("Fallback")
+                {
+                    if let Some(next_now) = p_obj.get("now").and_then(|n| n.as_str()) {
+                        curr = next_now;
+                        continue;
+                    }
+                }
+            }
+            return !is_special_target(curr);
+        }
+        false
+    };
+
+    let is_valid_global_candidate = |s: &str| {
+        (global_all.is_empty() || global_all.contains(&s)) && resolves_to_effective_proxy(s)
+    };
+
+    let active_node = global_now
+        .as_deref()
+        .filter(|n| is_valid_global_candidate(n))
+        .map(std::borrow::ToOwned::to_owned)
+        .or_else(|| {
+            // Priority 1: Check active `now` of common selector/urltest/fallback groups.
+            // If the group's `now` is in GLOBAL.all and resolves to a real proxy, prefer it.
+            // If not, but the group itself is in GLOBAL.all and resolves to a real proxy, use the group name.
+            for (name, proxy_val) in proxies {
+                if name == "GLOBAL" || is_special_target(name) {
+                    continue;
+                }
+                let p_type = proxy_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if p_type.eq_ignore_ascii_case("Selector")
+                    || p_type.eq_ignore_ascii_case("URLTest")
+                    || p_type.eq_ignore_ascii_case("Fallback")
+                {
+                    if let Some(now) = proxy_val.get("now").and_then(|n| n.as_str()) {
+                        if is_valid_global_candidate(now) {
+                            return Some(now.to_owned());
+                        }
+                    }
+                    if is_valid_global_candidate(name) {
+                        return Some(name.clone());
+                    }
+                }
+            }
+
+            // Priority 2: Look through GLOBAL's member list `all` for the first valid candidate.
+            // This ensures the chosen node or group is recognized as a valid GLOBAL member
+            // by Mihomo's PUT /proxies/GLOBAL API and actually routes through an active proxy.
+            for &member_name in &global_all {
+                if is_valid_global_candidate(member_name) {
+                    return Some(member_name.to_owned());
+                }
+            }
+
+            None
+        })?;
+
+    Some((active_node, global_now))
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -456,9 +696,16 @@ mod tests {
         assert!(is_private_host("127.0.0.1"));
         assert!(is_private_host("10.0.0.1"));
         assert!(is_private_host("192.168.1.1"));
+        assert!(is_private_host("172.16.0.1"));
+        assert!(is_private_host("::1"));
+        assert!(is_private_host("[::1]"));
+        assert!(is_private_host("[fd00::1]"));
+        assert!(is_private_host("[fe80::1]"));
         assert!(!is_private_host("my.test"));
         assert!(!is_private_host("example.com"));
+        assert!(!is_private_host("1.1.1.1"));
         assert!(!is_private_host("8.8.8.8"));
+        assert!(!is_private_host("[2606:4700:4700::1111]"));
     }
 
     #[test]
@@ -516,6 +763,184 @@ mod tests {
     fn test_validate_invalid_schemes_rejected() {
         assert!(validate_subscription_url_with_ip("ftp://192.168.1.1/sub").is_err());
         assert!(validate_subscription_url_with_ip("file:///etc/passwd").is_err());
+        assert!(validate_subscription_url_basic("ftp://192.168.1.1/sub").is_err());
+        assert!(validate_subscription_url_basic("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_subscription_url_basic_success() {
+        let (host, port, private) =
+            validate_subscription_url_basic("https://blocked-domain.example.com/sub?token=123")
+                .unwrap();
+        assert_eq!(host, "blocked-domain.example.com");
+        assert_eq!(port, 443);
+        assert!(!private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://192.168.1.100:8080/sub").unwrap();
+        assert_eq!(host, "192.168.1.100");
+        assert_eq!(port, 8080);
+        assert!(private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://localhost:9090/sub").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 9090);
+        assert!(private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://[::1]:8080/sub").unwrap();
+        assert_eq!(host, "[::1]");
+        assert_eq!(port, 8080);
+        assert!(private);
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url() {
+        // Valid loopback proxies
+        assert_eq!(
+            validate_ambient_proxy_url("http://127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://localhost:7890"),
+            Some("http://localhost:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://[::1]:7890"),
+            Some("http://[::1]:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://user:pass@127.0.0.1:1080"),
+            Some("socks5://user:pass@127.0.0.1:1080".to_owned())
+        );
+
+        // Multi-scheme and semicolon-separated (common Windows/GNOME proxy formats)
+        assert_eq!(
+            validate_ambient_proxy_url("http=127.0.0.1:7890;https=127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http=proxy.corp.com:8080;socks=127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks=127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://http=127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+
+        // Disallowed: Non-loopback IP or external host
+        assert_eq!(validate_ambient_proxy_url("http://192.168.1.1:7890"), None);
+        assert_eq!(validate_ambient_proxy_url("http://10.0.0.1:7890"), None);
+        assert_eq!(
+            validate_ambient_proxy_url("http://proxy.example.com:7890"),
+            None
+        );
+
+        // Disallowed: Cleartext credentials over http://
+        assert_eq!(
+            validate_ambient_proxy_url("http://user:pass@127.0.0.1:7890"),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://user@localhost:7890"),
+            None
+        );
+
+        // Disallowed: Unsupported schemes (e.g. ftp://)
+        assert_eq!(validate_ambient_proxy_url("ftp://127.0.0.1:21"), None);
+        assert_eq!(
+            validate_ambient_proxy_url("ftp://127.0.0.1:21;http://127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+
+        // Disallowed: Empty / whitespace
+        assert_eq!(validate_ambient_proxy_url(""), None);
+        assert_eq!(validate_ambient_proxy_url("   "), None);
+
+        // Scheme-specific ambient proxy selection (e.g. Windows protocol-specific ProxyServer)
+        let multi_proxy = "http=127.0.0.1:8080;https=127.0.0.1:8443;socks=127.0.0.1:1080";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, Some("https")),
+            Some("http://127.0.0.1:8443".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, Some("http")),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, None),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
+
+        // Fallback to socks when scheme-specific entry is absent
+        let socks_fallback = "ftp=127.0.0.1:21;socks=127.0.0.1:1080";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(socks_fallback, Some("https")),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_ipv6_loopback() {
+        let ipv6_proxy = "http=[::1]:7890;https=[::1]:7890";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(ipv6_proxy, Some("http")),
+            Some("http://[::1]:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(ipv6_proxy, Some("https")),
+            Some("http://[::1]:7890".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_socks_schemes() {
+        // SOCKS prefix variants (socks4, socks4a, socks5, socks5h)
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks4=127.0.0.1:1080", None),
+            Some("socks4://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks4a=127.0.0.1:1081", None),
+            Some("socks4a://127.0.0.1:1081".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks5=127.0.0.1:1082", None),
+            Some("socks5://127.0.0.1:1082".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks5h=127.0.0.1:1083", None),
+            Some("socks5h://127.0.0.1:1083".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_unknown_prefixes_rejected() {
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("ftp=127.0.0.1:21", None),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("unknown=127.0.0.1:8080", Some("http")),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("ftp=127.0.0.1:21;http=127.0.0.1:8080", None),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
     }
 
     #[test]
@@ -597,5 +1022,124 @@ mod tests {
     #[test]
     fn snapshot_redact_url_in_string_no_url() {
         insta::assert_snapshot!(redact_url_in_string("Just a plain message".to_owned()));
+    }
+
+    #[test]
+    fn test_select_global_candidate_special_targets_only() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["DIRECT", "REJECT", "REJECT-DROP"],
+                "now": "DIRECT"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_select_global_candidate_cycle_resolution() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["GroupA"],
+                "now": "GroupA"
+            },
+            "GroupA": {
+                "type": "Selector",
+                "now": "GroupB"
+            },
+            "GroupB": {
+                "type": "Selector",
+                "now": "GroupA"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_select_global_candidate_nested_selector() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["ProxyGroup"],
+                "now": "ProxyGroup"
+            },
+            "ProxyGroup": {
+                "type": "Selector",
+                "now": "HK-01"
+            },
+            "HK-01": {
+                "type": "Shadowsocks"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("ProxyGroup".to_owned(), Some("ProxyGroup".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_prefers_active_now_if_in_all() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["HK-01", "US-01"],
+                "now": "DIRECT"
+            },
+            "AutoGroup": {
+                "type": "Selector",
+                "now": "US-01"
+            },
+            "HK-01": {
+                "type": "Vmess"
+            },
+            "US-01": {
+                "type": "Vmess"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("US-01".to_owned(), Some("DIRECT".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_fallback_to_global_all_member() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["DIRECT", "JP-01"],
+                "now": "DIRECT"
+            },
+            "JP-01": {
+                "type": "Trojan"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("JP-01".to_owned(), Some("DIRECT".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_empty_global_all() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": [],
+                "now": "DIRECT"
+            },
+            "CustomSelector": {
+                "type": "Selector",
+                "now": "Node-A"
+            },
+            "Node-A": {
+                "type": "Shadowsocks"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("Node-A".to_owned(), Some("DIRECT".to_owned())))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Enhance subscription download resilience by allowing proxy fallback and Mihomo global mode recovery when subscription domains cannot be resolved or downloaded directly.

### Key Changes
- **Graceful Multi-Tier Download Strategy**:
  - **Tier 1 (Direct)**: Performs direct DNS resolution and HTTP download with DNS pinning and SSRF protection. Bounds concurrent blocking DNS lookups with an owned semaphore permit where both permit wait and resolver execution are strictly bounded by a cumulative deadline. Makes SSRF validation rejections fatal immediately to prevent malicious loopback/intranet probing through proxy fallbacks. Uses an adaptive request timeout (allocating up to 8500ms when Mihomo is stopped so slow direct servers can complete, and 3500ms with a 1500ms connect timeout when Mihomo is running so blocked domains fail fast and hand over to proxy fallbacks).
  - **Tier 2 (Mihomo Proxy)**: If direct download or direct DNS fails (e.g. DNS poisoned/blocked by local network), retries using the running Mihomo core's mixed-port proxy.
  - **Tier 3 (Mihomo Global Mode)**: If rule-based proxy routing fails, queries eligible active proxy nodes first. If a valid node is confirmed, updates the `GLOBAL` group node *prior* to switching mode, preventing routing disruption if node selection fails. Temporarily switches Mihomo to `global` mode and routes through the selected node. Recursively resolves group selections to verify that the effective leaf route is a real proxy node rather than a special target (`DIRECT`/`REJECT`). Extracted into a dedicated `try_global_mode_tier` helper for clean auditing and scoped lock lifetimes. Re-checks cumulative deadline headroom before mutating core state to avoid wasted operations. Reserves sufficient time headroom (>= 5000ms) before attempting this tier.
  - **Tier 4 (Ambient Proxy Fallback)**: If Mihomo is not running or fails, lazily discovers loopback ambient proxies via bounded and cached background tasks, selecting candidates matching the subscription URL's scheme (HTTP/HTTPS) with explicit fallback to SOCKS.
- **Pure Node Selection & Unit Testing**:
  - Extracted pure proxy candidate selection logic into `select_global_candidate`, with unit tests covering cycle resolution, only-special targets (`DIRECT`/`REJECT`), empty member lists, nested selectors, and candidate priority ordering.
- **Concurrency Protection & State Synchronization**:
  - Employs an asynchronous global mutex (`GLOBAL_MODE_LOCK`) for the global mode fallback phase, ensuring concurrent subscription downloads (manual, batch, or scheduled) do not race or corrupt core mode and proxy group selections. Records lock contention if timeout occurs.
  - Limits concurrent blocking DNS operations using an `Arc`-backed global semaphore (`DNS_SEMAPHORE`) with owned permits to prevent thread pool exhaustion.
  - Bounded system proxy discovery (`SYS_PROXY_DISCOVERY_LOCK` and `SYS_PROXY_CACHE`): ensures at most one system proxy query runs concurrently across the entire application and caches results for 5 seconds to eliminate repeated OS commands and prevent thread accumulation during concurrent subscription updates.
- **Cancellation-Safe State Restoration & Shared Helper**:
  - Uses `ModeRestoreGuard` constructed and armed before mode or proxy group switching API calls to ensure core mode and proxy node selections are conservatively restored even on task cancellation, timeout, or ambiguous network transport failures.
  - Restores original routing mode (e.g. `rule`) *before* restoring the previous `GLOBAL` group selection in `restore_mihomo_state`, ensuring regular user traffic immediately exits global routing.
  - Checks for an active Tokio runtime (`Handle::try_current()`) before spawning background cleanup in the drop guard, emitting an observable warning if no runtime is available.
  - Deduplicates state restoration and retries across inline and drop paths into a shared async helper (`restore_mihomo_state`).
  - Bounds inline restoration retries by the cumulative deadline; if time is tight, inline restoration safely hands off pending cleanup to the guard's background drop task, ensuring YAML parsing and disk persistence are completed well within the scheduler deadline.
- **Cross-Platform System Proxy Discovery**:
  - Supports multi-scheme and delimiter-separated system proxy formats on Windows, macOS, and Linux (reading enabled HTTP, HTTPS, and SOCKS system proxy configurations), matching the subscription target scheme, correctly mapping `socks`, `socks4`, `socks4a`, `socks5`, and `socks5h` with reqwest SOCKS support enabled, while strictly maintaining loopback-only SSRF constraints and filtering out unsupported schemes or unknown assignment prefixes (e.g. `ftp=...`).
  - Correctly parses macOS network configuration using `split_once(':')` and automatically formats IPv6 loopback addresses in brackets (`[::1]`).
  - Formats Linux GNOME IPv6 proxy hosts in brackets.
  - Normalizes legacy Linux KDE proxy configurations containing space-separated numeric ports into standard colon-separated endpoints.
  - Validates candidate environment variables in precedence order (`HTTPS_PROXY`, `ALL_PROXY`, `HTTP_PROXY`), ensuring invalid candidates are safely skipped in favor of subsequent valid loopback entries.
- **Strict SSRF Hardening**:
  - Strips brackets before IPv6 address parsing in `is_private_host`.
  - Rejects direct connections targeting private/loopback IP ranges and treats SSRF detection as fatal.
  - Enforces redirect target IP validation, treating DNS resolution failures on redirects as fatal for all connections so unresolvable destination hosts cannot bypass SSRF validation.
- **Diagnostics & Error Reporting**:
  - Standardizes error accumulation across all fallback tiers using a shared `append_error` helper.

## Testing & Verification
- `cargo test -p zephyr-core`: Passed (160 unit tests, including IPv6 loopback brackets, multi-scheme ambient proxy validation, unsupported scheme skipping, unknown assignment prefixes, SOCKS schemes, SSRF checks, and candidate selection test matrix).
- `cargo test -p zephyr-core-ffi`: Passed.
- `cargo test --bin Zephyr`: Passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: Passed with zero warnings.
- `cargo fmt --check`: Passed.
- `pnpm test`: Passed (497 frontend tests).
