### PR TITLE
fix(subscription): allow proxy fallback for blocked subscription domains

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-reqwest = { version = "0.13", features = ["json", "stream", "gzip", "brotli", "deflate", "blocking"] }
+reqwest = { version = "0.13", features = ["json", "stream", "gzip", "brotli", "deflate", "blocking", "socks"] }
 zip = "8.6"
 flate2 = "1"
 tar = "0.4"

--- a/apps/desktop/src-tauri/src/backend_event.rs
+++ b/apps/desktop/src-tauri/src/backend_event.rs
@@ -217,6 +217,12 @@ pub mod codes {
     pub const CORE_MODE_RESTORE_DROPPED: u16 = 1010;
     /// Panic was caught by `catch_unwind` in a core operation.
     pub const CORE_PANIC_GUARD: u16 = 1011;
+    /// Mihomo GLOBAL group restore after subscription update failed.
+    pub const CORE_GLOBAL_RESTORE_FAILED: u16 = 1012;
+    /// Mihomo GLOBAL group restore failed in Drop guard (deferred path).
+    pub const CORE_GLOBAL_RESTORE_DROPPED: u16 = 1013;
+    /// Mihomo GLOBAL group switch before subscription update failed.
+    pub const CORE_GLOBAL_SWITCH_FAILED: u16 = 1014;
 
     // Subscription: 2000-2999
     pub const SUB_UPDATE_FAILED: u16 = 2001;

--- a/apps/desktop/src-tauri/src/core/core_process.rs
+++ b/apps/desktop/src-tauri/src/core/core_process.rs
@@ -26,7 +26,7 @@ const HEALTH_CHECK_MAX_RETRIES: u32 = 20;
 const HEALTH_CHECK_INITIAL_INTERVAL_MS: u64 = 50;
 const HEALTH_CHECK_MAX_INTERVAL_MS: u64 = 1000;
 #[cfg(target_os = "macos")]
-use super::tun_manager::{is_tun_mode, restart_core_as_root};
+use super::tun_manager::{is_tun_mode, kill_all_mihomo_as_root, restart_core_as_root};
 use super::{AppPaths, CoreData, CoreStartResult, MihomoState, CORE_STARTING};
 
 #[cfg(target_os = "windows")]
@@ -1491,7 +1491,27 @@ pub async fn start_core_inner(
         // Notify the network coordinator that a fresh core instance was started.
         // The new process has no rules applied, so the coordinator's applied_state
         // is now stale and must be re-evaluated.
+        if let Err(e) = health_check(DEFAULT_API_PORT).await {
+            #[cfg(target_os = "macos")]
+            {
+                let kill_res = tokio::task::spawn_blocking(kill_all_mihomo_as_root).await;
+                if let Ok(Err(err)) = kill_res {
+                    emit_warn!(
+                        Core,
+                        CORE_STOP_FAILED,
+                        "Failed to clean up root mihomo process after health check failure: {err}"
+                    );
+                }
+            }
+            if let Ok(mut lock) =
+                lock_critical(&state.0, BackendModule::Core, codes::CORE_LOCK_FAILED)
+            {
+                clear_stopped_core_state(&mut lock);
+            }
+            return Err(e);
+        }
         notify_core_started(&app).await;
+        let _ = super::subscription::reconcile_global_mode_restore(&app).await;
         return Ok(CoreStartResult {
             secret,
             port: DEFAULT_API_PORT,
@@ -1708,6 +1728,7 @@ pub async fn start_core_inner(
     // `lock` is now out of scope — the MutexGuard is fully dropped before any `.await`.
 
     notify_core_started(&app).await;
+    let _ = super::subscription::reconcile_global_mode_restore(&app).await;
 
     Ok(CoreStartResult {
         secret: resolved_secret,

--- a/apps/desktop/src-tauri/src/core/subscription.rs
+++ b/apps/desktop/src-tauri/src/core/subscription.rs
@@ -6,21 +6,25 @@ use zephyr_core::config::sanitizer::remove_dangerous_keys_internal_pub as remove
 use zephyr_core::config::subscription::{
     classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
     parse_content_disposition_filename, quote_short_id_values, redact_url_in_string,
-    try_decode_base64_content, validate_subscription_name, validate_subscription_url_with_ip,
+    select_global_candidate, try_decode_base64_content, validate_subscription_name,
+    validate_subscription_url_basic,
 };
 
 use super::core_process::ensure_app_storage;
 use super::crypto::{load_metadata, lock_metadata, save_metadata, write_profile_file};
-use super::{MihomoState, MAX_RESPONSE_SIZE};
+use super::{CoreData, MihomoState, MAX_RESPONSE_SIZE};
 #[allow(unused_imports)]
 use crate::emit_warn;
 
 fn build_http_client_with_proxy(
     user_agent: Option<&str>,
-    resolve_pin: Option<(String, std::net::SocketAddr)>,
+    resolve_pin: Option<&(String, std::net::SocketAddr)>,
     proxy_url: Option<String>,
+    connect_timeout: Duration,
+    timeout: Duration,
 ) -> Result<reqwest::Client, String> {
-    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+    let via_proxy = proxy_url.is_some();
+    let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
         if attempt.previous().len() > 5 {
             return attempt.error("Too many redirects (max 5)");
         }
@@ -41,6 +45,10 @@ fn build_http_client_with_proxy(
             return attempt.error(format!("Redirect to private host blocked: {host}"));
         }
 
+        // Validate resolved IP addresses to block redirects to private IPs (SSRF protection).
+        // For direct requests without a proxy, local DNS resolution failure is fatal.
+        // For requests configured with a proxy, the proxy resolves the target remotely,
+        // so local DNS resolution failure is permitted to allow reaching blocked domains.
         let port = url
             .port()
             .unwrap_or(if scheme == "https" { 443 } else { 80 });
@@ -56,15 +64,28 @@ fn build_http_client_with_proxy(
                     }
                 }
             }
-            Err(e) => return attempt.error(format!("Failed to resolve redirect host {host}: {e}")),
+            Err(e) => {
+                let is_same_host = attempt
+                    .previous()
+                    .first()
+                    .and_then(|u| u.host_str())
+                    .is_some_and(|h| h.eq_ignore_ascii_case(&host));
+                // For requests via proxy, local DNS resolution failure is permitted ONLY if
+                // redirecting to the same host as originally requested (e.g. http->https or path redirects
+                // for domains unresolvable locally). Cross-host redirects must resolve to public IPs to prevent
+                // SSRF probing against unresolvable internal hostnames through the proxy.
+                if !via_proxy || !is_same_host {
+                    return attempt.error(format!("Failed to resolve redirect host {host}: {e}"));
+                }
+            }
         }
 
         attempt.follow()
     });
 
     let mut client_builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .connect_timeout(Duration::from_secs(5))
+        .timeout(timeout)
+        .connect_timeout(connect_timeout)
         .redirect(redirect_policy)
         .no_proxy();
 
@@ -75,7 +96,7 @@ fn build_http_client_with_proxy(
     }
 
     if let Some((host, addr)) = resolve_pin {
-        client_builder = client_builder.resolve(&host, addr);
+        client_builder = client_builder.resolve(host, *addr);
     }
 
     // Determine User-Agent: use provided UA, or default to Zephyr
@@ -165,32 +186,44 @@ fn resolve_url_from_metadata(
     super::config_manager::get_config_url(app, name)
 }
 
-/// 获取 mihomo API 的客户端、URL 和 secret。
+/// Check whether the mihomo core is currently active.
+///
+/// In normal mode, `process` is `Some`. In macOS TUN mode, the core is started externally
+/// as root and `process` is `None`, but `started_at` and `last_port` remain active while running.
+#[inline]
+const fn is_core_running_from_guard(guard: &CoreData) -> bool {
+    guard.started_at().is_some() && (guard.process().is_some() || guard.last_port().is_some())
+}
+
+/// 获取 mihomo API 的客户端、基础 URL 和 secret。
 /// 失败时返回 None（核心未运行或端口未就绪）。
-fn mihomo_api_client(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
+fn mihomo_base_api(app: &AppHandle) -> Option<(reqwest::Client, String, String)> {
     let (api_port, secret) = {
         let state = app.state::<MihomoState>();
         let guard = state
             .0
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        guard.process()?;
+        if !is_core_running_from_guard(&guard) {
+            return None;
+        }
         (guard.last_port()?, guard.last_secret().to_owned())
     };
 
     let client = reqwest::Client::builder()
         .no_proxy()
-        .timeout(Duration::from_secs(2))
+        .timeout(Duration::from_millis(1000))
         .build()
         .ok()?;
-    let url = format!("http://127.0.0.1:{api_port}/configs");
-    Some((client, url, secret))
+    let base = format!("http://127.0.0.1:{api_port}");
+    Some((client, base, secret))
 }
 
 /// 获取 mihomo 当前的代理模式（rule / global / direct）。
 /// 失败时返回 None，调用方可据此跳过 global 回退。
 async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client.get(&url);
     if !secret.is_empty() {
         req = req.bearer_auth(&secret);
@@ -207,7 +240,8 @@ async fn get_mihomo_mode(app: &AppHandle) -> Option<String> {
 
 /// 通过 mihomo API 切换代理模式。失败时返回 None。
 async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
-    let (client, url, secret) = mihomo_api_client(app)?;
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/configs");
     let mut req = client
         .patch(&url)
         .json(&serde_json::json!({ "mode": mode }));
@@ -218,10 +252,714 @@ async fn set_mihomo_mode(app: &AppHandle, mode: &str) -> Option<()> {
     resp.status().is_success().then_some(())
 }
 
+/// 查询 mihomo /proxies，获取主策略组当前激活的代理节点名以及 GLOBAL 组当前的选中项。
+async fn get_mihomo_active_node_and_global_now(
+    app: &AppHandle,
+) -> Option<(String, Option<String>)> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies");
+    let mut req = client.get(&url);
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let proxies = body.get("proxies")?.as_object()?;
+    select_global_candidate(proxies)
+}
+
+/// 通过 mihomo REST API 设置策略组的选中项。
+async fn set_mihomo_proxy_group(app: &AppHandle, group: &str, name: &str) -> Option<()> {
+    let (client, base, secret) = mihomo_base_api(app)?;
+    let url = format!("{base}/proxies/{group}");
+    let mut req = client.put(&url).json(&serde_json::json!({ "name": name }));
+    if !secret.is_empty() {
+        req = req.bearer_auth(&secret);
+    }
+    let resp = req.send().await.ok()?;
+    resp.status().is_success().then_some(())
+}
+
+/// 全局互斥锁，确保并发的订阅下载任务在尝试临时切换 Mihomo global 模式时不发生竞态。
+static GLOBAL_MODE_LOCK: std::sync::LazyLock<std::sync::Arc<tokio::sync::Mutex<()>>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::sync::Mutex::new(())));
+
+/// 全局 DNS 信号量，限制并发阻塞式 DNS 解析任务最多为 8 个，防止并发刷新时占满 Tokio 阻塞线程池。
+static DNS_SEMAPHORE: std::sync::LazyLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::sync::Semaphore::new(8)));
+
+/// 缓存的系统代理探测结果项。
+struct SysProxyCacheEntry {
+    cached_at: std::time::Instant,
+    proxy: Option<String>,
+}
+
+/// 系统代理发现互斥锁与缓存，限制全应用同时最多仅有 1 个系统代理发现任务在执行，
+/// 避免并发刷新时累积阻塞 worker 或系统子进程，并缓存最近 5 秒内的探测结果。
+static SYS_PROXY_DISCOVERY_LOCK: std::sync::LazyLock<std::sync::Arc<tokio::sync::Mutex<()>>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::sync::Mutex::new(())));
+static SYS_PROXY_CACHE: std::sync::LazyLock<std::sync::RwLock<Option<SysProxyCacheEntry>>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(None));
+
+async fn get_bounded_sys_proxy_address(timeout_dur: Duration) -> Option<String> {
+    let overall_deadline = std::time::Instant::now() + timeout_dur;
+
+    let rem_lock = overall_deadline.saturating_duration_since(std::time::Instant::now());
+    if rem_lock.is_zero() {
+        return None;
+    }
+
+    let lock_guard = tokio::time::timeout(rem_lock, SYS_PROXY_DISCOVERY_LOCK.clone().lock_owned())
+        .await
+        .ok()?;
+
+    if let Ok(guard) = SYS_PROXY_CACHE.read() {
+        if let Some(entry) = guard.as_ref() {
+            if entry.cached_at.elapsed() < Duration::from_secs(5) {
+                return entry.proxy.clone();
+            }
+        }
+    }
+
+    let rem_task = overall_deadline.saturating_duration_since(std::time::Instant::now());
+    if rem_task.is_zero() {
+        return None;
+    }
+
+    let handle = tokio::task::spawn_blocking(move || {
+        let _held_lock = lock_guard;
+        let res = crate::sys_proxy::get_sys_proxy_address_with_deadline(overall_deadline);
+        if let Ok(mut guard) = SYS_PROXY_CACHE.write() {
+            *guard = Some(SysProxyCacheEntry {
+                cached_at: std::time::Instant::now(),
+                proxy: res.clone(),
+            });
+        }
+        res
+    });
+
+    tokio::time::timeout(rem_task, handle)
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .flatten()
+}
+
+/// 执行单项 Mihomo 状态恢复的重试逻辑。
+/// 返回 (是否成功, 是否因时间不足且未尝试而 defer 给 drop guard)。
+async fn retry_restore_step<F, Fut>(
+    deadline: Option<std::time::Instant>,
+    mut action: F,
+) -> (bool, bool)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<()>>,
+{
+    let mut ok = false;
+    let mut deferred = false;
+    for attempt in 0..2 {
+        let call_timeout = if let Some(dl) = deadline {
+            let rem = dl.saturating_duration_since(std::time::Instant::now());
+            if rem < Duration::from_millis(300) {
+                if attempt == 0 {
+                    deferred = true;
+                }
+                break;
+            }
+            Duration::from_millis(1000).min(rem)
+        } else {
+            Duration::from_millis(1000)
+        };
+
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        if tokio::time::timeout(call_timeout, action())
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            ok = true;
+            break;
+        }
+    }
+    (ok, deferred)
+}
+
+/// 恢复 Mihomo 的原模式和原 GLOBAL 策略组选择。
+/// 支持在 inline 流程中受 deadline 约束，若时间耗尽则提前退出，由 `ModeRestoreGuard` 的 `Drop` 实现接管在后台异步完成。
+async fn restore_mihomo_state(
+    app: &AppHandle,
+    orig_global_now: &mut Option<String>,
+    orig_mode: &mut Option<String>,
+    deadline: Option<std::time::Instant>,
+    on_drop: bool,
+    core_started_at: Option<std::time::Instant>,
+) {
+    let check_core_alive = || -> bool {
+        if let Some(expected_started_at) = core_started_at {
+            let state = app.state::<MihomoState>();
+            let guard = state
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if guard.started_at() != Some(expected_started_at) {
+                return false;
+            }
+        }
+        true
+    };
+
+    if !check_core_alive() {
+        let _ = remove_global_mode_restore_marker(app);
+        *orig_mode = None;
+        *orig_global_now = None;
+        return;
+    }
+
+    if mihomo_base_api(app).is_none() {
+        return;
+    }
+
+    // 1. 先恢复原模式（如 rule），使用户常规流量立即脱离 global 路由
+    if let Some(orig) = orig_mode.as_deref() {
+        let (ok, deferred) = retry_restore_step(deadline, || async {
+            if !check_core_alive() {
+                return None;
+            }
+            set_mihomo_mode(app, orig).await
+        })
+        .await;
+
+        if !check_core_alive() {
+            let _ = remove_global_mode_restore_marker(app);
+            *orig_mode = None;
+            *orig_global_now = None;
+            return;
+        }
+
+        if ok {
+            *orig_mode = None;
+        } else if on_drop {
+            crate::emit_warn!(
+                Core,
+                CORE_MODE_RESTORE_DROPPED,
+                "Failed to restore original mihomo mode '{orig}' on drop"
+            );
+        } else if !deferred {
+            crate::emit_warn!(
+                Core,
+                CORE_MODE_RESTORE_FAILED,
+                "Failed to restore original mihomo mode '{orig}'"
+            );
+        }
+    }
+
+    // 2. 模式恢复成功后再恢复原 GLOBAL 策略组选择。
+    // 注意：若模式恢复未成功（仍停留在 global 模式），则跳过节点恢复，
+    // 避免在 global 模式下将节点切换回原节点（如 DIRECT）导致流量直接直连泄露。
+    if orig_mode.is_none() {
+        if let Some(orig_node) = orig_global_now.as_deref() {
+            if !check_core_alive() {
+                let _ = remove_global_mode_restore_marker(app);
+                *orig_mode = None;
+                *orig_global_now = None;
+                return;
+            }
+
+            let (ok, deferred) = retry_restore_step(deadline, || async {
+                if !check_core_alive() {
+                    return None;
+                }
+                set_mihomo_proxy_group(app, "GLOBAL", orig_node).await
+            })
+            .await;
+
+            if !check_core_alive() {
+                let _ = remove_global_mode_restore_marker(app);
+                *orig_mode = None;
+                *orig_global_now = None;
+                return;
+            }
+
+            if ok {
+                *orig_global_now = None;
+            } else if on_drop {
+                crate::emit_warn!(
+                    Core,
+                    CORE_GLOBAL_RESTORE_DROPPED,
+                    "Failed to restore original GLOBAL proxy group selection '{orig_node}' on drop"
+                );
+            } else if !deferred {
+                crate::emit_warn!(
+                    Core,
+                    CORE_GLOBAL_RESTORE_FAILED,
+                    "Failed to restore original GLOBAL proxy group selection '{orig_node}'"
+                );
+            }
+        }
+    }
+
+    // 3. 同步更新或移除持久化恢复标记
+    if orig_mode.is_none() && orig_global_now.is_none() {
+        let _ = remove_global_mode_restore_marker(app);
+    } else {
+        let _ =
+            write_global_mode_restore_marker(app, orig_mode.as_deref(), orig_global_now.as_deref());
+    }
+}
+
+/// Name of the global-mode restore marker file (stored in app data dir).
+const GLOBAL_MODE_RESTORE_FILE: &str = ".subscription-global-restore";
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct GlobalModeRestoreMarker {
+    pub orig_mode: Option<String>,
+    pub orig_global_now: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_config: Option<String>,
+}
+
+#[must_use]
+pub fn global_mode_restore_path(app: &AppHandle) -> Option<std::path::PathBuf> {
+    super::resolve_app_paths(app)
+        .ok()
+        .map(|p| p.app_data_dir.join(GLOBAL_MODE_RESTORE_FILE))
+}
+
+pub fn write_global_mode_restore_marker(
+    app: &AppHandle,
+    orig_mode: Option<&str>,
+    orig_global_now: Option<&str>,
+) -> Result<(), String> {
+    if orig_mode.is_none() && orig_global_now.is_none() {
+        let _ = remove_global_mode_restore_marker(app);
+        return Ok(());
+    }
+    let path = global_mode_restore_path(app)
+        .ok_or_else(|| "Failed to resolve app data path for restore marker".to_owned())?;
+    let active_config = app.try_state::<MihomoState>().and_then(|state| {
+        state
+            .0
+            .lock()
+            .ok()
+            .and_then(|guard| guard.last_config_path().map(str::to_owned))
+    });
+    let marker = GlobalModeRestoreMarker {
+        orig_mode: orig_mode.map(str::to_owned),
+        orig_global_now: orig_global_now.map(str::to_owned),
+        active_config,
+    };
+    let data = serde_json::to_string(&marker)
+        .map_err(|e| format!("Failed to serialize restore marker: {e}"))?;
+    let tmp_path = path.with_extension("tmp");
+    let persisted = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        std::io::Write::write_all(&mut file, data.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        #[cfg(windows)]
+        if path.exists() {
+            let _ = std::fs::remove_file(&path);
+        }
+        std::fs::rename(&tmp_path, &path)?;
+        #[cfg(unix)]
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    })();
+    if let Err(e) = persisted {
+        let _ = std::fs::remove_file(&tmp_path);
+        crate::emit_warn!(
+            Core,
+            CORE_MODE_RESTORE_FAILED,
+            "Failed to persist mihomo restore marker: {e}"
+        );
+        return Err(e.to_string());
+    }
+    Ok(())
+}
+
+pub fn remove_global_mode_restore_marker(app: &AppHandle) -> Result<(), String> {
+    if let Some(path) = global_mode_restore_path(app) {
+        if path.exists() {
+            if let Err(e) = std::fs::remove_file(&path) {
+                let _ = std::fs::write(&path, b"");
+                crate::emit_warn!(
+                    Core,
+                    CORE_MODE_RESTORE_FAILED,
+                    "Failed to remove mihomo restore marker at {}: {e}",
+                    path.display()
+                );
+                return Err(e.to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[must_use]
+pub fn read_global_mode_restore_marker(app: &AppHandle) -> Option<GlobalModeRestoreMarker> {
+    let path = global_mode_restore_path(app)?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    if data.trim().is_empty() {
+        let _ = std::fs::remove_file(path);
+        return None;
+    }
+    let marker: GlobalModeRestoreMarker = serde_json::from_str(&data).ok()?;
+    if marker.orig_mode.is_none() && marker.orig_global_now.is_none() {
+        let _ = std::fs::remove_file(path);
+        return None;
+    }
+    Some(marker)
+}
+
+/// Reconcile and restore any un-restored global mode / GLOBAL selection marker left by an abrupt termination.
+/// Returns `true` if reconciliation finished or was not needed, and `false` if acquiring `GLOBAL_MODE_LOCK` timed out.
+pub async fn reconcile_global_mode_restore(app: &AppHandle) -> bool {
+    if mihomo_base_api(app).is_none() {
+        return true;
+    }
+
+    let Ok(lock_guard) = tokio::time::timeout(
+        Duration::from_secs(5),
+        GLOBAL_MODE_LOCK.clone().lock_owned(),
+    )
+    .await
+    else {
+        return false;
+    };
+
+    let Some(marker) = read_global_mode_restore_marker(app) else {
+        return true;
+    };
+
+    let mut orig_mode = marker.orig_mode;
+    let mut orig_global_now = marker.orig_global_now;
+
+    if let Some(marker_cfg) = marker.active_config {
+        let current_cfg = app.try_state::<MihomoState>().and_then(|state| {
+            state
+                .0
+                .lock()
+                .ok()
+                .and_then(|guard| guard.last_config_path().map(str::to_owned))
+        });
+        if let Some(curr) = current_cfg {
+            if curr != marker_cfg {
+                // Active profile changed across restart or core start;
+                // do not restore proxy group selection from a different profile.
+                orig_global_now = None;
+            }
+        }
+    }
+
+    let configured_mode = app.try_state::<crate::SettingsState>().and_then(|st| {
+        let s = st.0.lock().ok()?;
+        s.mode.clone()
+    });
+    if let Some(cfg_mode) = configured_mode {
+        if orig_mode.as_ref().is_some_and(|m| m != &cfg_mode) {
+            // The user changed the configured mode after the marker was written.
+            // Drop the stale mode restore, but still restore the GLOBAL selection.
+            orig_mode = None;
+        }
+    }
+
+    if orig_mode.is_none() && orig_global_now.is_none() {
+        let _ = remove_global_mode_restore_marker(app);
+        drop(lock_guard);
+        return true;
+    }
+
+    restore_mihomo_state(app, &mut orig_global_now, &mut orig_mode, None, false, None).await;
+
+    drop(lock_guard);
+    true
+}
+
+/// Drop guard: 在发出 mode 切换前先行构造 guard。
+/// 即使后续的 `set_mihomo_mode`、`get_mihomo_active_node_and_global_now`、
+/// `set_mihomo_proxy_group`、sleep 或 download 任务被超时取消（Cancel），
+/// 也能在 drop 时恢复 core 的原模式和原节点选择，并在恢复执行期间持续持有互斥锁。
+struct ModeRestoreGuard {
+    app: tauri::AppHandle,
+    orig_mode: Option<String>,
+    orig_global_now: Option<String>,
+    lock_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    core_started_at: Option<std::time::Instant>,
+}
+
+impl Drop for ModeRestoreGuard {
+    fn drop(&mut self) {
+        let app = self.app.clone();
+        let mut orig_mode = self.orig_mode.take();
+        let mut orig_global_now = self.orig_global_now.take();
+        let lock_guard = self.lock_guard.take();
+        let core_started_at = self.core_started_at;
+        if orig_mode.is_some() || orig_global_now.is_some() {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _held_lock = lock_guard;
+                    restore_mihomo_state(
+                        &app,
+                        &mut orig_global_now,
+                        &mut orig_mode,
+                        None,
+                        true,
+                        core_started_at,
+                    )
+                    .await;
+                });
+            } else {
+                drop(lock_guard);
+                crate::emit_warn!(
+                    Core,
+                    CORE_MODE_RESTORE_DROPPED,
+                    "No Tokio runtime available in Drop; mihomo mode '{orig_mode:?}' and GLOBAL selection '{orig_global_now:?}' were not restored"
+                );
+            }
+        }
+    }
+}
+
 #[derive(serde::Serialize)]
 pub struct DownloadSubResult {
     pub name: String,
     pub message: String,
+}
+
+fn append_error(acc: &mut String, msg: &str) {
+    if !acc.is_empty() {
+        acc.push_str(" | ");
+    }
+    acc.push_str(msg);
+}
+
+async fn do_download_stream(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<(Vec<u8>, String, String, Option<String>), String> {
+    let resp = client.get(url).send().await.map_err(|e| {
+        if e.is_timeout() {
+            format!("Request timeout: {e}")
+        } else if e.is_connect() {
+            format!("Connection failed: {e}")
+        } else if e.is_request() {
+            format!("Request error: {e}")
+        } else if e.is_body() {
+            format!("Body error: {e}")
+        } else if e.is_decode() {
+            format!("Decode error: {e}")
+        } else {
+            format!("Network error: {e}")
+        }
+    })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let url_display = super::config_manager::mask_url(resp.url().as_ref());
+        return Err(format!("HTTP {status} from {url_display}"));
+    }
+
+    if let Some(content_length) = resp.content_length() {
+        if usize::try_from(content_length).unwrap_or(0) > MAX_RESPONSE_SIZE {
+            return Err(format!(
+                "Response too large: {content_length} bytes (max {MAX_RESPONSE_SIZE} bytes)"
+            ));
+        }
+    }
+
+    let sub_info_header = resp
+        .headers()
+        .get("subscription-userinfo")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+
+    // Persist the requested URL, not `resp.url()`. Redirect targets are often
+    // one-time signed URLs that would break later subscription updates.
+    let requested_url = url.to_owned();
+
+    let disp_filename = resp
+        .headers()
+        .get("content-disposition")
+        .and_then(|h| h.to_str().ok())
+        .and_then(parse_content_disposition_filename);
+
+    let bytes = read_response_body(resp).await?;
+
+    Ok((bytes, sub_info_header, requested_url, disp_filename))
+}
+
+async fn try_global_mode_tier(
+    app: &AppHandle,
+    m_url: &str,
+    url: &str,
+    user_agent: Option<&str>,
+    total_deadline: std::time::Instant,
+) -> Result<(Vec<u8>, String, String, Option<String>), String> {
+    let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+    if remaining < Duration::from_millis(4000) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    }
+
+    let lock_wait = remaining.min(Duration::from_millis(1500));
+    let lock_guard = tokio::time::timeout(lock_wait, GLOBAL_MODE_LOCK.clone().lock_owned())
+        .await
+        .map_err(|_timeout| "Global-mode: Skipped due to lock contention".to_owned())?;
+
+    let orig_mode = get_mihomo_mode(app)
+        .await
+        .ok_or_else(|| "Global-mode: Failed to get current Mihomo mode".to_owned())?;
+
+    let (active_node, global_now) = get_mihomo_active_node_and_global_now(app)
+        .await
+        .ok_or_else(|| "Global-mode: No eligible proxy node found in GLOBAL group".to_owned())?;
+
+    let orig_global_now = global_now.ok_or_else(|| {
+        "Global-mode: Original GLOBAL proxy group selection is unknown".to_owned()
+    })?;
+
+    let need_mode_switch = orig_mode != "global";
+    let need_node_switch = orig_global_now != active_node;
+
+    if !need_mode_switch && !need_node_switch {
+        return Err("Global-mode: Already in global mode with active node selected".to_owned());
+    }
+
+    // Re-check cumulative deadline before mutating any core state
+    let rem_before_mutate = total_deadline.saturating_duration_since(std::time::Instant::now());
+    if rem_before_mutate < Duration::from_millis(2500) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    }
+
+    let core_started_at = {
+        let state = app.state::<MihomoState>();
+        let guard = state
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.started_at()
+    };
+
+    let mut restore_guard = ModeRestoreGuard {
+        app: app.clone(),
+        orig_mode: None,
+        orig_global_now: None,
+        lock_guard: Some(lock_guard),
+        core_started_at,
+    };
+
+    // 在修改 Mihomo 状态前，先持久化恢复标记至磁盘。
+    // 这样即便进程遭遇 SIGKILL、崩溃中止或意外掉电，
+    // 下次启动时也能比自动更新更早读到标记并恢复原始模式与节点。
+    if let Err(e) = write_global_mode_restore_marker(
+        app,
+        need_mode_switch.then_some(&orig_mode),
+        need_node_switch.then_some(&orig_global_now),
+    ) {
+        crate::emit_warn!(
+            Core,
+            CORE_MODE_RESTORE_FAILED,
+            "Skipping global-mode fallback: failed to persist recovery marker: {e}"
+        );
+        return Err(format!(
+            "Global-mode: Failed to persist recovery marker: {e}"
+        ));
+    }
+
+    if need_node_switch {
+        // 先在原模式下切换 GLOBAL 策略组的目标节点；
+        // 若切换失败，尚未进入 global 模式，用户当前流量不会受到任何影响。
+        restore_guard.orig_global_now = Some(orig_global_now);
+        if set_mihomo_proxy_group(app, "GLOBAL", &active_node)
+            .await
+            .is_none()
+        {
+            crate::emit_warn!(
+                Core,
+                CORE_GLOBAL_SWITCH_FAILED,
+                "Failed to switch GLOBAL proxy group to '{active_node}'"
+            );
+            return Err(format!(
+                "Global-mode: Failed to select node '{active_node}'"
+            ));
+        }
+    }
+
+    if need_mode_switch {
+        restore_guard.orig_mode = Some(orig_mode);
+        if set_mihomo_mode(app, "global").await.is_none() {
+            return Err("Global-mode: Failed to switch Mihomo mode to global".to_owned());
+        }
+    }
+
+    // 切换后短暂等待 mihomo 生效
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let rem_dl = total_deadline.saturating_duration_since(std::time::Instant::now());
+    let (conn_to, req_to) = if rem_dl < Duration::from_millis(800) {
+        return Err("Global-mode: Skipped due to deadline exhaustion".to_owned());
+    } else {
+        (
+            Duration::from_millis(1500).min(rem_dl),
+            Duration::from_millis(2500).min(rem_dl),
+        )
+    };
+
+    let client =
+        build_http_client_with_proxy(user_agent, None, Some(m_url.to_owned()), conn_to, req_to)
+            .map_err(|e| format!("Global-mode client build: {e}"))?;
+
+    let download_res = do_download_stream(&client, url).await;
+
+    // 正常流程：尝试恢复原模式和策略组选择。
+    // 传递 restore_guard 字段的可变引用，成功恢复的字段会被置为 None；
+    // 若在 inline 恢复执行期间任务被取消，guard 内部尚未恢复的字段完好无损，
+    // Drop 守卫将在后台继续接管恢复，并在恢复期间继续持有互斥锁。
+    restore_mihomo_state(
+        app,
+        &mut restore_guard.orig_global_now,
+        &mut restore_guard.orig_mode,
+        Some(total_deadline),
+        false,
+        core_started_at,
+    )
+    .await;
+    drop(restore_guard);
+
+    download_res.map_err(|e| format!("Global-mode: {e}"))
+}
+
+fn is_same_loopback_proxy_endpoint(amb: &str, mihomo: &str) -> bool {
+    if amb == mihomo {
+        return true;
+    }
+    if let (Ok(u1), Ok(u2)) = (url::Url::parse(amb), url::Url::parse(mihomo)) {
+        let p1 = u1.port_or_known_default();
+        let p2 = u2.port_or_known_default();
+        if p1 == p2 && p1.is_some() {
+            let h1 = u1.host_str().unwrap_or("");
+            let h2 = u2.host_str().unwrap_or("");
+            let is_loop1 =
+                h1.eq_ignore_ascii_case("localhost") || h1 == "127.0.0.1" || h1 == "[::1]";
+            let is_loop2 =
+                h2.eq_ignore_ascii_case("localhost") || h2 == "127.0.0.1" || h2 == "[::1]";
+            if is_loop1 && is_loop2 {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 pub(crate) async fn download_sub_inner(
@@ -246,81 +984,153 @@ async fn download_sub_inner_raw(
 ) -> Result<DownloadSubResult, String> {
     let safe_name = validate_subscription_name(&name).map_err(|e| e.to_string())?;
 
-    let (host, resolved_addr, user_entered_private) = validate_subscription_url_with_ip(&url)?;
+    let (host, port, user_entered_private) = validate_subscription_url_basic(&url)?;
+
+    // Outer scheduler timeout is 15s. We set a cumulative internal budget of 12.0s
+    // across all tiers and DNS resolution to guarantee completion, cleanup, YAML parsing,
+    // and transactional file saving before outer scheduler cancellation (leaving a 3.0s margin).
+    let total_deadline = std::time::Instant::now() + Duration::from_millis(12000);
+
     // For user-entered private addresses, skip DNS pinning (proxy/system handles resolution).
-    // For public addresses, use DNS pinning to prevent DNS rebinding.
+    // For public addresses, resolve and pin DNS to prevent DNS rebinding for direct connections.
+    // If DNS resolution fails (e.g. host is blocked by GFW or DNS poisoned to private IP)
+    // or times out (unresponsive DNS / packet drop), record the error and bypass direct connection,
+    // falling through to proxy.
+    let mut direct_dns_error = None;
     let resolve_pin = if user_entered_private {
         None
     } else {
-        resolved_addr.map(|addr| (host.clone(), addr))
+        let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining < Duration::from_millis(1000) {
+            direct_dns_error = Some("Skipped DNS resolution due to deadline exhaustion".to_owned());
+            None
+        } else {
+            let dns_timeout = Duration::from_millis(1500).min(remaining);
+            let host_clone = host.clone();
+            let resolve_future = async {
+                let deadline = tokio::time::Instant::now() + dns_timeout;
+                let permit = tokio::time::timeout_at(deadline, DNS_SEMAPHORE.clone().acquire_owned())
+                    .await
+                    .map_err(|_err| {
+                        format!("DNS resolution timed out waiting for permit for '{host}' ({dns_timeout:?})")
+                    })?
+                    .map_err(|e| e.to_string())?;
+
+                let remaining_dns = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining_dns.is_zero() {
+                    return Err(format!(
+                        "DNS resolution timed out for '{host}' ({dns_timeout:?})"
+                    ));
+                }
+
+                let handle = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    std::net::ToSocketAddrs::to_socket_addrs(&format!("{host_clone}:{port}"))
+                        .map(std::iter::Iterator::collect::<Vec<_>>)
+                });
+                let abort_handle = handle.abort_handle();
+                tokio::select! {
+                    res = handle => match res {
+                        Ok(Ok(addrs)) => Ok(addrs),
+                        Ok(Err(e)) => Err(format!("DNS resolution failed for '{host}': {e}")),
+                        Err(e) => Err(format!("DNS resolution task join error: {e}")),
+                    },
+                    _ = tokio::time::sleep_until(deadline) => {
+                        abort_handle.abort();
+                        Err(format!("DNS resolution timed out for '{host}' ({dns_timeout:?})"))
+                    }
+                }
+            };
+
+            match resolve_future.await {
+                Ok(addrs) => {
+                    if addrs.is_empty() {
+                        direct_dns_error =
+                            Some("Could not resolve any IP address for host".to_owned());
+                        None
+                    } else {
+                        match zephyr_core::config::subscription::validate_public_host_addrs(
+                            &host, &addrs,
+                        ) {
+                            Ok((_, Some(addr), _)) => Some((host.clone(), addr)),
+                            Ok((_, None, _)) => {
+                                direct_dns_error =
+                                    Some("Could not resolve any IP address for host".to_owned());
+                                None
+                            }
+                            Err(
+                                zephyr_core::config::subscription::PublicHostAddrError::SsrfBlocked(
+                                    e,
+                                ),
+                            ) => {
+                                // SSRF rejection is a security policy decision, not a transient transport failure.
+                                // Reject immediately instead of retrying through proxy tiers.
+                                return Err(e);
+                            }
+                            Err(e) => {
+                                direct_dns_error = Some(e.to_string());
+                                None
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    direct_dns_error = Some(e);
+                    None
+                }
+            }
+        }
     };
 
-    let do_download = |client: reqwest::Client, url: String| async move {
-        let resp = client.get(&url).send().await.map_err(|e| {
-            if e.is_timeout() {
-                format!("Request timeout: {e}")
-            } else if e.is_connect() {
-                format!("Connection failed: {e}")
-            } else if e.is_request() {
-                format!("Request error: {e}")
-            } else if e.is_body() {
-                format!("Body error: {e}")
-            } else if e.is_decode() {
-                format!("Decode error: {e}")
-            } else {
-                format!("Network error: {e}")
-            }
-        })?;
+    let has_mihomo = {
+        let state = app.state::<MihomoState>();
+        let guard = state
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        is_core_running_from_guard(&guard)
+    };
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let url_display = super::config_manager::mask_url(resp.url().as_ref());
-            return Err(format!("HTTP {status} from {url_display}"));
+    let get_tier_timeout = |max_total_ms: u64, max_conn_ms: u64| -> Option<(Duration, Duration)> {
+        let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining < Duration::from_millis(500) {
+            return None;
         }
-
-        if let Some(content_length) = resp.content_length() {
-            if usize::try_from(content_length).unwrap_or(0) > MAX_RESPONSE_SIZE {
-                return Err(format!(
-                    "Response too large: {content_length} bytes (max {MAX_RESPONSE_SIZE} bytes)"
-                ));
-            }
-        }
-
-        let sub_info_header = resp
-            .headers()
-            .get("subscription-userinfo")
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("")
-            .to_owned();
-
-        // Use original URL for metadata storage, not profile-web-page-url
-        // profile-web-page-url often points to HTML pages, not the actual subscription endpoint
-        let final_url = url.clone();
-
-        // Try to extract filename from Content-Disposition header
-        let disp_filename = resp
-            .headers()
-            .get("content-disposition")
-            .and_then(|h| h.to_str().ok())
-            .and_then(parse_content_disposition_filename);
-
-        let bytes = read_response_body(resp).await?;
-
-        Ok::<(Vec<u8>, String, String, Option<String>), String>((
-            bytes,
-            sub_info_header,
-            final_url,
-            disp_filename,
-        ))
+        let connect_timeout = Duration::from_millis(max_conn_ms).min(remaining);
+        let request_timeout = Duration::from_millis(max_total_ms).min(remaining);
+        Some((connect_timeout, request_timeout))
     };
 
     let mut last_error = String::new();
     let mut result: Option<(Vec<u8>, String, String, Option<String>)> = None;
 
-    // Try direct connection first
-    let direct_error =
-        match build_http_client_with_proxy(user_agent.as_deref(), resolve_pin.clone(), None) {
-            Ok(client) => match do_download(client, url.clone()).await {
+    // Try direct connection first (if DNS resolution didn't fail)
+    // 1. For user-entered private/LAN subscriptions, proxy tiers are not attempted, so allocate a full
+    //    10000ms request window (4000ms connect timeout).
+    // 2. For public subscriptions with Mihomo running, allocate 3500ms request (1500ms connect) so
+    //    slow direct endpoints have time to complete while blocked domains fast-fail on connect (1500ms)
+    //    and leave ample budget (>= 7000ms before Tier 2; >= 4500ms before Tier 3) for proxy tiers.
+    // 3. For public subscriptions with Mihomo stopped, allocate up to 5500ms (2000ms connect) to allow
+    //    direct servers to succeed while still reserving at least 4500ms for ambient proxy fallbacks.
+    let (direct_req_ms, direct_conn_ms) = if user_entered_private {
+        (10000, 4000)
+    } else if has_mihomo {
+        (3500, 1500)
+    } else {
+        (5500, 2000)
+    };
+
+    let direct_error = if let Some(dns_err) = direct_dns_error {
+        Some(format!("Direct DNS: {dns_err}"))
+    } else if let Some((conn_to, req_to)) = get_tier_timeout(direct_req_ms, direct_conn_ms) {
+        match build_http_client_with_proxy(
+            user_agent.as_deref(),
+            resolve_pin.as_ref(),
+            None,
+            conn_to,
+            req_to,
+        ) {
+            Ok(client) => match do_download_stream(&client, &url).await {
                 Ok(data) => {
                     result = Some(data);
                     None
@@ -328,132 +1138,208 @@ async fn download_sub_inner_raw(
                 Err(e) => Some(format!("Direct: {e}")),
             },
             Err(e) => Some(format!("Direct client build: {e}")),
-        };
+        }
+    } else {
+        Some("Direct: Skipped due to deadline exhaustion".to_owned())
+    };
 
     if result.is_none() {
-        // Get proxy port from state, then immediately release the lock
-        let proxy_url = {
-            let state = app.state::<MihomoState>();
-            let guard = state.0.lock().ok();
-            guard.and_then(|g| {
-                g.process()
-                    .is_some()
-                    .then(|| format!("http://127.0.0.1:{}", g.last_proxy_port().unwrap_or(7890)))
-            })
-        };
+        if let Some(de) = direct_error.as_deref() {
+            append_error(&mut last_error, de);
+        }
 
-        if let Some(proxy_url_val) = proxy_url {
-            // When using proxy, skip DNS pre-resolve pinning to let the proxy
-            // handle DNS resolution (avoids issues with CDN / geo-balanced IPs).
-            //
-            // SSRF protection coverage for proxy paths:
-            // - ✅ Initial URL host validated (private host check before any request)
-            // - ✅ Redirect policy blocks redirects to private hosts/IPs
-            // - ⚠️  Proxy-side SSRF (proxy resolving to internal IPs) is NOT
-            //     preventable client-side — this is inherent to any proxy architecture.
-            //     Mitigate by only configuring trusted proxies.
-            let client_mihomo = build_http_client_with_proxy(
-                user_agent.as_deref(),
-                None,
-                Some(proxy_url_val.clone()),
-            );
-            match client_mihomo {
-                Ok(client) => match do_download(client, url.clone()).await {
-                    Ok(data) => {
-                        result = Some(data);
+        // Only public subscription URLs fall back to proxy tiers.
+        // User-entered private/LAN destinations are strictly direct-only to prevent internal SSRF via proxies.
+        if !user_entered_private {
+            // Resolve Mihomo mixed-port proxy and ambient (system / environment) proxy as distinct candidates.
+            let mihomo_proxy_url = {
+                let state = app.state::<MihomoState>();
+                let guard = state
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let running = is_core_running_from_guard(&guard);
+                let proxy_port = guard.last_proxy_port().unwrap_or(7890);
+                drop(guard);
+                running.then(|| format!("http://127.0.0.1:{proxy_port}"))
+            };
+
+            // ── Tier 2: Mihomo proxy (mixed-port) ──────────────────────────────────
+            if let Some(m_url) = &mihomo_proxy_url {
+                if let Some((conn_to, req_to)) = get_tier_timeout(2500, 1500) {
+                    let client_proxy = build_http_client_with_proxy(
+                        user_agent.as_deref(),
+                        None,
+                        Some(m_url.clone()),
+                        conn_to,
+                        req_to,
+                    );
+                    match client_proxy {
+                        Ok(client) => match do_download_stream(&client, &url).await {
+                            Ok(data) => {
+                                result = Some(data);
+                            }
+                            Err(e) => {
+                                append_error(&mut last_error, &format!("Proxy: {e}"));
+                            }
+                        },
+                        Err(e) => {
+                            append_error(&mut last_error, &format!("Proxy client build: {e}"));
+                        }
                     }
-                    Err(e) => {
-                        last_error = match direct_error.as_deref() {
-                            Some(de) => format!("{de} | Proxy: {e}"),
-                            None => format!("Proxy: {e}"),
-                        };
-                    }
-                },
-                Err(e) => {
-                    last_error = match direct_error.as_deref() {
-                        Some(de) => format!("{de} | Proxy client build: {e}"),
-                        None => format!("Proxy client build: {e}"),
+                } else {
+                    append_error(&mut last_error, "Proxy: Skipped due to deadline exhaustion");
+                }
+
+                // ── Tier 3: 临时切换 global 模式并选择可用节点重试 ──────────────────
+                // 直连和普通代理（规则分流）都失败后，若使用的是 Mihomo 内核代理，
+                // 尝试把 Mihomo 切到 global 模式并确保 GLOBAL 策略组选择当前活跃的代理节点，
+                // 让所有流量走代理节点（绕过分流规则可能导致的不可达），
+                // 下载完成后或任务中断时自动切回原模式和原策略组选择。
+                // 使用全局异步互斥锁防止并发下载任务在全局模式切换和还原期间发生竞态。
+                if result.is_none() {
+                    match try_global_mode_tier(
+                        app,
+                        m_url,
+                        &url,
+                        user_agent.as_deref(),
+                        total_deadline,
+                    )
+                    .await
+                    {
+                        Ok(data) => {
+                            result = Some(data);
+                        }
+                        Err(err) => {
+                            append_error(&mut last_error, &err);
+                        }
                     }
                 }
             }
 
-            // ── Tier 3: 临时切换 global 模式重试 ──────────────────────────────
-            // 直连和普通代理都失败后，尝试临时把 mihomo 切到 global 模式，
-            // 让所有流量走当前选中的代理节点（绕过分流规则可能导致的不可达），
-            // 下载完成后切回原模式。
+            // ── Tier 4: 环境代理 / 系统代理回退 ──────────────────────────────────
+            // 4. Ambient Proxy 兜底重试阶段：
+            // 若 Mihomo 未启动，或 Mihomo 代理与全局模式均无法拉取订阅，
+            // 则在存在且不与 Mihomo 重复的有效本地回环代理（系统代理及环境变量代理）中按优先级依次尝试重试。
+            // 当目标主机匹配 NO_PROXY / no_proxy 时，遵循环境配置直接跳过该阶段。
             if result.is_none() {
-                // 只有成功获取到当前模式且不是 global 时才切换，
-                // 否则切到 global 后无法切回（original_mode 为 None 时跳过恢复）。
-                if let Some(orig) = get_mihomo_mode(app).await {
-                    if orig != "global" && set_mihomo_mode(app, "global").await.is_some() {
-                        // Drop guard: 即使 task 在 sleep/download 期间被 cancel，
-                        // 也能在 drop 时 spawn 恢复任务，避免 core 永久停留在 global 模式。
-                        struct ModeRestoreGuard {
-                            app: tauri::AppHandle,
-                            orig_mode: Option<String>,
+                let parsed_sub_url = url::Url::parse(&url).ok();
+                let sub_scheme = parsed_sub_url
+                    .as_ref()
+                    .map(|u| u.scheme().to_ascii_lowercase());
+                let sub_host = parsed_sub_url.as_ref().and_then(|u| u.host_str());
+                let sub_port = parsed_sub_url
+                    .as_ref()
+                    .and_then(url::Url::port_or_known_default);
+                let is_no_proxy = sub_host.is_some_and(|h| {
+                    zephyr_core::config::is_destination_in_no_proxy(h, sub_port)
+                        || resolve_pin.as_ref().is_some_and(|(_, sa)| {
+                            zephyr_core::config::is_destination_in_no_proxy(
+                                &sa.ip().to_string(),
+                                sub_port,
+                            )
+                        })
+                });
+
+                let remaining = total_deadline.saturating_duration_since(std::time::Instant::now());
+                if !is_no_proxy && remaining >= Duration::from_millis(600) {
+                    let sys_proxy_timeout = Duration::from_millis(500).min(remaining / 2);
+                    let sys_proxy = get_bounded_sys_proxy_address(sys_proxy_timeout).await;
+
+                    let mut ambient_candidates: Vec<String> = Vec::new();
+
+                    if let Some(raw) = sys_proxy.as_deref() {
+                        for sp in
+                            zephyr_core::config::subscription::collect_ambient_proxy_urls_for_scheme(
+                                raw,
+                                sub_scheme.as_deref(),
+                            )
+                        {
+                            if !ambient_candidates.contains(&sp) {
+                                ambient_candidates.push(sp);
+                            }
                         }
-                        impl Drop for ModeRestoreGuard {
-                            fn drop(&mut self) {
-                                if let Some(orig) = self.orig_mode.take() {
-                                    let app = self.app.clone();
-                                    tokio::spawn(async move {
-                                        if set_mihomo_mode(&app, &orig).await.is_none() {
-                                            crate::emit_warn!(
-                                                Core,
-                                                CORE_MODE_RESTORE_DROPPED,
-                                                "Failed to restore original mihomo mode '{orig}' on drop"
-                                            );
-                                        }
-                                    });
+                    }
+
+                    let env_keys: &[&str] = if sub_scheme.as_deref() == Some("https") {
+                        &[
+                            "HTTPS_PROXY",
+                            "https_proxy",
+                            "ALL_PROXY",
+                            "all_proxy",
+                            "HTTP_PROXY",
+                            "http_proxy",
+                        ]
+                    } else {
+                        &[
+                            "HTTP_PROXY",
+                            "http_proxy",
+                            "ALL_PROXY",
+                            "all_proxy",
+                            "HTTPS_PROXY",
+                            "https_proxy",
+                        ]
+                    };
+
+                    for key in env_keys {
+                        if let Ok(val) = std::env::var(key) {
+                            for candidate in
+                                zephyr_core::config::subscription::collect_ambient_proxy_urls_for_scheme(
+                                    &val,
+                                    sub_scheme.as_deref(),
+                                )
+                            {
+                                if !ambient_candidates.contains(&candidate) {
+                                    ambient_candidates.push(candidate);
                                 }
                             }
                         }
+                    }
 
-                        let mut restore_guard = ModeRestoreGuard {
-                            app: app.clone(),
-                            orig_mode: Some(orig.clone()),
-                        };
-
-                        // 切换后短暂等待 mihomo 生效
-                        tokio::time::sleep(Duration::from_millis(300)).await;
-
-                        let client_global = build_http_client_with_proxy(
-                            user_agent.as_deref(),
-                            None,
-                            Some(proxy_url_val),
-                        );
-                        match client_global {
-                            Ok(client) => match do_download(client, url).await {
-                                Ok(data) => {
-                                    result = Some(data);
-                                }
+                    for amb_url in ambient_candidates {
+                        if mihomo_proxy_url
+                            .as_ref()
+                            .is_some_and(|m| is_same_loopback_proxy_endpoint(&amb_url, m))
+                        {
+                            continue;
+                        }
+                        if result.is_some() {
+                            break;
+                        }
+                        if let Some((conn_to, req_to)) = get_tier_timeout(2500, 1500) {
+                            let client_ambient = build_http_client_with_proxy(
+                                user_agent.as_deref(),
+                                resolve_pin.as_ref(),
+                                Some(amb_url),
+                                conn_to,
+                                req_to,
+                            );
+                            match client_ambient {
+                                Ok(client) => match do_download_stream(&client, &url).await {
+                                    Ok(data) => {
+                                        result = Some(data);
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        append_error(
+                                            &mut last_error,
+                                            &format!("Ambient Proxy: {e}"),
+                                        );
+                                    }
+                                },
                                 Err(e) => {
-                                    last_error = if last_error.is_empty() {
-                                        format!("Global-mode: {e}")
-                                    } else {
-                                        format!("{last_error} | Global-mode: {e}")
-                                    };
+                                    append_error(
+                                        &mut last_error,
+                                        &format!("Ambient Proxy client build: {e}"),
+                                    );
                                 }
-                            },
-                            Err(e) => {
-                                last_error = if last_error.is_empty() {
-                                    format!("Global-mode client build: {e}")
-                                } else {
-                                    format!("{last_error} | Global-mode client build: {e}")
-                                };
                             }
-                        }
-
-                        // 正常流程：手动恢复原模式并从 guard 中 take 走 orig_mode，
-                        // 避免 Drop 时重复执行恢复。
-                        if let Some(orig) = restore_guard.orig_mode.take() {
-                            if set_mihomo_mode(app, &orig).await.is_none() {
-                                crate::emit_warn!(
-                                    Core,
-                                    CORE_MODE_RESTORE_FAILED,
-                                    "Failed to restore original mihomo mode '{orig}'"
-                                );
-                            }
+                        } else {
+                            append_error(
+                                &mut last_error,
+                                "Ambient Proxy: Skipped due to deadline exhaustion",
+                            );
+                            break;
                         }
                     }
                 }
@@ -461,11 +1347,12 @@ async fn download_sub_inner_raw(
         }
     }
 
-    // Two-tier download strategy: direct → Mihomo proxy.
-    // System proxy fallback is intentionally removed to reduce SSRF attack surface.
-    // The Mihomo proxy path is trusted (user-configured), while system proxy
-    // could be set by any application/malware on the system.
-    let (bytes, sub_info_header, final_url, disp_filename) = result.ok_or_else(|| {
+    // Multi-tier download strategy:
+    // Tier 1: Direct connection with DNS pinning (SSRF protection).
+    // Tier 2: Mihomo mixed-port proxy connection.
+    // Tier 3: Mihomo global mode with active proxy node selection and auto-restoration.
+    // Tier 4: Ambient proxy (system / environment proxy fallback).
+    let (bytes, sub_info_header, requested_url, disp_filename) = result.ok_or_else(|| {
         if !last_error.is_empty() {
             last_error
         } else if let Some(de) = direct_error {
@@ -676,7 +1563,7 @@ async fn download_sub_inner_raw(
         metadata.configs.insert(
             clean_name.clone(),
             super::crypto::ConfigMetadata {
-                url: preserved_url.or(Some(final_url)),
+                url: preserved_url.or(Some(requested_url)),
                 sub_info: if sub_info_header.is_empty() {
                     preserved_sub_info
                 } else {
@@ -1004,7 +1891,10 @@ mod tests {
         let addrs: Vec<std::net::SocketAddr> = vec!["192.168.1.1:80".parse().unwrap()];
         let result = validate_public_host_addrs("attacker.com", &addrs);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("SSRF protection"));
+        assert!(matches!(
+            result.unwrap_err(),
+            zephyr_core::config::PublicHostAddrError::SsrfBlocked(_)
+        ));
     }
 
     #[test]
@@ -1036,7 +1926,10 @@ mod tests {
         let addrs: Vec<std::net::SocketAddr> = vec![];
         let result = validate_public_host_addrs("empty.com", &addrs);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Could not resolve"));
+        assert!(matches!(
+            result.unwrap_err(),
+            zephyr_core::config::PublicHostAddrError::NoAddresses(_)
+        ));
     }
 
     #[test]
@@ -1131,5 +2024,39 @@ proxies:
         let yaml = "    short-id: 34010e92\n";
         let result = quote_short_id_values(yaml);
         assert!(result.contains(r#"short-id: "34010e92""#));
+    }
+
+    #[test]
+    fn test_global_mode_restore_marker_serde() {
+        let marker = super::GlobalModeRestoreMarker {
+            orig_mode: Some("rule".to_owned()),
+            orig_global_now: Some("Node1".to_owned()),
+            active_config: Some("profile.yaml".to_owned()),
+        };
+        let serialized = serde_json::to_string(&marker).unwrap();
+        let deserialized: super::GlobalModeRestoreMarker =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(marker, deserialized);
+
+        let marker_mode_only = super::GlobalModeRestoreMarker {
+            orig_mode: Some("rule".to_owned()),
+            orig_global_now: None,
+            active_config: None,
+        };
+        let serialized2 = serde_json::to_string(&marker_mode_only).unwrap();
+        let deserialized2: super::GlobalModeRestoreMarker =
+            serde_json::from_str(&serialized2).unwrap();
+        assert_eq!(marker_mode_only, deserialized2);
+
+        // Verify backward compatibility when active_config is missing in JSON
+        let legacy_json = r#"{"orig_mode":"rule","orig_global_now":"Node1"}"#;
+        let legacy_deserialized: super::GlobalModeRestoreMarker =
+            serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(legacy_deserialized.orig_mode.as_deref(), Some("rule"));
+        assert_eq!(
+            legacy_deserialized.orig_global_now.as_deref(),
+            Some("Node1")
+        );
+        assert_eq!(legacy_deserialized.active_config, None);
     }
 }

--- a/apps/desktop/src-tauri/src/core/subscription_scheduler.rs
+++ b/apps/desktop/src-tauri/src/core/subscription_scheduler.rs
@@ -91,6 +91,9 @@ pub fn start_scheduler(app: AppHandle) -> Arc<SchedulerState> {
 
 /// Main scheduler loop - checks each subscription individually.
 async fn run_scheduler_loop(app: AppHandle, state: Arc<SchedulerState>) {
+    // Reconcile and restore any un-restored global mode or GLOBAL selection marker left from an abrupt shutdown
+    let _ = super::subscription::reconcile_global_mode_restore(&app).await;
+
     let mut check_interval = interval(Duration::from_secs(60)); // Check every minute
     check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -154,6 +157,17 @@ async fn check_and_update_subscriptions(
     app: &AppHandle,
     state: &Arc<SchedulerState>,
 ) -> Result<usize, String> {
+    // Reconcile any un-restored global mode marker before triggering new subscription downloads.
+    // If lock acquisition times out, another task is actively using global mode; skip this update pass.
+    if !super::subscription::reconcile_global_mode_restore(app).await {
+        emit_warn!(
+            Subscription,
+            SUB_UPDATE_FAILED,
+            "Skipping subscription update pass: global mode lock acquisition timed out"
+        );
+        return Ok(0);
+    }
+
     let paths = ensure_app_storage(app)?;
     let metadata = load_metadata(&paths);
 

--- a/apps/desktop/src-tauri/src/sys_proxy.rs
+++ b/apps/desktop/src-tauri/src/sys_proxy.rs
@@ -188,15 +188,14 @@ fn run_networksetup(args: &[&str]) -> Result<(), String> {
     }
 }
 
-/// Dynamically get all network services from macOS
+/// Dynamically get all network services from macOS with a bounded timeout
 #[cfg(target_os = "macos")]
-fn get_network_services() -> Vec<String> {
-    let output = match Command::new("networksetup")
-        .arg("-listallnetworkservices")
-        .output()
-    {
-        Ok(out) => out,
-        Err(_) => return vec!["Wi-Fi".to_owned(), "Ethernet".to_owned()],
+fn get_network_services_bounded(timeout: std::time::Duration) -> Vec<String> {
+    let mut cmd = Command::new("networksetup");
+    cmd.arg("-listallnetworkservices");
+    let output = match run_cmd_bounded(cmd, timeout) {
+        Some(out) => out,
+        None => return vec!["Wi-Fi".to_owned(), "Ethernet".to_owned()],
     };
 
     if !output.status.success() {
@@ -230,6 +229,12 @@ fn get_network_services() -> Vec<String> {
     services
 }
 
+/// Dynamically get all network services from macOS
+#[cfg(target_os = "macos")]
+fn get_network_services() -> Vec<String> {
+    get_network_services_bounded(std::time::Duration::from_millis(800))
+}
+
 #[cfg(target_os = "macos")]
 fn apply_networksetup_for_services<F>(mut op: F) -> Result<(), String>
 where
@@ -251,35 +256,161 @@ where
     }
 }
 
-#[cfg(target_os = "linux")]
-fn is_cmd_available(cmd: &str) -> bool {
-    Command::new(cmd).arg("--help").output().is_ok()
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn kill_child_and_descendants(child: &mut std::process::Child) {
+    if let Ok(pid) = i32::try_from(child.id()) {
+        if pid > 0 {
+            // SAFETY: We send SIGKILL to the process group created for this child (pgid == pid).
+            // The child was spawned in its own process group via `process_group(0)`, so killing `-pid`
+            // cleanly terminates the child and any descendants holding inherited file descriptors.
+            unsafe {
+                libc::kill(-pid, libc::SIGKILL);
+            }
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
-#[cfg(target_os = "linux")]
-fn get_kde_cmd() -> Option<(&'static str, &'static str)> {
-    if is_cmd_available("kwriteconfig6") {
-        Some(("kwriteconfig6", "kreadconfig6"))
-    } else if is_cmd_available("kwriteconfig5") {
-        Some(("kwriteconfig5", "kreadconfig5"))
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn run_cmd_bounded(mut cmd: Command, timeout: std::time::Duration) -> Option<std::process::Output> {
+    use std::os::unix::process::CommandExt as _;
+
+    cmd.process_group(0);
+    let mut child = cmd
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let mut stdout = child.stdout.take()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    let reader_handle = std::thread::spawn(move || {
+        use std::io::Read as _;
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // The child has exited and was reaped, so the reader thread only drains
+                // buffered pipe data. Avoid signaling the process group post-reap to
+                // prevent killing recycled PIDs.
+                let stdout_bytes = rx
+                    .recv_timeout(std::time::Duration::from_millis(200))
+                    .unwrap_or_default();
+                if reader_handle.is_finished() {
+                    let _ = reader_handle.join();
+                }
+                return Some(std::process::Output {
+                    status,
+                    stdout: stdout_bytes,
+                    stderr: Vec::new(),
+                });
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    kill_child_and_descendants(&mut child);
+                    let _ = rx.recv_timeout(std::time::Duration::from_millis(100));
+                    if reader_handle.is_finished() {
+                        let _ = reader_handle.join();
+                    }
+                    return None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(15));
+            }
+            Err(_) => {
+                kill_child_and_descendants(&mut child);
+                let _ = rx.recv_timeout(std::time::Duration::from_millis(100));
+                if reader_handle.is_finished() {
+                    let _ = reader_handle.join();
+                }
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn push_normalized_proxy_part(parts: &mut Vec<String>, raw: &str, tag: &str) {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "false" {
+        return;
+    }
+    let mut normalized = trimmed.to_owned();
+    if let Some(rest) = normalized.strip_prefix("socks://") {
+        normalized = format!("socks5://{rest}");
+    }
+    if normalized.ends_with(":0") {
+        return;
+    }
+    let part = if normalized.contains('=') {
+        normalized
     } else {
-        None
+        format!("{tag}={normalized}")
+    };
+    if !parts.contains(&part) {
+        parts.push(part);
     }
 }
 
 #[cfg(target_os = "linux")]
+fn run_cmd_bounded_status(cmd: Command, timeout: std::time::Duration) -> bool {
+    run_cmd_bounded(cmd, timeout).is_some_and(|out| out.status.success())
+}
+
+#[cfg(target_os = "linux")]
+fn is_cmd_available_bounded(cmd: &str, timeout: std::time::Duration) -> bool {
+    let mut command = Command::new(cmd);
+    command.arg("--help");
+    run_cmd_bounded_status(command, timeout)
+}
+
+#[cfg(target_os = "linux")]
+fn get_kde_cmd_bounded(timeout: std::time::Duration) -> Option<(&'static str, &'static str)> {
+    let start = std::time::Instant::now();
+    if is_cmd_available_bounded("kwriteconfig6", timeout) {
+        Some(("kwriteconfig6", "kreadconfig6"))
+    } else {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            None
+        } else if is_cmd_available_bounded("kwriteconfig5", remaining) {
+            Some(("kwriteconfig5", "kreadconfig5"))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn get_kde_cmd() -> Option<(&'static str, &'static str)> {
+    get_kde_cmd_bounded(std::time::Duration::from_millis(800))
+}
+
+#[cfg(target_os = "linux")]
+fn has_gnome_bounded(timeout: std::time::Duration) -> bool {
+    let mut cmd = Command::new("gsettings");
+    cmd.args(["get", "org.gnome.system.proxy", "mode"]);
+    run_cmd_bounded_status(cmd, timeout)
+}
+
+#[cfg(target_os = "linux")]
 fn has_gnome() -> bool {
-    Command::new("gsettings")
-        .arg("get")
-        .arg("org.gnome.system.proxy")
-        .arg("mode")
-        .output()
-        .is_ok()
+    has_gnome_bounded(std::time::Duration::from_millis(800))
+}
+
+#[cfg(target_os = "linux")]
+fn has_xfce_bounded(timeout: std::time::Duration) -> bool {
+    is_cmd_available_bounded("xfconf-query", timeout)
 }
 
 #[cfg(target_os = "linux")]
 fn has_xfce() -> bool {
-    is_cmd_available("xfconf-query")
+    has_xfce_bounded(std::time::Duration::from_millis(800))
 }
 
 /// Run a gsettings command and return whether it succeeded.
@@ -758,8 +889,16 @@ pub fn has_sysproxy_ownership(app: AppHandle) -> bool {
 
 #[must_use]
 pub fn get_sys_proxy_address() -> Option<String> {
+    get_sys_proxy_address_with_deadline(
+        std::time::Instant::now() + std::time::Duration::from_millis(1500),
+    )
+}
+
+#[must_use]
+pub fn get_sys_proxy_address_with_deadline(deadline: std::time::Instant) -> Option<String> {
     #[cfg(target_os = "windows")]
     {
+        let _ = deadline;
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         let path = "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings";
         if let Ok(key) = hkcu.open_subkey(path) {
@@ -767,7 +906,7 @@ pub fn get_sys_proxy_address() -> Option<String> {
             if enable == 1 {
                 if let Ok(server) = key.get_value::<String, _>("ProxyServer") {
                     if !server.is_empty() {
-                        if server.contains("://") {
+                        if server.contains("://") || server.contains('=') {
                             return Some(server);
                         }
                         return Some(format!("http://{server}"));
@@ -779,12 +918,25 @@ pub fn get_sys_proxy_address() -> Option<String> {
     }
     #[cfg(target_os = "macos")]
     {
-        let services = get_network_services();
+        let rem = deadline.saturating_duration_since(std::time::Instant::now());
+        if rem < std::time::Duration::from_millis(50) {
+            return None;
+        }
+        let services = get_network_services_bounded(std::time::Duration::from_millis(800).min(rem));
         for service in services {
-            if let Ok(output) = Command::new("networksetup")
-                .args(["-getwebproxy", &service])
-                .output()
-            {
+            let rem_loop = deadline.saturating_duration_since(std::time::Instant::now());
+            if rem_loop < std::time::Duration::from_millis(50) {
+                break;
+            }
+            let parse_proxy = |proto: &str| -> Option<(String, String)> {
+                let rem_cmd = deadline.saturating_duration_since(std::time::Instant::now());
+                if rem_cmd < std::time::Duration::from_millis(50) {
+                    return None;
+                }
+                let mut cmd = Command::new("networksetup");
+                cmd.args([proto, &service]);
+                let output =
+                    run_cmd_bounded(cmd, std::time::Duration::from_millis(800).min(rem_cmd))?;
                 let text = String::from_utf8_lossy(&output.stdout);
                 let mut enabled = false;
                 let mut host = String::new();
@@ -792,95 +944,213 @@ pub fn get_sys_proxy_address() -> Option<String> {
 
                 for line in text.lines() {
                     let trimmed = line.trim();
-                    if trimmed.starts_with("Enabled:") {
-                        enabled = trimmed.contains("Yes");
-                    } else if trimmed.starts_with("Server:") {
-                        host = trimmed.split(':').nth(1).unwrap_or("").trim().to_owned();
-                    } else if trimmed.starts_with("Port:") {
-                        port = trimmed.split(':').nth(1).unwrap_or("").trim().to_owned();
+                    if let Some((key, val)) = trimmed.split_once(':') {
+                        let k = key.trim();
+                        let v = val.trim();
+                        if k.eq_ignore_ascii_case("Enabled") {
+                            enabled = v.contains("Yes");
+                        } else if k.eq_ignore_ascii_case("Server") {
+                            if v.parse::<std::net::Ipv6Addr>().is_ok() {
+                                host = format!("[{v}]");
+                            } else {
+                                host = v.to_owned();
+                            }
+                        } else if k.eq_ignore_ascii_case("Port") {
+                            port = v.to_owned();
+                        }
                     }
                 }
 
-                if enabled && !host.is_empty() && !port.is_empty() {
-                    return Some(format!("http://{host}:{port}"));
+                if enabled && !host.is_empty() && !port.is_empty() && port != "0" {
+                    Some((host, port))
+                } else {
+                    None
                 }
+            };
+
+            let mut parts = Vec::new();
+            if let Some((h, p)) = parse_proxy("-getwebproxy") {
+                parts.push(format!("http={h}:{p}"));
+            }
+            if let Some((h, p)) = parse_proxy("-getsecurewebproxy") {
+                parts.push(format!("https={h}:{p}"));
+            }
+            if let Some((h, p)) = parse_proxy("-getsocksfirewallproxy") {
+                parts.push(format!("socks={h}:{p}"));
+            }
+
+            if !parts.is_empty() {
+                return Some(parts.join(";"));
             }
         }
         None
     }
     #[cfg(target_os = "linux")]
     {
-        if has_gnome() {
-            if let Ok(output) = Command::new("gsettings")
-                .args(["get", "org.gnome.system.proxy", "mode"])
-                .output()
-            {
-                let mode = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-                if mode == "'manual'" {
-                    if let Ok(host_output) = Command::new("gsettings")
-                        .args(["get", "org.gnome.system.proxy.http", "host"])
-                        .output()
-                    {
-                        let host = String::from_utf8_lossy(&host_output.stdout)
-                            .trim()
-                            .trim_matches('\'')
-                            .to_owned();
-                        if !host.is_empty() {
-                            if let Ok(port_output) = Command::new("gsettings")
-                                .args(["get", "org.gnome.system.proxy.http", "port"])
-                                .output()
-                            {
-                                let port = String::from_utf8_lossy(&port_output.stdout)
+        let mut all_parts = Vec::new();
+
+        let rem_gnome = deadline.saturating_duration_since(std::time::Instant::now());
+        if rem_gnome >= std::time::Duration::from_millis(50)
+            && has_gnome_bounded(std::time::Duration::from_millis(800).min(rem_gnome))
+        {
+            let rem_cmd = deadline.saturating_duration_since(std::time::Instant::now());
+            if rem_cmd >= std::time::Duration::from_millis(50) {
+                let mut m_cmd = Command::new("gsettings");
+                m_cmd.args(["get", "org.gnome.system.proxy", "mode"]);
+                if let Some(output) =
+                    run_cmd_bounded(m_cmd, std::time::Duration::from_millis(800).min(rem_cmd))
+                {
+                    let mode = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+                    if mode == "'manual'" {
+                        let mut check_gnome_proxy = |schema: &str, tag: &str| {
+                            let rem = deadline.saturating_duration_since(std::time::Instant::now());
+                            if rem < std::time::Duration::from_millis(50) {
+                                return;
+                            }
+                            let mut h_cmd = Command::new("gsettings");
+                            h_cmd.args(["get", schema, "host"]);
+                            if let Some(host_output) = run_cmd_bounded(
+                                h_cmd,
+                                std::time::Duration::from_millis(800).min(rem),
+                            ) {
+                                let raw_host = String::from_utf8_lossy(&host_output.stdout)
                                     .trim()
                                     .trim_matches('\'')
                                     .to_owned();
-                                if !port.is_empty() {
-                                    return Some(format!("http://{host}:{port}"));
+                                if !raw_host.is_empty() {
+                                    let host = if raw_host.parse::<std::net::Ipv6Addr>().is_ok() {
+                                        format!("[{raw_host}]")
+                                    } else {
+                                        raw_host
+                                    };
+                                    let rem_p = deadline
+                                        .saturating_duration_since(std::time::Instant::now());
+                                    if rem_p < std::time::Duration::from_millis(50) {
+                                        return;
+                                    }
+                                    let mut p_cmd = Command::new("gsettings");
+                                    p_cmd.args(["get", schema, "port"]);
+                                    if let Some(port_output) = run_cmd_bounded(
+                                        p_cmd,
+                                        std::time::Duration::from_millis(800).min(rem_p),
+                                    ) {
+                                        let raw_port = String::from_utf8_lossy(&port_output.stdout);
+                                        let port_str = raw_port
+                                            .split_whitespace()
+                                            .last()
+                                            .unwrap_or("")
+                                            .trim_matches('\'');
+                                        if let Ok(port_num) = port_str.parse::<u16>() {
+                                            if port_num > 0 {
+                                                push_normalized_proxy_part(
+                                                    &mut all_parts,
+                                                    &format!("{host}:{port_num}"),
+                                                    tag,
+                                                );
+                                            }
+                                        }
+                                    }
                                 }
                             }
+                        };
+
+                        check_gnome_proxy("org.gnome.system.proxy.http", "http");
+                        check_gnome_proxy("org.gnome.system.proxy.https", "https");
+                        check_gnome_proxy("org.gnome.system.proxy.socks", "socks");
+                    }
+                }
+            }
+        }
+
+        let rem_kde = deadline.saturating_duration_since(std::time::Instant::now());
+        if rem_kde >= std::time::Duration::from_millis(50) {
+            if let Some((_, kread_cmd)) =
+                get_kde_cmd_bounded(std::time::Duration::from_millis(800).min(rem_kde))
+            {
+                let rem_cmd = deadline.saturating_duration_since(std::time::Instant::now());
+                if rem_cmd >= std::time::Duration::from_millis(50) {
+                    let mut k_cmd = Command::new(kread_cmd);
+                    k_cmd.args([
+                        "--file",
+                        "kioslaverc",
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                    ]);
+                    if let Some(output) =
+                        run_cmd_bounded(k_cmd, std::time::Duration::from_millis(800).min(rem_cmd))
+                    {
+                        let ptype = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+                        if ptype == "1" {
+                            let mut check_kde_proxy = |key: &str, tag: &str| {
+                                let rem =
+                                    deadline.saturating_duration_since(std::time::Instant::now());
+                                if rem < std::time::Duration::from_millis(50) {
+                                    return;
+                                }
+                                let mut cmd = Command::new(kread_cmd);
+                                cmd.args([
+                                    "--file",
+                                    "kioslaverc",
+                                    "--group",
+                                    "Proxy Settings",
+                                    "--key",
+                                    key,
+                                ]);
+                                if let Some(proxy_output) = run_cmd_bounded(
+                                    cmd,
+                                    std::time::Duration::from_millis(800).min(rem),
+                                ) {
+                                    let raw_proxy = String::from_utf8_lossy(&proxy_output.stdout);
+                                    let trimmed = raw_proxy.trim();
+                                    let normalized = match trimmed.rsplit_once(' ') {
+                                        Some((head, tail))
+                                            if tail.parse::<u16>().is_ok() && !head.is_empty() =>
+                                        {
+                                            format!("{}:{tail}", head.trim_end())
+                                        }
+                                        _ => trimmed.to_owned(),
+                                    };
+                                    push_normalized_proxy_part(&mut all_parts, &normalized, tag);
+                                }
+                            };
+
+                            check_kde_proxy("httpProxy", "http");
+                            check_kde_proxy("httpsProxy", "https");
+                            check_kde_proxy("socksProxy", "socks");
                         }
                     }
                 }
             }
         }
 
-        if let Some((_, kread_cmd)) = get_kde_cmd() {
-            if let Ok(output) = Command::new(kread_cmd)
-                .args([
-                    "--file",
-                    "kioslaverc",
-                    "--group",
-                    "Proxy Settings",
-                    "--key",
-                    "ProxyType",
-                ])
-                .output()
-            {
-                let ptype = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-                if ptype == "1" {
-                    if let Ok(proxy_output) = Command::new(kread_cmd)
-                        .args([
-                            "--file",
-                            "kioslaverc",
-                            "--group",
-                            "Proxy Settings",
-                            "--key",
-                            "httpProxy",
-                        ])
-                        .output()
-                    {
-                        let proxy = String::from_utf8_lossy(&proxy_output.stdout)
-                            .trim()
-                            .to_owned();
-                        if !proxy.is_empty() {
-                            if proxy.starts_with("http://") || proxy.starts_with("https://") {
-                                return Some(proxy);
-                            }
-                            return Some(format!("http://{proxy}"));
-                        }
-                    }
+        let rem_xfce = deadline.saturating_duration_since(std::time::Instant::now());
+        if rem_xfce >= std::time::Duration::from_millis(50)
+            && has_xfce_bounded(std::time::Duration::from_millis(800).min(rem_xfce))
+        {
+            let mut check_xfce_proxy = |prop: &str, tag: &str| {
+                let rem = deadline.saturating_duration_since(std::time::Instant::now());
+                if rem < std::time::Duration::from_millis(50) {
+                    return;
                 }
-            }
+                let mut cmd = Command::new("xfconf-query");
+                cmd.args(["-c", "xfce4-session", "-p", prop]);
+                if let Some(output) =
+                    run_cmd_bounded(cmd, std::time::Duration::from_millis(800).min(rem))
+                {
+                    let raw = String::from_utf8_lossy(&output.stdout);
+                    push_normalized_proxy_part(&mut all_parts, &raw, tag);
+                }
+            };
+
+            check_xfce_proxy("/proxies/HTTP", "http");
+            check_xfce_proxy("/proxies/HTTPS", "https");
+            check_xfce_proxy("/proxies/SOCKS", "socks");
+        }
+
+        if !all_parts.is_empty() {
+            return Some(all_parts.join(";"));
         }
 
         None
@@ -1061,5 +1331,28 @@ mod tests {
         assert!(parse_host_port("[::1]").is_err());
         assert!(parse_host_port("[::1]:").is_err());
         assert!(parse_host_port("[::1]:abc").is_err());
+    }
+
+    #[test]
+    fn test_push_normalized_proxy_part() {
+        let mut parts = Vec::new();
+        push_normalized_proxy_part(&mut parts, "127.0.0.1:7890", "http");
+        assert_eq!(parts, vec!["http=127.0.0.1:7890"]);
+
+        parts.clear();
+        push_normalized_proxy_part(&mut parts, "socks://127.0.0.1:1080", "socks");
+        assert_eq!(parts, vec!["socks=socks5://127.0.0.1:1080"]);
+
+        parts.clear();
+        push_normalized_proxy_part(&mut parts, "127.0.0.1:0", "http");
+        assert!(parts.is_empty());
+
+        parts.clear();
+        push_normalized_proxy_part(&mut parts, "false", "http");
+        assert!(parts.is_empty());
+
+        parts.clear();
+        push_normalized_proxy_part(&mut parts, "http=127.0.0.1:7890", "ignored");
+        assert_eq!(parts, vec!["http=127.0.0.1:7890"]);
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -27,11 +27,13 @@ pub use sanitizer::{
     sanitize_config_file_name, url_decode_complete, validate_path_within_dir,
 };
 pub use subscription::{
-    classify_sub_error, extract_name_from_rules, is_private_host, is_private_ip,
-    parse_content_disposition_filename, percent_decode, quote_short_id_values,
-    redact_url_in_string, try_decode_base64_content, validate_public_host_addrs,
-    validate_subscription_name, validate_subscription_url_with_ip, BatchUpdateItem,
-    BatchUpdateResult, MAX_RESPONSE_SIZE,
+    classify_sub_error, collect_ambient_proxy_urls_for_scheme, extract_name_from_rules,
+    is_destination_in_no_proxy, is_host_in_no_proxy, is_private_host, is_private_ip,
+    matches_no_proxy_rules, matches_no_proxy_rules_with_port, parse_content_disposition_filename,
+    percent_decode, quote_short_id_values, redact_url_in_string, try_decode_base64_content,
+    validate_ambient_proxy_url, validate_ambient_proxy_url_for_scheme, validate_public_host_addrs,
+    validate_subscription_name, validate_subscription_url_basic, validate_subscription_url_with_ip,
+    BatchUpdateItem, BatchUpdateResult, PublicHostAddrError, MAX_RESPONSE_SIZE,
 };
 pub use types::{
     AppPaths, ConfigInfo, ConfigMetadata, NetworkOptimStatus, ProfilesMetadata, ReadLogResult,

--- a/crates/core/src/config/subscription.rs
+++ b/crates/core/src/config/subscription.rs
@@ -216,11 +216,19 @@ pub fn is_private_host(host: &str) -> bool {
     if host_lower == "localhost"
         || host_lower.ends_with(".localhost")
         || host_lower.ends_with(".local")
+        || host_lower.ends_with(".internal")
+        || host_lower.ends_with(".lan")
+        || host_lower.ends_with(".home.arpa")
     {
         return true;
     }
 
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    let unbracketed = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = unbracketed.parse::<IpAddr>() {
         return is_private_ip(ip);
     }
 
@@ -237,21 +245,42 @@ pub fn validate_subscription_name(name: &str) -> Result<String, crate::error::Ap
     crate::config::sanitizer::sanitize_base_filename(name.to_owned())
 }
 
+/// Dedicated error type for public host address validation, distinguishing SSRF policy blocks
+/// from transient or empty DNS lookup results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublicHostAddrError {
+    SsrfBlocked(String),
+    NoAddresses(String),
+    Other(String),
+}
+
+impl std::fmt::Display for PublicHostAddrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SsrfBlocked(msg) | Self::NoAddresses(msg) | Self::Other(msg) => {
+                write!(f, "{msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PublicHostAddrError {}
+
 /// Core validation logic for a public host's resolved addresses.
 /// Extracted so tests can inject mock DNS results without real DNS.
 pub fn validate_public_host_addrs(
     host: &str,
     addrs: &[std::net::SocketAddr],
-) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+) -> Result<(String, Option<std::net::SocketAddr>, bool), PublicHostAddrError> {
     let mut resolved_addr = None;
 
     for addr in addrs {
         if is_private_ip(addr.ip()) {
-            return Err(format!(
-                "SSRF protection: host '{}' resolved to private IP {} — access to private/local addresses is not allowed. \
+            return Err(PublicHostAddrError::SsrfBlocked(format!(
+                "SSRF protection: host '{host}' resolved to private IP {} — access to private/local addresses is not allowed. \
                  If this is a trusted internal subscription, enter the private address directly (e.g. http://192.168.x.x) instead of using a domain name.",
-                host, addr.ip()
-            ));
+                addr.ip()
+            )));
         }
         if resolved_addr.is_none() {
             resolved_addr = Some(*addr);
@@ -259,17 +288,17 @@ pub fn validate_public_host_addrs(
     }
 
     if resolved_addr.is_none() {
-        return Err("Could not resolve any IP address for the host".to_owned());
+        return Err(PublicHostAddrError::NoAddresses(
+            "Could not resolve any IP address for the host".to_owned(),
+        ));
     }
 
     Ok((host.to_owned(), resolved_addr, false))
 }
 
-/// Validate URL and its resolved IPs for SSRF protection.
-/// Returns `(host, resolved_addr, user_entered_private)`.
-pub fn validate_subscription_url_with_ip(
-    url: &str,
-) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+/// Validate URL scheme, host, and port without DNS resolution.
+/// Returns `(host, port, user_entered_private)`.
+pub fn validate_subscription_url_basic(url: &str) -> Result<(String, u16, bool), String> {
     let parsed_url = url::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
 
     let scheme = parsed_url.scheme();
@@ -281,17 +310,437 @@ pub fn validate_subscription_url_with_ip(
 
     let user_entered_private = is_private_host(host);
 
-    if user_entered_private {
-        return Ok((host.to_owned(), None, true));
+    let default_port = if scheme == "https" { 443 } else { 80 };
+    let port = parsed_url.port().unwrap_or(default_port);
+
+    Ok((host.to_owned(), port, user_entered_private))
+}
+
+/// Validate an ambient environment or system proxy URL.
+/// Security: Only permit local loopback proxies (`127.0.0.1` / `localhost` / `::1`)
+/// and reject cleartext credentialed `http://` proxies to prevent SSRF and credential leaks.
+/// Also supports semicolon/whitespace-separated entries and scheme-prefixed entries
+/// commonly found in Windows/macOS/Linux system proxy configurations (e.g. `http=127.0.0.1:7890;https=...`).
+#[must_use]
+pub fn validate_ambient_proxy_url(raw: &str) -> Option<String> {
+    validate_ambient_proxy_url_for_scheme(raw, None)
+}
+
+struct AmbientCandidate {
+    tag: Option<String>,
+    url: String,
+}
+
+fn parse_assignment_tag(s: &str) -> Option<(&str, &str)> {
+    let (raw_prefix, rest) = s.split_once('=')?;
+    let prefix = raw_prefix.trim();
+    (!prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_alphanumeric()))
+        .then(|| (prefix, rest.trim()))
+}
+
+fn map_protocol_tag(prefix: &str) -> Option<(Option<String>, &'static str)> {
+    let p_lower = prefix.to_ascii_lowercase();
+    match p_lower.as_str() {
+        "socks" | "socks5" => Some((Some("socks".to_owned()), "socks5")),
+        "socks5h" => Some((Some("socks".to_owned()), "socks5h")),
+        "socks4" => Some((Some("socks".to_owned()), "socks4")),
+        "socks4a" => Some((Some("socks".to_owned()), "socks4a")),
+        "https" => Some((Some("https".to_owned()), "http")),
+        "http" => Some((Some("http".to_owned()), "http")),
+        "all" => Some((Some("all".to_owned()), "http")),
+        _ => None,
+    }
+}
+
+fn parse_ambient_proxy_segment(segment: &str) -> Option<AmbientCandidate> {
+    let mut seg = segment.trim();
+    if seg.is_empty() {
+        return None;
     }
 
-    let default_port = if scheme == "https" { 443 } else { 80 };
+    // Strip extraneous "http://" or "https://" prefix if followed by a recognized scheme assignment
+    // (e.g. "http://http=127.0.0.1:7890"), while preserving valid authenticated URLs
+    // (e.g. "https://user:p=ss@127.0.0.1:8443").
+    if let Some(rest) = seg
+        .strip_prefix("http://")
+        .or_else(|| seg.strip_prefix("https://"))
+    {
+        if let Some((prefix, _)) = parse_assignment_tag(rest) {
+            if map_protocol_tag(prefix).is_some() {
+                seg = rest;
+            }
+        }
+    }
+
+    // Handle leading scheme assignment prefixes like "http=host:port", "socks=...", "all=..."
+    let (tag, default_scheme, inner) = if let Some((prefix, remainder)) = parse_assignment_tag(seg)
+    {
+        if let Some((mapped_tag, default_scheme)) = map_protocol_tag(prefix) {
+            (mapped_tag, default_scheme, remainder)
+        } else {
+            // Explicit protocol key that is unsupported for HTTP/SOCKS proxies (e.g. "ftp=")
+            return None;
+        }
+    } else {
+        (None, "http", seg)
+    };
+
+    let candidate = if let Some(rest) = inner.strip_prefix("socks://") {
+        format!("socks5://{rest}")
+    } else if inner.contains("://") {
+        inner.to_owned()
+    } else {
+        format!("{default_scheme}://{inner}")
+    };
+
+    let parsed = url::Url::parse(&candidate).ok()?;
+    if !matches!(
+        parsed.scheme(),
+        "http" | "https" | "socks4" | "socks4a" | "socks5" | "socks5h"
+    ) {
+        return None;
+    }
+    let is_loopback = parsed.host_str().is_some_and(|h| {
+        if h.eq_ignore_ascii_case("localhost") {
+            return true;
+        }
+        let unbracketed = h.trim_start_matches('[').trim_end_matches(']');
+        if let Ok(ip) = unbracketed.parse::<std::net::IpAddr>() {
+            ip.is_loopback()
+        } else {
+            false
+        }
+    });
+    if !is_loopback {
+        return None;
+    }
+    if parsed.port() == Some(0) {
+        return None;
+    }
+    let has_credentials = !parsed.username().is_empty() || parsed.password().is_some();
+    if has_credentials && parsed.scheme() == "http" {
+        return None;
+    }
+
+    Some(AmbientCandidate {
+        tag,
+        url: candidate,
+    })
+}
+
+/// Split ambient/system proxy configuration into candidate segments.
+/// Standalone URLs with semicolons in credentials (e.g. `user:p;ss@127.0.0.1:8443`) are
+/// preserved without incorrect splitting.
+fn split_ambient_proxy_segments(raw: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+
+    for (i, &b) in raw.as_bytes().iter().enumerate() {
+        if b == b'\n' || b == b'\r' {
+            if let Some(raw_part) = raw.get(start..i) {
+                let part = raw_part.trim();
+                if !part.is_empty() {
+                    segments.push(part);
+                }
+            }
+            start = i.saturating_add(1);
+        } else if b == b';' || b == b' ' {
+            let remainder = raw.get(i.saturating_add(1)..).unwrap_or("").trim_start();
+            let has_scheme_or_tag = [
+                "http", "https", "socks", "socks4", "socks4a", "socks5", "socks5h",
+            ]
+            .iter()
+            .any(|tag| {
+                remainder
+                    .strip_prefix(tag)
+                    .is_some_and(|rest| rest.starts_with('=') || rest.starts_with("://"))
+            });
+            let has_host_prefix = remainder.starts_with("localhost:")
+                || remainder
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit() || c == '[');
+
+            let is_separator = if b == b' ' {
+                !remainder.is_empty() && (has_scheme_or_tag || has_host_prefix)
+            } else {
+                let delims = [
+                    remainder.find(';'),
+                    remainder.find(' '),
+                    remainder.find('\n'),
+                    remainder.find('\r'),
+                ];
+                let next_delim = delims
+                    .into_iter()
+                    .flatten()
+                    .min()
+                    .unwrap_or(remainder.len());
+                let segment_ahead = remainder.get(..next_delim).unwrap_or(remainder);
+                let in_userinfo = segment_ahead.contains('@') && !segment_ahead.contains("://");
+                !in_userinfo && (has_scheme_or_tag || has_host_prefix)
+            };
+
+            if is_separator {
+                if let Some(raw_part) = raw.get(start..i) {
+                    let part = raw_part.trim();
+                    if !part.is_empty() {
+                        segments.push(part);
+                    }
+                }
+                start = i.saturating_add(1);
+            }
+        }
+    }
+
+    if let Some(raw_tail) = raw.get(start..) {
+        let tail = raw_tail.trim();
+        if !tail.is_empty() {
+            segments.push(tail);
+        }
+    }
+
+    segments
+}
+
+/// Validate an ambient environment or system proxy configuration, returning all valid loopback proxy candidates
+/// ordered by priority for the specified destination scheme.
+#[must_use]
+pub fn collect_ambient_proxy_urls_for_scheme(
+    raw: &str,
+    target_scheme: Option<&str>,
+) -> Vec<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    let segments = split_ambient_proxy_segments(trimmed);
+    let candidates: Vec<AmbientCandidate> = if segments.len() <= 1 {
+        parse_ambient_proxy_segment(trimmed)
+            .or_else(|| {
+                segments
+                    .first()
+                    .copied()
+                    .and_then(parse_ambient_proxy_segment)
+            })
+            .into_iter()
+            .collect()
+    } else {
+        segments
+            .into_iter()
+            .filter_map(parse_ambient_proxy_segment)
+            .collect()
+    };
+
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let mut push_dedup = |u: &str| {
+        if seen.insert(u.to_owned()) {
+            result.push(u.to_owned());
+        }
+    };
+
+    if let Some(target) = target_scheme {
+        let t_lower = target.to_ascii_lowercase();
+        // 1. Direct scheme match (e.g. tag == "https" when requesting HTTPS)
+        for c in candidates
+            .iter()
+            .filter(|c| c.tag.as_deref() == Some(&t_lower))
+        {
+            push_dedup(&c.url);
+        }
+        // 2. "all" match
+        for c in candidates
+            .iter()
+            .filter(|c| c.tag.as_deref() == Some("all"))
+        {
+            push_dedup(&c.url);
+        }
+        // 3. "socks" match
+        for c in candidates
+            .iter()
+            .filter(|c| c.tag.as_deref() == Some("socks"))
+        {
+            push_dedup(&c.url);
+        }
+        // 4. Unprefixed candidate
+        for c in candidates.iter().filter(|c| c.tag.is_none()) {
+            push_dedup(&c.url);
+        }
+    }
+
+    // 5. Any remaining candidates in discovery order
+    for c in &candidates {
+        push_dedup(&c.url);
+    }
+
+    result
+}
+
+/// Validate an ambient environment or system proxy URL, selecting candidate matching an optional destination scheme.
+#[must_use]
+pub fn validate_ambient_proxy_url_for_scheme(
+    raw: &str,
+    target_scheme: Option<&str>,
+) -> Option<String> {
+    collect_ambient_proxy_urls_for_scheme(raw, target_scheme)
+        .into_iter()
+        .next()
+}
+
+fn matches_cidr(host_ip: IpAddr, pat: &str) -> bool {
+    let Some((ip_str, prefix_str)) = pat.split_once('/') else {
+        return false;
+    };
+    let Ok(prefix_len) = prefix_str.trim().parse::<u32>() else {
+        return false;
+    };
+    match (
+        host_ip,
+        ip_str
+            .trim()
+            .trim_matches('[')
+            .trim_matches(']')
+            .parse::<IpAddr>(),
+    ) {
+        (IpAddr::V4(target), Ok(IpAddr::V4(net))) => {
+            if prefix_len > 32 {
+                return false;
+            }
+            let mask = !((!0u32).checked_shr(prefix_len).unwrap_or(0));
+            (u32::from(target) & mask) == (u32::from(net) & mask)
+        }
+        (IpAddr::V6(target), Ok(IpAddr::V6(net))) => {
+            if prefix_len > 128 {
+                return false;
+            }
+            let mask = !((!0u128).checked_shr(prefix_len).unwrap_or(0));
+            (u128::from(target) & mask) == (u128::from(net) & mask)
+        }
+        _ => false,
+    }
+}
+
+/// Check if a host and optional port match a `NO_PROXY` rule list.
+#[must_use]
+pub fn matches_no_proxy_rules_with_port(host: &str, port: Option<u16>, no_proxy_val: &str) -> bool {
+    if no_proxy_val.is_empty() {
+        return false;
+    }
+    let trimmed_host = host.trim().trim_matches('[').trim_matches(']');
+    if trimmed_host.is_empty() {
+        return false;
+    }
+    let host_ip = trimmed_host.parse::<IpAddr>().ok();
+    for raw_pat in no_proxy_val.split(|c: char| c == ',' || c.is_ascii_whitespace()) {
+        let pat = raw_pat.trim();
+        if pat.is_empty() {
+            continue;
+        }
+
+        if let Some(ip) = host_ip {
+            if pat.contains('/') && matches_cidr(ip, pat) {
+                return true;
+            }
+        }
+
+        let (pat_host, pat_port) = if pat.parse::<std::net::Ipv6Addr>().is_ok() {
+            (pat, None)
+        } else if let Some((h, p)) = pat.rsplit_once(':') {
+            if let Ok(parsed_port) = p.parse::<u16>() {
+                (h.trim_matches('[').trim_matches(']'), Some(parsed_port))
+            } else {
+                (pat.trim_matches('[').trim_matches(']'), None)
+            }
+        } else {
+            (pat.trim_matches('[').trim_matches(']'), None)
+        };
+
+        if pat_host.is_empty() {
+            continue;
+        }
+
+        if let Some(rule_port) = pat_port {
+            if port != Some(rule_port) {
+                continue;
+            }
+        }
+
+        if pat_host == "*" {
+            return true;
+        }
+        if trimmed_host.eq_ignore_ascii_case(pat_host) {
+            return true;
+        }
+        let domain_suffix = pat_host
+            .strip_prefix("*.")
+            .or_else(|| pat_host.strip_prefix('.'))
+            .unwrap_or(pat_host);
+        if trimmed_host.len() > domain_suffix.len()
+            && trimmed_host
+                .to_ascii_lowercase()
+                .ends_with(&domain_suffix.to_ascii_lowercase())
+            && trimmed_host
+                .as_bytes()
+                .get(trimmed_host.len() - domain_suffix.len() - 1)
+                == Some(&b'.')
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if a host matches a `NO_PROXY` rule list.
+#[must_use]
+pub fn matches_no_proxy_rules(host: &str, no_proxy_val: &str) -> bool {
+    matches_no_proxy_rules_with_port(host, None, no_proxy_val)
+}
+
+/// Check if a host and optional port match the current process environment `NO_PROXY` / `no_proxy` setting.
+#[must_use]
+pub fn is_destination_in_no_proxy(host: &str, port: Option<u16>) -> bool {
+    if let Ok(val_upper) = std::env::var("NO_PROXY") {
+        if matches_no_proxy_rules_with_port(host, port, &val_upper) {
+            return true;
+        }
+    }
+    if let Ok(val_lower) = std::env::var("no_proxy") {
+        if matches_no_proxy_rules_with_port(host, port, &val_lower) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if a host matches the current process environment `NO_PROXY` / `no_proxy` setting.
+#[must_use]
+pub fn is_host_in_no_proxy(host: &str) -> bool {
+    is_destination_in_no_proxy(host, None)
+}
+
+/// Validate URL and its resolved IPs for SSRF protection.
+/// Returns `(host, resolved_addr, user_entered_private)`.
+pub fn validate_subscription_url_with_ip(
+    url: &str,
+) -> Result<(String, Option<std::net::SocketAddr>, bool), String> {
+    let (host, port, user_entered_private) = validate_subscription_url_basic(url)?;
+
+    if user_entered_private {
+        return Ok((host, None, true));
+    }
+
     let addrs: Vec<std::net::SocketAddr> =
-        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{default_port}"))
+        std::net::ToSocketAddrs::to_socket_addrs(&format!("{host}:{port}"))
             .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
             .collect();
 
-    validate_public_host_addrs(host, &addrs)
+    validate_public_host_addrs(&host, &addrs).map_err(|e| e.to_string())
 }
 
 /// Determine the appropriate error code based on the error message content.
@@ -422,6 +871,104 @@ pub struct BatchUpdateItem {
     pub name: String,
 }
 
+/// 从 mihomo /proxies 返回的字典中提取全局模式候选节点及当前 GLOBAL 选中项。
+/// 纯函数，便于独立单元测试。
+pub fn select_global_candidate(
+    proxies: &serde_json::Map<String, serde_json::Value>,
+) -> Option<(String, Option<String>)> {
+    let global_obj = proxies.get("GLOBAL");
+    let global_now = global_obj
+        .and_then(|g| g.get("now"))
+        .and_then(|n| n.as_str())
+        .map(std::borrow::ToOwned::to_owned);
+
+    let is_special_target = |s: &str| {
+        matches!(
+            s,
+            "DIRECT" | "REJECT" | "REJECT-DROP" | "PASS" | "PASS-RULE" | "COMPATIBLE"
+        )
+    };
+
+    let global_all: Vec<&str> = global_obj
+        .and_then(|g| g.get("all"))
+        .and_then(|a| a.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    // 递归解析候选节点/策略组，确保最终生效的叶子节点存在于 proxies 中且不是 DIRECT / REJECT 等特殊目标。
+    // 递归深度限制为 8 层以防止配置中存在循环依赖。
+    let resolves_to_effective_proxy = |start_name: &str| -> bool {
+        let mut curr = start_name;
+        for _ in 0..8 {
+            if is_special_target(curr) {
+                return false;
+            }
+            if let Some(p_obj) = proxies.get(curr) {
+                let p_type = p_obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if p_type.eq_ignore_ascii_case("Selector")
+                    || p_type.eq_ignore_ascii_case("URLTest")
+                    || p_type.eq_ignore_ascii_case("Fallback")
+                {
+                    if let Some(next_now) = p_obj.get("now").and_then(|n| n.as_str()) {
+                        curr = next_now;
+                        continue;
+                    }
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+        false
+    };
+
+    let is_valid_global_candidate = |s: &str| {
+        !global_all.is_empty() && global_all.contains(&s) && resolves_to_effective_proxy(s)
+    };
+
+    let active_node = global_now
+        .as_deref()
+        .filter(|n| is_valid_global_candidate(n))
+        .map(std::borrow::ToOwned::to_owned)
+        .or_else(|| {
+            // Priority 1: Check active `now` of common selector/urltest/fallback groups.
+            // If the group's `now` is in GLOBAL.all and resolves to a real proxy, prefer it.
+            // If not, but the group itself is in GLOBAL.all and resolves to a real proxy, use the group name.
+            for (name, proxy_val) in proxies {
+                if name == "GLOBAL" || is_special_target(name) {
+                    continue;
+                }
+                let p_type = proxy_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if p_type.eq_ignore_ascii_case("Selector")
+                    || p_type.eq_ignore_ascii_case("URLTest")
+                    || p_type.eq_ignore_ascii_case("Fallback")
+                {
+                    if let Some(now) = proxy_val.get("now").and_then(|n| n.as_str()) {
+                        if is_valid_global_candidate(now) {
+                            return Some(now.to_owned());
+                        }
+                    }
+                    if is_valid_global_candidate(name) {
+                        return Some(name.clone());
+                    }
+                }
+            }
+
+            // Priority 2: Look through GLOBAL's member list `all` for the first valid candidate.
+            // This ensures the chosen node or group is recognized as a valid GLOBAL member
+            // by Mihomo's PUT /proxies/GLOBAL API and actually routes through an active proxy.
+            for &member_name in &global_all {
+                if is_valid_global_candidate(member_name) {
+                    return Some(member_name.to_owned());
+                }
+            }
+
+            None
+        })?;
+
+    Some((active_node, global_now))
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -453,12 +1000,22 @@ mod tests {
         assert!(is_private_host("localhost"));
         assert!(is_private_host("my.localhost"));
         assert!(is_private_host("my.local"));
+        assert!(is_private_host("service.internal"));
+        assert!(is_private_host("router.lan"));
+        assert!(is_private_host("device.home.arpa"));
         assert!(is_private_host("127.0.0.1"));
         assert!(is_private_host("10.0.0.1"));
         assert!(is_private_host("192.168.1.1"));
+        assert!(is_private_host("172.16.0.1"));
+        assert!(is_private_host("::1"));
+        assert!(is_private_host("[::1]"));
+        assert!(is_private_host("[fd00::1]"));
+        assert!(is_private_host("[fe80::1]"));
         assert!(!is_private_host("my.test"));
         assert!(!is_private_host("example.com"));
+        assert!(!is_private_host("1.1.1.1"));
         assert!(!is_private_host("8.8.8.8"));
+        assert!(!is_private_host("[2606:4700:4700::1111]"));
     }
 
     #[test]
@@ -516,6 +1073,283 @@ mod tests {
     fn test_validate_invalid_schemes_rejected() {
         assert!(validate_subscription_url_with_ip("ftp://192.168.1.1/sub").is_err());
         assert!(validate_subscription_url_with_ip("file:///etc/passwd").is_err());
+        assert!(validate_subscription_url_basic("ftp://192.168.1.1/sub").is_err());
+        assert!(validate_subscription_url_basic("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_subscription_url_basic_success() {
+        let (host, port, private) =
+            validate_subscription_url_basic("https://blocked-domain.example.com/sub?token=123")
+                .unwrap();
+        assert_eq!(host, "blocked-domain.example.com");
+        assert_eq!(port, 443);
+        assert!(!private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://192.168.1.100:8080/sub").unwrap();
+        assert_eq!(host, "192.168.1.100");
+        assert_eq!(port, 8080);
+        assert!(private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://localhost:9090/sub").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 9090);
+        assert!(private);
+
+        let (host, port, private) =
+            validate_subscription_url_basic("http://[::1]:8080/sub").unwrap();
+        assert_eq!(host, "[::1]");
+        assert_eq!(port, 8080);
+        assert!(private);
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url() {
+        // Valid loopback proxies
+        assert_eq!(
+            validate_ambient_proxy_url("http://127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://localhost:7890"),
+            Some("http://localhost:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://[::1]:7890"),
+            Some("http://[::1]:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://user:pass@127.0.0.1:1080"),
+            Some("socks5://user:pass@127.0.0.1:1080".to_owned())
+        );
+
+        // Multi-scheme and semicolon-separated (common Windows/GNOME proxy formats)
+        assert_eq!(
+            validate_ambient_proxy_url("http=127.0.0.1:7890;https=127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http=proxy.corp.com:8080;socks=127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks=127.0.0.1:1080"),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://http=127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+
+        // Disallowed: Non-loopback IP or external host
+        assert_eq!(validate_ambient_proxy_url("http://192.168.1.1:7890"), None);
+        assert_eq!(validate_ambient_proxy_url("http://10.0.0.1:7890"), None);
+        assert_eq!(
+            validate_ambient_proxy_url("http://proxy.example.com:7890"),
+            None
+        );
+
+        // Disallowed: Cleartext credentials over http://
+        assert_eq!(
+            validate_ambient_proxy_url("http://user:pass@127.0.0.1:7890"),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://user@localhost:7890"),
+            None
+        );
+
+        // Disallowed: Unsupported schemes (e.g. ftp://)
+        assert_eq!(validate_ambient_proxy_url("ftp://127.0.0.1:21"), None);
+        assert_eq!(
+            validate_ambient_proxy_url("ftp://127.0.0.1:21;http://127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_owned())
+        );
+
+        // Disallowed: Empty / whitespace
+        assert_eq!(validate_ambient_proxy_url(""), None);
+        assert_eq!(validate_ambient_proxy_url("   "), None);
+
+        // Scheme-specific ambient proxy selection (e.g. Windows protocol-specific ProxyServer)
+        let multi_proxy = "http=127.0.0.1:8080;https=127.0.0.1:8443;socks=127.0.0.1:1080";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, Some("https")),
+            Some("http://127.0.0.1:8443".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, Some("http")),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(multi_proxy, None),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
+
+        // Fallback to socks when scheme-specific entry is absent
+        let socks_fallback = "ftp=127.0.0.1:21;socks=127.0.0.1:1080";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(socks_fallback, Some("https")),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_ipv6_loopback() {
+        let ipv6_proxy = "http=[::1]:7890;https=[::1]:7890";
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(ipv6_proxy, Some("http")),
+            Some("http://[::1]:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme(ipv6_proxy, Some("https")),
+            Some("http://[::1]:7890".to_owned())
+        );
+        // Test full 127.0.0.0/8 loopback range and localhost
+        assert_eq!(
+            validate_ambient_proxy_url("http://127.0.0.2:7890"),
+            Some("http://127.0.0.2:7890".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("http://localhost:7890"),
+            Some("http://localhost:7890".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_socks_schemes() {
+        // SOCKS prefix variants (socks4, socks4a, socks5, socks5h)
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks4=127.0.0.1:1080", None),
+            Some("socks4://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks4a=127.0.0.1:1081", None),
+            Some("socks4a://127.0.0.1:1081".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks5=127.0.0.1:1082", None),
+            Some("socks5://127.0.0.1:1082".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks5h=127.0.0.1:1083", None),
+            Some("socks5h://127.0.0.1:1083".to_owned())
+        );
+        // Bare socks:// normalized to socks5://
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks=socks://127.0.0.1:1080", None),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("socks://127.0.0.1:1080", None),
+            Some("socks5://127.0.0.1:1080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_unknown_prefixes_rejected() {
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("ftp=127.0.0.1:21", None),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("unknown=127.0.0.1:8080", Some("http")),
+            None
+        );
+        assert_eq!(
+            validate_ambient_proxy_url_for_scheme("ftp=127.0.0.1:21;http=127.0.0.1:8080", None),
+            Some("http://127.0.0.1:8080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_query_param_preserved() {
+        assert_eq!(
+            validate_ambient_proxy_url("http://127.0.0.1:7890/p?token=abc"),
+            Some("http://127.0.0.1:7890/p?token=abc".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_zero_port_rejected() {
+        assert_eq!(validate_ambient_proxy_url("http://127.0.0.1:0"), None);
+        assert_eq!(validate_ambient_proxy_url("socks5://127.0.0.1:0"), None);
+    }
+
+    #[test]
+    fn test_validate_ambient_proxy_url_credentials_with_equals() {
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://user:p=ss@127.0.0.1:1080"),
+            Some("socks5://user:p=ss@127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks5://user:p=ss=word@127.0.0.1:1080"),
+            Some("socks5://user:p=ss=word@127.0.0.1:1080".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("https://user:p=ss@127.0.0.1:8443"),
+            Some("https://user:p=ss@127.0.0.1:8443".to_owned())
+        );
+        assert_eq!(
+            validate_ambient_proxy_url("socks=socks5://user:p=ss@127.0.0.1:1080"),
+            Some("socks5://user:p=ss@127.0.0.1:1080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_collect_ambient_proxy_urls_for_scheme_multiple_candidates() {
+        let multi_proxy = "http=127.0.0.1:8080;https=127.0.0.1:8443;socks=127.0.0.1:1080";
+        let candidates = collect_ambient_proxy_urls_for_scheme(multi_proxy, Some("https"));
+        assert_eq!(
+            candidates,
+            vec![
+                "http://127.0.0.1:8443".to_owned(),
+                "socks5://127.0.0.1:1080".to_owned(),
+                "http://127.0.0.1:8080".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_ambient_proxy_urls_credentials_with_semicolon() {
+        let proxy_with_semicolon = "https://user:p;ss@127.0.0.1:8443";
+        let candidates = collect_ambient_proxy_urls_for_scheme(proxy_with_semicolon, Some("https"));
+        assert_eq!(
+            candidates,
+            vec!["https://user:p;ss@127.0.0.1:8443".to_owned()]
+        );
+
+        let multi = "https=https://user:p;ss@127.0.0.1:7890;http=127.0.0.1:8443";
+        let candidates_multi = collect_ambient_proxy_urls_for_scheme(multi, Some("https"));
+        assert_eq!(
+            candidates_multi,
+            vec![
+                "https://user:p;ss@127.0.0.1:7890".to_owned(),
+                "http://127.0.0.1:8443".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_ambient_proxy_urls_with_path_in_multi_entry() {
+        let multi = "http=http://127.0.0.1:7890/sub_proxy;https=127.0.0.1:8443";
+        let candidates = collect_ambient_proxy_urls_for_scheme(multi, Some("http"));
+        assert_eq!(
+            candidates,
+            vec![
+                "http://127.0.0.1:7890/sub_proxy".to_owned(),
+                "http://127.0.0.1:8443".to_owned()
+            ]
+        );
     }
 
     #[test]
@@ -530,7 +1364,10 @@ mod tests {
         let addrs: Vec<std::net::SocketAddr> = vec!["192.168.1.1:80".parse().unwrap()];
         let result = validate_public_host_addrs("attacker.com", &addrs);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("SSRF protection"));
+        assert!(matches!(
+            result.unwrap_err(),
+            PublicHostAddrError::SsrfBlocked(_)
+        ));
     }
 
     #[test]
@@ -597,5 +1434,219 @@ mod tests {
     #[test]
     fn snapshot_redact_url_in_string_no_url() {
         insta::assert_snapshot!(redact_url_in_string("Just a plain message".to_owned()));
+    }
+
+    #[test]
+    fn test_select_global_candidate_special_targets_only() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["DIRECT", "REJECT", "REJECT-DROP", "PASS-RULE"],
+                "now": "PASS-RULE"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_select_global_candidate_cycle_resolution() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["GroupA"],
+                "now": "GroupA"
+            },
+            "GroupA": {
+                "type": "Selector",
+                "now": "GroupB"
+            },
+            "GroupB": {
+                "type": "Selector",
+                "now": "GroupA"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_select_global_candidate_nested_selector() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["ProxyGroup"],
+                "now": "ProxyGroup"
+            },
+            "ProxyGroup": {
+                "type": "Selector",
+                "now": "HK-01"
+            },
+            "HK-01": {
+                "type": "Shadowsocks"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("ProxyGroup".to_owned(), Some("ProxyGroup".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_prefers_active_now_if_in_all() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["HK-01", "US-01"],
+                "now": "DIRECT"
+            },
+            "AutoGroup": {
+                "type": "Selector",
+                "now": "US-01"
+            },
+            "HK-01": {
+                "type": "Vmess"
+            },
+            "US-01": {
+                "type": "Vmess"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("US-01".to_owned(), Some("DIRECT".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_fallback_to_global_all_member() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["DIRECT", "JP-01"],
+                "now": "DIRECT"
+            },
+            "JP-01": {
+                "type": "Trojan"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(
+            select_global_candidate(proxies),
+            Some(("JP-01".to_owned(), Some("DIRECT".to_owned())))
+        );
+    }
+
+    #[test]
+    fn test_select_global_candidate_empty_global_all() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": [],
+                "now": "DIRECT"
+            },
+            "CustomSelector": {
+                "type": "Selector",
+                "now": "Node-A"
+            },
+            "Node-A": {
+                "type": "Shadowsocks"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_select_global_candidate_unknown_leaf_rejected() {
+        let json = serde_json::json!({
+            "GLOBAL": {
+                "all": ["GhostNode"],
+                "now": "GhostNode"
+            }
+        });
+        let proxies = json.as_object().unwrap();
+        assert_eq!(select_global_candidate(proxies), None);
+    }
+
+    #[test]
+    fn test_split_ambient_proxy_segments_with_socks5h() {
+        let raw = "127.0.0.1:7890 socks5h://127.0.0.1:1080 socks4a://127.0.0.1:1081";
+        let segments = split_ambient_proxy_segments(raw);
+        assert_eq!(
+            segments,
+            vec![
+                "127.0.0.1:7890",
+                "socks5h://127.0.0.1:1080",
+                "socks4a://127.0.0.1:1081"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_split_ambient_proxy_segments_with_semicolon_in_query() {
+        let raw = "http://127.0.0.1:7890/?token=a;b;http=http://127.0.0.1:7891";
+        let segments = split_ambient_proxy_segments(raw);
+        assert_eq!(
+            segments,
+            vec![
+                "http://127.0.0.1:7890/?token=a;b",
+                "http=http://127.0.0.1:7891"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_matches_no_proxy_rules() {
+        assert!(matches_no_proxy_rules("example.com", "example.com"));
+        assert!(matches_no_proxy_rules("sub.example.com", "example.com"));
+        assert!(matches_no_proxy_rules("sub.example.com", ".example.com"));
+        assert!(matches_no_proxy_rules("any.domain.com", "*"));
+        assert!(matches_no_proxy_rules("127.0.0.1", "127.0.0.1,localhost"));
+        assert!(matches_no_proxy_rules("localhost", "127.0.0.1,localhost"));
+        assert!(!matches_no_proxy_rules(
+            "other.com",
+            "example.com,localhost"
+        ));
+        assert!(!matches_no_proxy_rules("notexample.com", "example.com"));
+
+        // Whitespace separation and port-qualified rules
+        assert!(matches_no_proxy_rules_with_port(
+            "example.com",
+            Some(443),
+            "example.com:443 other.com:80"
+        ));
+        assert!(!matches_no_proxy_rules_with_port(
+            "example.com",
+            Some(80),
+            "example.com:443 other.com:80"
+        ));
+        assert!(matches_no_proxy_rules_with_port(
+            "sub.example.com",
+            Some(443),
+            "example.com:443"
+        ));
+        assert!(matches_no_proxy_rules_with_port(
+            "127.0.0.1",
+            Some(8080),
+            "127.0.0.1:8080 [::1]:8080"
+        ));
+        assert!(matches_no_proxy_rules_with_port(
+            "::1",
+            Some(8080),
+            "127.0.0.1:8080 [::1]:8080"
+        ));
+
+        // Wildcard rules
+        assert!(matches_no_proxy_rules("sub.example.com", "*.example.com"));
+        assert!(matches_no_proxy_rules(
+            "deep.sub.example.com",
+            "*.example.com"
+        ));
+        assert!(!matches_no_proxy_rules("notexample.com", "*.example.com"));
+
+        // CIDR subnet rules
+        assert!(matches_no_proxy_rules("100.64.0.1", "100.64.0.0/10"));
+        assert!(matches_no_proxy_rules("100.127.255.254", "100.64.0.0/10"));
+        assert!(!matches_no_proxy_rules("100.128.0.1", "100.64.0.0/10"));
+        assert!(!matches_no_proxy_rules("192.168.1.1", "100.64.0.0/10"));
+        assert!(matches_no_proxy_rules("192.168.1.50", "192.168.0.0/16"));
+        assert!(matches_no_proxy_rules("2001:db8::1", "2001:db8::/32"));
+        assert!(!matches_no_proxy_rules("2001:db9::1", "2001:db8::/32"));
     }
 }


### PR DESCRIPTION
## Summary

Enhance subscription download resilience by allowing proxy fallback and Mihomo global mode recovery when subscription domains cannot be resolved or downloaded directly.

### Key Changes
- **Graceful Multi-Tier Download Strategy**:
  - **Tier 1 (Direct)**: Performs direct DNS resolution and HTTP download with DNS pinning and SSRF protection. Bounds concurrent blocking DNS lookups with an owned semaphore permit passed directly into the blocking resolver execution thread, ensuring the permit remains bound to the actual worker execution and prevents stalled resolvers from accumulating background threads beyond the global limit. Makes SSRF validation rejections fatal immediately using a dedicated `PublicHostAddrError` enum (rather than string matching) to prevent malicious loopback/intranet probing through proxy fallbacks, while distinguishing empty/NODATA resolver results from SSRF rejections so proxy fallback proceeds smoothly. Uses an adaptive request timeout: user-entered private/LAN destinations receive a full direct timeout window (up to ten seconds request / four seconds connect); for public destinations when Mihomo is stopped, allocates up to 5500ms request / 2000ms connect to preserve ample headroom for ambient proxies; when Mihomo is running, allocates 3500ms request / 1500ms connect so slow direct endpoints complete or fast-fail on connect (1500ms) and leave ample headroom for subsequent proxy tiers.
  - **Tier 2 (Mihomo Proxy)**: If direct download or direct DNS fails (e.g. DNS poisoned/blocked by local network), retries using the running Mihomo core's mixed-port proxy. Supports macOS root-spawned TUN mode core recognition alongside standard subprocesses via centralized `is_core_running_from_guard` helper.
  - **Tier 3 (Mihomo Global Mode)**: If rule-based proxy routing fails, queries eligible active proxy nodes first. Guards node switching to run only when the original selection is known and differs from the active candidate, ensuring the original state can always be faithfully restored. If a valid node is confirmed, updates the `GLOBAL` group node *prior* to switching mode, preventing routing disruption if node selection fails. Temporarily switches Mihomo to `global` mode and routes through the selected node. Recursively resolves group selections to verify that the effective leaf route is a real proxy node rather than a special target (`DIRECT`, `REJECT`, `PASS-RULE`). Extracted into a dedicated `try_global_mode_tier` helper for clean auditing and scoped lock lifetimes. Re-checks cumulative deadline headroom (enforcing a 4000ms threshold) before mutating core state to avoid wasted operations. Verifies that the recovery marker is durably persisted to disk (flushed and synchronized, with existing destination replacement handled across platforms) before modifying core state, aborting the global mode fallback tier if disk persistence fails.
  - **Tier 4 (Ambient Proxy Fallback)**: If Mihomo is not running or fails, collects an ordered, prioritized queue of all distinct validated loopback ambient proxy candidates from operating system configurations (HTTP, HTTPS, SOCKS) via `collect_ambient_proxy_urls_for_scheme`, followed by environment variables (`HTTPS_PROXY`, `ALL_PROXY`, `HTTP_PROXY`), matching the subscription URL's scheme (HTTP/HTTPS) with explicit fallback to SOCKS, attempting each candidate in priority order until success or deadline exhaustion. Bypasses ambient proxy fallback when the target subscription host, port, or resolved destination IP match configured `NO_PROXY` / `no_proxy` rules, checking both uppercase and lowercase environment definitions and supporting whitespace and comma delimiters, port-qualified targets, wildcard patterns (e.g. `*.example.com`), IPv6 loopback addresses, and IPv4/IPv6 CIDR subnet masks (e.g. `100.64.0.0/10`, `2001:db8::/32`). Accepts full IPv4 (`127.0.0.0/8`) and IPv6 loopback ranges via `IpAddr::is_loopback()`. Preserves validated public destination DNS pin decisions in the ambient proxy HTTP client. Normalizes loopback host comparisons so identical host/port endpoints (e.g. `localhost:7890` vs `127.0.0.1:7890`) skip redundant retries against the local Mihomo port.
- **Pure Node Selection & Unit Testing**:
  - Extracted pure proxy candidate selection logic into `select_global_candidate`, with unit tests covering cycle resolution, special routing targets (`DIRECT`, `REJECT`, `PASS-RULE`), failing closed on empty `GLOBAL.all` member lists, rejecting unknown or nonexistent proxy leaf nodes, nested selectors, and candidate priority ordering.
- **Concurrency Protection & State Synchronization**:
  - Employs an asynchronous global mutex (`GLOBAL_MODE_LOCK`) for the global mode fallback phase, ensuring concurrent subscription downloads (manual, batch, or scheduled) do not race or corrupt core mode and proxy group selections. Records lock contention if timeout occurs.
  - Limits concurrent blocking DNS operations using an `Arc`-backed global semaphore (`DNS_SEMAPHORE`) where permits are bound to the execution thread lifetime.
  - Bounded system proxy discovery (`SYS_PROXY_DISCOVERY_LOCK` and `SYS_PROXY_CACHE`): applies a single unified absolute deadline across discovery lock acquisition, blocking system-proxy discovery, and join waiting so lock contention cannot consume multiple timeout windows or starve subsequent proxy attempts. Transfers the lock guard to the blocking discovery closure so the lock strictly mirrors the actual OS query lifetime, preventing overlapping orphaned executions and caching results for five seconds to eliminate repeated OS commands.
  - Mitigates descendant pipe inheritance and background thread accumulation in `run_cmd_bounded` by running child processes in dedicated process groups, killing the process group on timeout or error before process exit, draining buffered stdout safely, and avoiding post-reap signals once the process leader has already been reaped to prevent signaling recycled process groups. Unifies bounded execution by delegating status probing (`run_cmd_bounded_status`) directly to `run_cmd_bounded`. Ensures KDE command probes consume a shared remaining deadline so multiple probes never exceed caller timeouts.
- **Cancellation-Safe State Restoration & Shared Helper**:
  - Uses `ModeRestoreGuard` constructed and armed before mode or proxy group switching API calls to ensure core mode and proxy node selections are conservatively restored even on task cancellation, timeout, or ambiguous network transport failures.
  - Continuously checks active core generation (`check_core_alive`) before each mutation in `restore_mihomo_state`; if the core was stopped or restarted during global mode download or retry steps, aborts mutation on the new instance and clears the marker.
  - Persists the restore marker atomically via temporary file swap and rename with explicit file sync, parent directory synchronization, and Windows existing file replacement to guarantee durability across unexpected power loss and multi-step marker updates. Records the active configuration profile identifier in `GlobalModeRestoreMarker`, ensuring startup and core restart reconciliation does not apply stale group selections from a previous profile if the configuration was changed.
  - Hardens marker cleanup by truncating the file and emitting observable warnings if file deletion fails, ensuring unremoved markers cannot be deserialized or replayed on subsequent startups.
  - Defers reconciliation without rewriting marker files when the core REST API is unavailable, preventing redundant disk churn during startup or when the core is stopped.
  - Reconciles any unrestored marker under `GLOBAL_MODE_LOCK` protection during scheduler loops and immediately upon Mihomo core startup (both normal and TUN startup paths, with HTTP API readiness verified via `health_check` and state rolled back on check failure), eliminating startup race conditions and stale file reads. Propagates lock acquisition status and skips scheduler update passes if lock acquisition times out while another task is using global mode.
  - Compares the marker's original mode with the user's configured mode in settings, dropping stale mode restoration while preserving the user's original `GLOBAL` group node selection when the configuration profile matches.
  - Restores original routing mode (e.g. `rule`) *before* restoring the previous `GLOBAL` group selection in `restore_mihomo_state`, skips group restoration if mode restoration fails to avoid leaking traffic to direct routing, and mutates state references in place so task cancellation during inline restoration preserves pending restores for background cleanup.
  - Checks for an active Tokio runtime (`Handle::try_current()`) before spawning background cleanup in the drop guard, emitting an observable warning if no runtime is available.
  - Deduplicates state restoration and retries across inline and drop paths into a shared async helper (`retry_restore_step` and `restore_mihomo_state`).
  - Bounds inline restoration retries by the cumulative deadline; if deadline headroom is below 300ms, inline restoration safely defers pending cleanup to the guard's background drop task without emitting false inline failure warnings, ensuring YAML parsing and disk persistence complete well within the scheduler deadline.
- **Cross-Platform System Proxy Discovery & Parsing**:
  - Supports multi-scheme and delimiter-separated system proxy formats on Windows, macOS, and Linux (reading enabled HTTP, HTTPS, and SOCKS configurations across Windows, macOS, GNOME, KDE, and XFCE environments), matching the subscription target scheme, correctly mapping `socks`, `socks4`, `socks4a`, `socks5`, and `socks5h` (normalizing bare `socks://` to `socks5://` in Linux KDE and XFCE while eliminating variable shadowing, unused trait name warnings, and single-match clippy lints), with reqwest SOCKS support enabled, while strictly maintaining loopback-only SSRF constraints and filtering out unsupported schemes, zero ports, or unknown assignment prefixes (e.g. `ftp=...`).
  - Robustly extracts numeric port components from GNOME GVariant typed outputs (such as `uint32 7890`) and validates port numbers within the valid `u16` range.
  - Aggregates system proxy candidates across GNOME, KDE, and XFCE within the deadline budget rather than early-exiting on GNOME, allowing fallback to KDE/XFCE loopback proxies when GNOME configurations are non-loopback or invalid.
  - Supports `socks4a` and `socks5h` in space-delimited ambient proxy segment parsing, and preserves semicolons located in URL query parameters and paths.
  - Enforces child-process execution timeouts on Unix system-proxy commands, terminating and reaping hung child processes to guarantee that background discovery closures never block indefinitely.
  - Bounded macOS network service enumeration (`networksetup -listallnetworkservices`) using an 800ms command limit to prevent hung subprocesses from blocking future system proxy discovery.
  - Splits multi-candidate strings prior to single-candidate evaluation in `collect_ambient_proxy_urls_for_scheme` so multi-proxy configurations with paths are evaluated cleanly without swallowing subsequent entries.
  - Deduplicates ambient proxy candidates with a hash-set backed check for efficient collection while strictly preserving priority ordering.
  - Correctly distinguishes protocol assignment syntax from credentials containing equals signs or semicolons in ambient proxy strings via `split_ambient_proxy_segments`, ensuring valid authenticated loopback proxies are preserved.
  - Discards zero-port candidates across system proxy discovery and ambient proxy validation to avoid unroutable loopback entries.
  - Restricts prefix-stripping heuristics to recognized scheme assignments, ensuring proxy URLs containing query parameters (e.g. `?token=...`) are preserved intact.
  - Collects all valid system-derived proxy candidates into a prioritized sequence rather than truncating to a single entry, enabling full sequential fallback across multiple system protocols.
  - Correctly parses macOS network configuration using `split_once(':')` and automatically formats IPv6 loopback addresses in brackets (`[::1]`).
  - Formats Linux GNOME IPv6 proxy hosts in brackets.
  - Normalizes legacy Linux KDE proxy configurations containing space-separated numeric ports into standard colon-separated endpoints after trimming stdout, ensuring trailing newlines do not invalidate port parsing.
  - Validates candidate environment variables in precedence order (`HTTPS_PROXY`, `ALL_PROXY`, `HTTP_PROXY`), ensuring invalid candidates are safely skipped in favor of subsequent valid loopback entries.
- **Strict SSRF Hardening & Proxy Redirect Support**:
  - Strips brackets before IPv6 address parsing in `is_private_host`, and recognizes `.internal`, `.lan`, and `.home.arpa` as private TLDs.
  - Rejects direct connections targeting private/loopback IP ranges and treats SSRF detection as fatal.
  - User-entered private/LAN destinations are strictly direct-only; proxy fallback tiers are skipped if direct connection fails, preventing internal intranet probing via proxies.
  - Enforces redirect target IP validation, treating local DNS resolution failures on redirects as fatal for direct requests. For proxy requests, permits local DNS failure only when redirecting to the same originally requested subscription host (accommodating domains blocked by local resolvers while strictly preventing cross-host SSRF against unresolvable internal hostnames via proxy).
- **Diagnostics, Core Lifecycle & Cleanup**:
  - On macOS root TUN mode startup failure during the health check phase, automatically cleans up the root-spawned Mihomo process and routing entries before clearing core state and returning the error, preventing orphaned privileged processes.
  - Standardizes error accumulation across all fallback tiers using a shared `append_error` helper.

## Testing & Verification
- `cargo test -p zephyr-core`: Passed (all unit tests, including private TLDs, wildcard domain rules and CIDR subnet matching in NO_PROXY, IPv6 loopback brackets, multi-scheme ambient proxy validation, multi-entry proxy configurations with URL paths, credentials with semicolons and equals signs, unsupported scheme skipping, unknown assignment prefixes, zero-port rejection, SOCKS schemes, bare SOCKS normalization, query parameter preservation, semicolon query preservation, multi-candidate ordered collection, `PASS-RULE` handling, SSRF checks, fail-closed empty membership and nonexistent leaf validation, NO_PROXY rule matching with whitespace and ports, and candidate selection test matrix).
- `cargo test -p zephyr-core-ffi`: Passed.
- `cargo test --bin Zephyr`: Passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: Passed with zero warnings.
- `cargo fmt --check`: Passed.
- `pnpm test`: Passed (all 497 frontend tests).
